### PR TITLE
Top level global variables

### DIFF
--- a/examples/global_variables_test.py
+++ b/examples/global_variables_test.py
@@ -13,6 +13,8 @@ def function():
 VALUE = 0
 function()
 print(VALUE)
+ex = 1
+print(ex)
 
 
 def function1():

--- a/global_variables_checker.py
+++ b/global_variables_checker.py
@@ -11,8 +11,8 @@ class GlobalVariablesChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = 'global_variables'
-    msgs = {'E9997': ('Global variables should not be used in CSC108/CSC148 - %s', 'forbidden-global-variables',
-                      '')}
+    msgs = {'E9997': ('Global variables should not be used in CSC108/CSC148 - '
+                      '%s', 'forbidden-global-variables', '')}
 
     options = ()
     # this is important so that your checker is executed before others
@@ -33,8 +33,11 @@ class GlobalVariablesChecker(BaseChecker):
             a = re.match('(([A-Z_][A-Z0-9_]*)|(__.*__))$', s)
             # Raise an error only if it's not a constant
             if a is None:
-                args = "you declared global variables on line {}".format(node.lineno)
-                self.add_message('forbidden-global-variables', node=node, args=args)
+                args = "you declared the global variable '{}' on line {}".\
+                    format(s, node.lineno)
+                self.add_message('forbidden-global-variables', node=node,
+                                 args=args)
+
 
 def register(linter):
     """required method to auto register this checker"""

--- a/global_variables_checker.py
+++ b/global_variables_checker.py
@@ -24,6 +24,11 @@ class GlobalVariablesChecker(BaseChecker):
         args = "you used the keyword 'nonlocal' on line {}".format(node.lineno)
         self.add_message('forbidden-global-variables', node=node, args=args)
 
+    def visit_assign(self, node):
+        if isinstance(node.frame(), astroid.scoped_nodes.Module):
+            args = "you declared global variables on line {}".format(node.lineno)
+            self.add_message('forbidden-global-variables', node=node, args=args)
+
 def register(linter):
     """required method to auto register this checker"""
     linter.register_checker(GlobalVariablesChecker(linter))

--- a/global_variables_checker.py
+++ b/global_variables_checker.py
@@ -5,6 +5,7 @@ from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 import astroid
 import re
+from pylint.checkers.base import CONST_NAME_RGX
 
 
 class GlobalVariablesChecker(BaseChecker):
@@ -30,7 +31,7 @@ class GlobalVariablesChecker(BaseChecker):
         if isinstance(node.frame(), astroid.scoped_nodes.Module):
             regex = str(node.targets[0])
             s = re.findall('\((.*?)\)', regex)[0]
-            a = re.match('(([A-Z_][A-Z0-9_]*)|(__.*__))$', s)
+            a = re.match(CONST_NAME_RGX, s)
             # Raise an error only if it's not a constant
             if a is None:
                 args = "you declared the global variable '{}' on line {}".\

--- a/global_variables_checker.py
+++ b/global_variables_checker.py
@@ -4,6 +4,8 @@
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 import astroid
+import re
+
 
 class GlobalVariablesChecker(BaseChecker):
     __implements__ = IAstroidChecker
@@ -26,8 +28,13 @@ class GlobalVariablesChecker(BaseChecker):
 
     def visit_assign(self, node):
         if isinstance(node.frame(), astroid.scoped_nodes.Module):
-            args = "you declared global variables on line {}".format(node.lineno)
-            self.add_message('forbidden-global-variables', node=node, args=args)
+            regex = str(node.targets[0])
+            s = re.findall('\((.*?)\)', regex)[0]
+            a = re.match('(([A-Z_][A-Z0-9_]*)|(__.*__))$', s)
+            # Raise an error only if it's not a constant
+            if a is None:
+                args = "you declared global variables on line {}".format(node.lineno)
+                self.add_message('forbidden-global-variables', node=node, args=args)
 
 def register(linter):
     """required method to auto register this checker"""


### PR DESCRIPTION
Modified the global variables checker so that it throws an error when top-level variables are declared and used.