### PR TITLE
Issue 62 examples readme

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,6 @@ Print statements should be avoided.
 
 ## Correctness
 
-The (pycodestyle)[https://github.com/PyCQA/pycodestyle] tool can be used to check for compliance with the (PEP 8)[https://www.python.org/dev/peps/pep-0008/] style guide.
+The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
 
 Examples should be checked with PyTA to ensure the indented message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -76,7 +76,7 @@ Use single quotes, unless specified otherwise.
 
 Indent with 4 spaces.
 
-Each example generally has only one class or method.
+Each example generally has only one class or function.
 
 Examples typically do not need to be executed by calling them, since the
 linter checks the examples statically.
@@ -88,4 +88,4 @@ Print statements should be avoided.
 
 Examples should be compliant with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide. The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with PEP 8.
 
-Examples should be checked with PyTA to ensure the indented message is raised. Extraneous messages should be limited in a well-crafted example.
+Examples should be checked with PyTA to ensure the intended message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,8 +50,8 @@ def the_function_name(arg_name1, arg_name2):
 
 #### Comments
 
-Write comments in a manner that would be used to talk to a beginner. Be explicit
-with clear explanation, and avoid using jargon.
+Write comments in a manner that would be used to explain to a beginner. Be 
+explicit with clear explanation, and avoid using jargon.
 
 Try to point out where the error occurs in the example, if possible. Inline
 comments, with two spaces before the hash symbol, are useful for this purpose, for
@@ -86,6 +86,6 @@ Print statements should be avoided.
 
 ## Correctness
 
-Examples should be compliant with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide. The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with PEP 8.
+Examples should be compliant with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide, where possible. The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with PEP 8.
 
 Examples should be checked with PyTA to ensure the intended message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,6 +5,17 @@
 * Custom examples: located in `pyta/examples/`
 * PyLint examples: located in `pyta/examples/pylint`
 
+
+## Purpose
+
+Examples should illustrate an error in a succinct way, while clearly explaining
+the cause of the error to a beginner audience.
+
+The examples are included in the website index file with the `pandocfilters`
+module. See `/website/index.md` for the syntax to include the examples. Note
+that further explanation in addition to the example can be added directly to
+the `index.md` file.
+
 ## Documentation
 
 #### Module Docstrings
@@ -27,7 +38,7 @@ def the_function_name(arg_name1, arg_name2):
     @type arg_name2: <type>
     @rtype: <type>
     """
-    return x + y
+    return arg_name1 + arg_name2
 ```
 
 
@@ -36,16 +47,32 @@ def the_function_name(arg_name1, arg_name2):
 Write comments in a manner that would be used to talk to a beginner. Be explicit
 with clear explanation, and avoid using jargon terms.
 
-Try to point out where the error occurs in the example, if possible, and usually
-with an inline comment.
+Try to point out where the error occurs in the example, if possible. Inline
+comments, with two spaces before the has, are useful for this purpose, for
+example:
+
+```python
+return temp
+temp += 1  # Error on this line. This line is unreachable.
+```
 
 
 ## Structure
 
+Indent with 4 spaces.
+
 Each example generally has only one class or method.
 
 Examples typically do not need to be executed by calling them, since the
-linter checks the examples statically. 
+linter checks the examples statically.
 
 Print statements are acceptable, but not necessary.
+
+Imports should be one-per-line, like:
+
+```python
+import sys
+import math
+```
+
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,51 @@
+# Standardization of PyTA Examples
+
+## Sorts of Examples
+
+* Custom examples: located in `pyta/examples/`
+* PyLint examples: located in `pyta/examples/pylint`
+
+## Documentation
+
+#### Module Docstrings
+
+Examples typically do not use module docstrings.
+
+
+#### Function Docstrings
+
+Function docstrings use double quotes. Try to minimize the vertical size for
+compactness on the website.
+
+Type contracts follow the format: `@type <variable_name>: <type>`, and 
+`@rtype <type>`
+
+```python
+def the_function_name(arg_name1, arg_name2):
+    """Brief explanation of ????
+    @type arg_name1: <type>
+    @type arg_name2: <type>
+    @rtype: <type>
+    """
+    return x + y
+```
+
+
+#### Comments
+
+Write comments in a manner that would be used to talk to a beginner. Be explicit
+with clear explanation, and avoid using jargon terms.
+
+Try to point out where the error occurs in the example, if possible, and usually
+with an inline comment.
+
+
+## Structure
+
+Each example generally has only one class or method.
+
+Examples typically do not need to be executed by calling them, since the
+linter checks the examples statically. 
+
+Print statements are acceptable, but not necessary.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,4 +88,11 @@ Print statements should be avoided.
 
 Examples should be compliant with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide, where possible. The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with PEP 8.
 
+Some messages are allowed in the examples:
+
+```
+Invalid module name
+Missing module docstring
+```
+
 Examples should be checked with PyTA to ensure the intended message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -51,10 +51,10 @@ def the_function_name(arg_name1, arg_name2):
 #### Comments
 
 Write comments in a manner that would be used to talk to a beginner. Be explicit
-with clear explanation, and avoid using jargon terms.
+with clear explanation, and avoid using jargon.
 
 Try to point out where the error occurs in the example, if possible. Inline
-comments, with two spaces before the has, are useful for this purpose, for
+comments, with two spaces before the hash symbol, are useful for this purpose, for
 example:
 
 ```python
@@ -65,6 +65,15 @@ temp += 1  # Error on this line. This line is unreachable.
 
 ## Structure
 
+Imports (if needed) should be one-per-line, like:
+
+```python
+import sys
+import math
+```
+
+Use single quotes, unless specified otherwise.
+
 Indent with 4 spaces.
 
 Each example generally has only one class or method.
@@ -72,13 +81,11 @@ Each example generally has only one class or method.
 Examples typically do not need to be executed by calling them, since the
 linter checks the examples statically.
 
-Print statements are acceptable, but not necessary.
-
-Imports should be one-per-line, like:
-
-```python
-import sys
-import math
-```
+Print statements should be avoided.
 
 
+## Correctness
+
+The (pycodestyle)[https://github.com/PyCQA/pycodestyle] tool can be used to check for compliance with the (PEP 8)[https://www.python.org/dev/peps/pep-0008/] style guide.
+
+Examples should be checked with PyTA to ensure the indented message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,22 +1,28 @@
 # Standardization of PyTA Examples
 
-## Sorts of Examples
-
-* Custom examples: located in `pyta/examples/`
-* PyLint examples: located in `pyta/examples/pylint`
-
 
 ## Purpose
 
 Examples should illustrate an error in a succinct way, while clearly explaining
 the cause of the error to a beginner audience.
 
+
+## Sorts of Examples
+
+* Custom examples: located in `pyta/examples/`
+* PyLint examples: located in `pyta/examples/pylint/`
+
+
+## How Examples are Included
+
 The examples are included in the website index file with the `pandocfilters`
 module. See `/website/index.md` for the syntax to include the examples. Note
 that further explanation in addition to the example can be added directly to
 the `index.md` file.
 
+
 ## Documentation
+
 
 #### Module Docstrings
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -93,6 +93,7 @@ Some messages are allowed in the examples:
 ```
 Invalid module name
 Missing module docstring
+Invalid constant name
 ```
 
 Examples should be checked with PyTA to ensure the intended message is raised. Extraneous messages should be limited in a well-crafted example.

--- a/examples/README.md
+++ b/examples/README.md
@@ -86,6 +86,6 @@ Print statements should be avoided.
 
 ## Correctness
 
-The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide.
+Examples should be compliant with the [PEP 8](https://www.python.org/dev/peps/pep-0008/) style guide. The [pycodestyle](https://github.com/PyCQA/pycodestyle) tool can be used to check for compliance with PEP 8.
 
 Examples should be checked with PyTA to ensure the indented message is raised. Extraneous messages should be limited in a well-crafted example.


### PR DESCRIPTION
The pyta/examples/ directory should have a readme file to explain the format of examples, with the purpose of standardizing the examples.