### PR TITLE
typecheck: Type Constraints

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -46,25 +46,65 @@ def set_binop_type_constraints(node):
     left_type = node.left.type_constraints
     right_type = node.right.type_constraints
 
-    if left_type == right_type:
+    # '*' does not work for same type of operands such as str, list... etc
+    if node.op != '*' and left_type == right_type:
         node.type_constraints = node.left.type_constraints
-    elif type(node.left) == type(node.right) == astroid.node_classes.List:
+
+    # A list can be concatenate to another list using '+' operator
+    elif node.op == '+' and \
+            (isinstance(node.left, astroid.node_classes.List) and
+                isinstance(node.right, astroid.node_classes.List)):
         node.type_constraints = List
-    elif type(node.left) == type(node.right) == astroid.node_classes.Tuple:
-        node.type_constraints = Tuple
-    elif type(node.left) == type(node.right) == astroid.node_classes.Dict:
-        node.type_constraints = Dict
+
+    # A tuple can be concatenate to another tuple using '+' operator
+    elif node.op == '+' and \
+            (isinstance(node.left, astroid.node_classes.Tuple) and
+                isinstance(node.right, astroid.node_classes.Tuple)):
+        node.type_constraints = Tuple[tuple(x.type_constraints for x in
+                                            node.left.elts + node.right.elts)]
+
+    # operations between an integer and float should result a float
     elif ((right_type == int and left_type == float) or
         (right_type == float and left_type == int)):
         node.type_constraints = float
-    elif ((right_type == int and left_type == str) or
-        (right_type == str and left_type == int) or
-        (right_type == float and left_type == str) or
-        (right_type == str and left_type == float) or
-        (right_type == list and left_type != list) or
-        (right_type != list and left_type == list) or
-        (right_type == tuple and left_type != tuple) or
-        (right_type != tuple and left_type == tuple)):
+
+    elif right_type == int and left_type == int:
+        node.type_constraints = int
+
+    elif right_type == float and left_type == float:
+        node.type_constraints = float
+
+    # multiply an int n to a str s is concatenating n-1 times s to the
+    # original string s.
+    elif node.op == '*' and \
+            ((right_type == int and left_type == str) or
+            (right_type == str and left_type == int)):
+        node.type_constraints = str
+
+    # multiply an int n to a list l is concatenating n-1 times l to the
+    # original list l.
+    elif node.op == '*' and left_type == int and \
+            isinstance(node.right, astroid.node_classes.List):
+        node.type_constraints = right_type
+
+    elif node.op == '*' and right_type == int and \
+            isinstance(node.left, astroid.node_classes.List):
+        node.type_constraints = left_type
+
+    # multiply an int n to a tuple t is concatenating n-1 times t to the
+    # original tuple t.
+    elif node.op == '*' and left_type == int and \
+            isinstance(node.right, astroid.node_classes.Tuple):
+        node.type_constraints = Tuple[tuple(x.type_constraints for x in
+                                            node.right.elts * node.left.value)]
+
+    elif node.op == '*' and right_type == int and \
+            isinstance(node.left, astroid.node_classes.Tuple):
+        node.type_constraints = Tuple[tuple(x.type_constraints for x in
+                                            node.left.elts * node.right.value)]
+
+    # for all other invalid cases, raise an ValueError
+    else:
         raise ValueError('Different types of operands found, binop node %s'
                          'might have a type error.' % node)
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -200,6 +200,12 @@ def set_subscript_type_constraints(node):
             node.type_constraints = inferred.type_constraints
 
 
+def set_compare_type_constraints(node):
+    """Compare operators includes:
+    '<', '>', '==', '>=', '<=', '<>', '!=', 'is' ['not'], ['not'] 'in' """
+    node.type_constraints = bool
+
+
 def register_type_constraints_setter():
     """Instantiate a visitor to transform the nodes.
     Register the transform functions on an instance of TransformVisitor.
@@ -213,5 +219,7 @@ def register_type_constraints_setter():
                                     set_unaryop_type_constraints)
     type_visitor.register_transform(astroid.Subscript,
                                     set_subscript_type_constraints)
+    type_visitor.register_transform(astroid.Compare,
+                                    set_compare_type_constraints)
     type_visitor.register_transform(astroid.BinOp, set_binop_type_constraints)
     return type_visitor

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -1,4 +1,5 @@
 import astroid
+import astroid.node_classes
 from typing import Tuple, List, Dict, Set
 from astroid.transforms import TransformVisitor
 
@@ -45,12 +46,25 @@ def set_binop_type_constraints(node):
     left_type = node.left.type_constraints
     right_type = node.right.type_constraints
 
-    if ((right_type == int and left_type == float) or
+    if left_type == right_type:
+        node.type_constraints = node.left.type_constraints
+    elif type(node.left) == type(node.right) == astroid.node_classes.List:
+        node.type_constraints = List
+    elif type(node.left) == type(node.right) == astroid.node_classes.Tuple:
+        node.type_constraints = Tuple
+    elif type(node.left) == type(node.right) == astroid.node_classes.Dict:
+        node.type_constraints = Dict
+    elif ((right_type == int and left_type == float) or
         (right_type == float and left_type == int)):
         node.type_constraints = float
-    elif right_type == left_type:
-        node.type_constraints = left_type
-    else:
+    elif ((right_type == int and left_type == str) or
+        (right_type == str and left_type == int) or
+        (right_type == float and left_type == str) or
+        (right_type == str and left_type == float) or
+        (right_type == list and left_type != list) or
+        (right_type != list and left_type == list) or
+        (right_type == tuple and left_type != tuple) or
+        (right_type != tuple and left_type == tuple)):
         raise ValueError('Different types of operands found, binop node %s'
                          'might have a type error.' % node)
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -42,27 +42,24 @@ def set_dict_type_constraints(node):
         node.type_constraints = Dict
 
 
+def helper_list_tuple_detection(typeConstraints):
+    result = -1
+    if hasattr(typeConstraints, '__origin__'):
+        if typeConstraints.__origin__ == List:
+            result = 1
+    elif hasattr(typeConstraints, '__class__'):
+        if typeConstraints.__class__ == TupleMeta:
+            result = 0
+    return result
+
+
 def helper_rules(par1, par2, operator):
     operand1 = par1.type_constraints
     operand2 = par2.type_constraints
+    types = [] # result
     # checking if the types could possible be List/Tuple
-    left_type = -1
-    right_type = -1
-    types = []
-
-    if hasattr(operand1, '__origin__'):
-        if operand1.__origin__ == List:
-            left_type = 1 # 1 for List 0 for Tuple.
-    elif hasattr(operand1, '__class__'):
-        if operand1.__class__ == TupleMeta:
-            left_type = 0
-
-    if hasattr(operand2, '__origin__'):
-        if operand2.__origin__ == List:
-            right_type = 1
-    elif hasattr(operand2, '__class__'):
-        if operand2.__class__ == TupleMeta:
-            right_type = 0
+    left_type = helper_list_tuple_detection(operand1)
+    right_type = helper_list_tuple_detection(operand2)
 
     if operator == '+':
         if operand1 == float and operand2 == int:
@@ -121,13 +118,12 @@ def helper_rules(par1, par2, operator):
         elif left_type == 0 and operand2 == int:
             types.append(Tuple[tuple(operand1.__tuple_params__ *
                                      par2.value)])
+
     return types
 
 
 def set_binop_type_constraints(node):
-
     ruled_type = helper_rules(node.left, node.right, node.op)
-
     if len(ruled_type) == 1:
         node.type_constraints = ruled_type[0]
     else:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -119,6 +119,39 @@ def helper_rules(par1, par2, operator):
             types.append(Tuple[tuple(operand1.__tuple_params__ *
                                      par2.value)])
 
+    elif operator == '**' or operator == '%' or operator == '//':
+        if operand1 == int and operand2 == int:
+            types.append(int)
+        elif operand1 == int and operand2 == float:
+            types.append(float)
+        elif operand1 == float and operand2 == int:
+            types.append(float)
+        elif operand1 == float and operand2 == float:
+            types.append(float)
+
+    elif operator == '/':
+        if operand1 == int and operand2 == int:
+            if par1.value % par2.value == 0:
+                types.append(int)
+            else:
+                types.append(float)
+        elif operand1 == int and operand2 == float:
+            types.append(float)
+        elif operand1 == float and operand2 == int:
+            types.append(float)
+        elif operand1 == float and operand2 == float:
+            types.append(float)
+
+    elif operator == '<' or operator == '>':
+        if (operand1 == str and operand2 == str) or \
+        (operand1 == int and operand2 == int) or \
+        (operand1 == float and operand2 == int) or \
+        (operand1 == int and operand2 == float) or \
+        (operand1 == float and operand2 == float) or \
+        (operand1 == List and operand2 == List) or \
+        (operand1 == Tuple and operand2 == Tuple):
+            types.append(bool)
+
     return types
 
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -142,16 +142,6 @@ def helper_rules(par1, par2, operator):
         elif operand1 == float and operand2 == float:
             types.append(float)
 
-    elif operator == '<' or operator == '>':
-        if (operand1 == str and operand2 == str) or \
-        (operand1 == int and operand2 == int) or \
-        (operand1 == float and operand2 == int) or \
-        (operand1 == int and operand2 == float) or \
-        (operand1 == float and operand2 == float) or \
-        (operand1 == List and operand2 == List) or \
-        (operand1 == Tuple and operand2 == Tuple):
-            types.append(bool)
-
     return types
 
 

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -338,6 +338,13 @@ class MoreTupleTests(unittest.TestCase):
         # Instantiate a visitor, and register the transform functions to it.
         self.type_visitor = register_type_constraints_setter()
 
+    def test_str_multiplication(self):
+        module = astroid.parse("""[1, 2, 'ccc' * 3]""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([str], result)
+
     def test_list_of_str(self):
         module = astroid.parse("""['a', 'b'] + ['c', 'd']""")
         self.type_visitor.visit(module)
@@ -352,6 +359,20 @@ class MoreTupleTests(unittest.TestCase):
             node_classes.BinOp)]
         self.assertEqual([List], result)
 
+    def test_list_multiplication(self):
+        module = astroid.parse("""[1, True] * 2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([List], result)
+
+    def test_list_multiplication2(self):
+        module = astroid.parse("""3 * ['abc', 'def', 'gcd']""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([List[str]], result)
+
     def test_tuple_of_int(self):
         module = astroid.parse("""(1, 2) + (3, 4)""")
         self.type_visitor.visit(module)
@@ -364,23 +385,37 @@ class MoreTupleTests(unittest.TestCase):
         self.type_visitor.visit(module)
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.BinOp)]
-        # for the type_constraints of binop which has tuple type of operands,
-        # does all elements type from both operands need to be listed?
-        self.assertEqual([Tuple], result)
+        self.assertEqual([Tuple[str, str, int, int]], result)
 
-    def test_dict_of_str_int(self):
-        module = astroid.parse("""{'a': 1} + {'b': 2}""")
+    def test_tuple_multiplication(self):
+        module = astroid.parse("""(1, 2) * 2""")
         self.type_visitor.visit(module)
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.BinOp)]
-        self.assertEqual([Dict[str, int]], result)
+        self.assertEqual([Tuple[int, int, int, int]], result)
 
-    def test_mixed_dict(self):
-        module = astroid.parse("""{'a': 1} + {'b': 'c'}""")
+    def test_tuple_multiplication2(self):
+        module = astroid.parse("""3 * ('abc', 'def', 'gcd')""")
         self.type_visitor.visit(module)
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.BinOp)]
-        self.assertEqual([Dict], result)
+        self.assertEqual([Tuple[str, str, str, str, str, str, str, str, str]],
+                         result)
+
+    def test_int_with_parentheses(self):
+        module = astroid.parse("""(2) * 6""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
+    def test_float_with_parentheses(self):
+        module = astroid.parse("""(2.2) * 6""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -331,5 +331,56 @@ class TypeInferenceVisitorTestMoreComplex(unittest.TestCase):
         self.assertEqual(Tuple[int, List, List, Tuple[bool, str]], result[0])
 
 
+class MoreTupleTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(self):
+        # Instantiate a visitor, and register the transform functions to it.
+        self.type_visitor = register_type_constraints_setter()
+
+    def test_list_of_str(self):
+        module = astroid.parse("""['a', 'b'] + ['c', 'd']""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([List[str]], result)
+
+    def test_mixed_list(self):
+        module = astroid.parse("""['a', 'b'] + [1, 2]""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([List], result)
+
+    def test_tuple_of_int(self):
+        module = astroid.parse("""(1, 2) + (3, 4)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([Tuple[int, int]], result)
+
+    def test_mixed_tuple(self):
+        module = astroid.parse("""('a', 'b') + (1, 2)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        # for the type_constraints of binop which has tuple type of operands,
+        # does all elements type from both operands need to be listed?
+        self.assertEqual([Tuple], result)
+
+    def test_dict_of_str_int(self):
+        module = astroid.parse("""{'a': 1} + {'b': 2}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([Dict[str, int]], result)
+
+    def test_mixed_dict(self):
+        module = astroid.parse("""{'a': 1} + {'b': 'c'}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([Dict], result)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -575,6 +575,18 @@ class TypeInferenceVisitorTest(unittest.TestCase):
             node_classes.Subscript)]
         self.assertEqual([str], result)
 
+    def test_subscript6(self):
+        test_block = """
+            nested = ('a', 1, [0, 0, ('hhhhh', ['hhhhh', 1])])
+            nested[2][2][1][0][0]
+            """
+        # problem encountered: we should be able to directly
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([str, str, List, Tuple[str, List], List], result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -612,6 +612,34 @@ class TypeInferenceVisitorTest(unittest.TestCase):
             node_classes.Compare)]
         self.assertEqual([bool], result)
 
+    def test_compare3(self):
+        module = astroid.parse("True != False")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
+    def test_compare4(self):
+        module = astroid.parse("[1, 2, 3] is List")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
+    def test_compare5(self):
+        module = astroid.parse("[1, 1, 1] is not [1, 1, 1]")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
+    def test_compare6(self):
+        module = astroid.parse("[1, 1, 1] not in (1, 2)")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -580,12 +580,37 @@ class TypeInferenceVisitorTest(unittest.TestCase):
             nested = ('a', 1, [0, 0, ('hhhhh', ['hhhhh', 1])])
             nested[2][2][1][0][0]
             """
-        # problem encountered: we should be able to directly
         module = astroid.parse(test_block)
         self.type_visitor.visit(module)
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.Subscript)]
         self.assertEqual([str, str, List, Tuple[str, List], List], result)
+
+    def test_compare0(self):
+        module = astroid.parse("""1 < 2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
+    def test_compare1(self):
+        module = astroid.parse("""[1, 2, 3] <= [4, 5]""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
+
+    def test_compare2(self):
+        code = """
+        a = 'forest'
+        b = 'gold'
+        a >= b
+        """
+        module = astroid.parse(code)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Compare)]
+        self.assertEqual([bool], result)
 
 
 if __name__ == '__main__':

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -329,7 +329,7 @@ class TypeInferenceVisitorTestMoreComplex(unittest.TestCase):
         self.assertEqual(Tuple[int, List, List, Tuple[bool, str]], result[0])
 
 
-class MoreTupleTests(unittest.TestCase):
+class BinOpTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(self):
@@ -420,6 +420,91 @@ class MoreTupleTests(unittest.TestCase):
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.BinOp)]
         self.assertEqual([float], result)
+
+    def test_float_with_power(self):
+        module = astroid.parse("""(2.2) ** 1.2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_int_with_power(self):
+        module = astroid.parse("""2 ** 3""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
+    def test_int_float_with_power(self):
+        module = astroid.parse("""2.2 ** 6""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_modulus0(self):
+        module = astroid.parse("""(2.2) % 1.2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_modulus1(self):
+        module = astroid.parse("""23 % 3""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
+    def test_modulus2(self):
+        module = astroid.parse("""2.2 % 6""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_floordiv0(self):
+        module = astroid.parse("""(2.2) // 1.223332""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_floordiv1(self):
+        module = astroid.parse("""23 // 300""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
+    def test_floordiv2(self):
+        module = astroid.parse("""2.2212 // 600""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_div0(self):
+        module = astroid.parse("""2.2212 / 600""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_div1(self):
+        module = astroid.parse("""300 / 600""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_div2(self):
+        module = astroid.parse("""1200 / 600""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
 
 
 if __name__ == '__main__':

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -63,7 +63,6 @@ class SetConstFunctionTest(unittest.TestCase):
 class TypeInferenceVisitorTest(unittest.TestCase):
     """testers for type_inference_visitor. Modules are been passed in instead
     of single nodes."""
-
     @classmethod
     def setUpClass(self):
         # Instantiate a visitor, and register the transform functions to it.

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -60,275 +60,6 @@ class SetConstFunctionTest(unittest.TestCase):
         self.assertEqual([type(None)], result)
 
 
-class TypeInferenceVisitorTest(unittest.TestCase):
-    """testers for type_inference_visitor. Modules are been passed in instead
-    of single nodes."""
-    @classmethod
-    def setUpClass(self):
-        # Instantiate a visitor, and register the transform functions to it.
-        self.type_visitor = register_type_constraints_setter()
-
-    def test_binop_same_type_operands(self):
-        """testing if a binary operator passed into TypeVisitor
-        has the correct type_constraints attribute when both operands have
-        the same type.
-        """
-        module = astroid.parse("""10 + 2""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.BinOp)]
-        self.assertEqual([int], result)
-
-    def test_binop_diff_type_operands(self):
-        """testing if a binary operator that's been passed into
-        TypeVisitor has the correct type_constraints attribute
-        when operands have different types.
-        """
-        module = astroid.parse("""6 + 0.3""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(node_classes.BinOp)]
-        self.assertEqual([float], result)
-
-    def test_unary(self):
-        """testing if a unary operator that's been passed into
-        TypeVisitor has the correct type_constraints attribute.
-        """
-        module = astroid.parse("""-2""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.UnaryOp)]
-        self.assertEqual([int], result)
-
-    def test_list_same_type_elements(self):
-        """testing if a list that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The list contains only 1 type of elements.
-        """
-        module = astroid.parse("""['hi', 'how', 'is', 'life']""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.List)]
-        self.assertEqual([List[str]], result)
-
-    def test_list_different_type_elements(self):
-        """testing if a list that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The list contains different type of elements.
-        """
-        module = astroid.parse("""[1, 2, 2.5, 3, 'cheese']""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.List)]
-        self.assertEqual([List], result)
-
-    def test_tuple_same_type_elements(self):
-        """testing if a tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The tuple contains 2 same type of elements.
-        """
-        module = astroid.parse("""(1, 2)""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual([Tuple[int, int]], result)
-
-    def test_tuple_diff_type_elements(self):
-        """testing if a tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The tuple contains 2 different type of elements.
-        """
-        module = astroid.parse("""('GPA', 4.0)""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual([Tuple[str, float]], result)
-
-    def test_dict_same_type_elements(self):
-        """testing if a dict that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The dict contains same type of elements.
-
-        Note: parameter of Dict[] must be 2 or 0. Even if a Dict object only
-        contains a single type(call it type1), the type_constraints of this
-        Dict object has to be set as Dict[type1, type1].
-        """
-        module = astroid.parse("""{'a':'one', 'b':'two'}""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Dict)]
-        self.assertEqual([Dict[str, str]], result)
-
-    def test_dict_2_diff_type_elements(self):
-        """testing if a dict that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The dict contains only two different types of elements.
-
-        Note: The reason that a Dict object with 2 different types of elements
-        has type_constraints Dict[type1, type2] instead of the general type
-        Dict is, when use Typing.Dict, parameter of Dict[] must be 2 or 0.
-        Therefore, if the Dict object only contains 1 type, we have to
-        return Dict[type1, type1] with a repetition of type1, so I think it
-        will be reasonable to show 2 different types as well.
-        """
-        module = astroid.parse("""{'a': 1, 'b': 2}""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Dict)]
-        self.assertEqual([Dict[str, int]], result)
-
-    def test_dict_multi_diff_type_elements(self):
-        """testing if a dict that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The dict contains more than 2 different types of elements.
-        """
-        module = astroid.parse("""{'a': 1, 0.25:True}""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Dict)]
-        self.assertEqual([Dict], result)
-
-
-class TypeInferenceVisitorTestMoreComplex(unittest.TestCase):
-
-    @classmethod
-    def setUpClass(self):
-        # Instantiate a visitor, and register the transform functions to it.
-        self.type_visitor = register_type_constraints_setter()
-
-    def test_multi_unary(self):
-        module = astroid.parse("""-(+(-(+(-1))))""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.UnaryOp)]
-        # There are 5 Unary Operators, and each one of them has the
-        # type_constraints int.
-        self.assertEqual([int, int, int, int, int], result)
-
-    def test_binop_multiple_operands_same_type(self):
-        """testing if a binary operator that's been passed into
-        TypeVisitor has the correct type_constraints attribute
-        when multiple operands have same types.
-        """
-        module = astroid.parse("""1 + 2 + 3 + 4 + 5""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.BinOp)]
-        # There are 4 Binary Operators, and each one of them has the
-        # type_constraints int.
-        self.assertEqual([int, int, int ,int], result)
-
-    def test_binop_multiple_operands_different_type(self):
-        """testing if a binary operator that's been passed into
-        TypeVisitor has the correct type_constraints attribute
-        when multiple operands have different types.
-        """
-        module = astroid.parse("""1 + 2 + 3 + 4 - 5.5""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.BinOp)]
-        self.assertEqual([float, int, int, int], result)
-
-    def test_binop_multiple_operands_different_type_with_brackets(self):
-        """testing if a binary operator that's been passed into
-        TypeVisitor has the correct type_constraints attribute
-        when multiple operands have different types with brackets.
-        """
-        module = astroid.parse("""1 + 2 + 3 + 4 - (5.5 + 4.5)""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.BinOp)]
-        self.assertEqual([float, int, int, int, float], result)
-
-    def test_tuple_same_type_multi_elements(self):
-        """testing if a tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The tuple contains same type of multiple elements.
-        """
-        module = astroid.parse("""(1, 2, 3, 4, 5, 6)""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual([Tuple[int, int, int, int, int, int]], result)
-
-    def test_nested_list(self):
-        """testing if a nested list that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-        """
-        module = astroid.parse("""[1, [[2, 2.5], [3, 'a']]]""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.List)]
-        self.assertEqual(List, result[0])
-
-    def test_dict_with_key_tuple_value_list(self):
-        """testing if a dict that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The dict contains list and tuple.
-        """
-        module = astroid.parse("""{(0, 1): [3, 4], (1, 1): [3, 2], (1, 0
-        ): [7, 8, 5], (1, 2): [0, 0, 0], (1, 3): [2, 3, 4]}""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Dict)]
-        self.assertEqual([Dict[Tuple[int, int], List[int]]], result)
-
-    def test_dict_mixed(self):
-        """testing if a dict that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The dict contains binop, list, tuple, unaryop, str, bool, nested
-        tuple and nested list.
-        """
-        module = astroid.parse("""{(['l', 'a'], 'b'): 'c', (4, 7): 2+5,
-        (True): False, ('h', ('i', ('2'))): -7, [1, [3, 4]]: ("that's it")}""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Dict)]
-        self.assertEqual([Dict], result)
-
-    def test_tuple_diff_type_elements(self):
-        """testing if a tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute.
-
-        The tuple contains different type of multiple elements.
-        """
-        module = astroid.parse("""('a', 4.0, 'b', 'c', 'd', True)""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual([Tuple[str, float, str, str, str, bool]], result)
-
-    def test_nested_tuple(self):
-        """testing if a nested tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute..
-        """
-        module = astroid.parse("""(1, (2, (3, '4')))""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual(Tuple[int, Tuple[int, Tuple[int, str]]], result[0])
-
-    def test_nested_tuple_list(self):
-        """testing if a nested tuple that's been passed into TypeVisitor
-        has the correct type_constraints attribute..
-        """
-        module = astroid.parse("""(1, [2, (3, '4')], [True, False,['str1',
-        'str2', 6.99, ('bacon', 'salad')]], (False, 'chicken'))""")
-        self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.Tuple)]
-        self.assertEqual(Tuple[int, List, List, Tuple[bool, str]], result[0])
-
-
 class BinOpTests(unittest.TestCase):
 
     @classmethod
@@ -505,6 +236,344 @@ class BinOpTests(unittest.TestCase):
             node_classes.BinOp)]
         self.assertEqual([int], result)
 
+
+class TypeInferenceVisitorTest(unittest.TestCase):
+    """testers for type_inference_visitor. Modules are been passed in instead
+    of single nodes."""
+    @classmethod
+    def setUpClass(self):
+        # Instantiate a visitor, and register the transform functions to it.
+        self.type_visitor = register_type_constraints_setter()
+
+    def test_binop_same_type_operands(self):
+        """testing if a binary operator passed into TypeVisitor
+        has the correct type_constraints attribute when both operands have
+        the same type.
+        """
+        module = astroid.parse("""10 + 2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([int], result)
+
+    def test_binop_diff_type_operands(self):
+        """testing if a binary operator that's been passed into
+        TypeVisitor has the correct type_constraints attribute
+        when operands have different types.
+        """
+        module = astroid.parse("""6 + 0.3""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(node_classes.BinOp)]
+        self.assertEqual([float], result)
+
+    def test_unary(self):
+        """testing if a unary operator that's been passed into
+        TypeVisitor has the correct type_constraints attribute.
+        """
+        module = astroid.parse("""-2""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.UnaryOp)]
+        self.assertEqual([int], result)
+
+    def test_list_same_type_elements(self):
+        """testing if a list that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The list contains only 1 type of elements.
+        """
+        module = astroid.parse("""['hi', 'how', 'is', 'life']""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.List)]
+        self.assertEqual([List[str]], result)
+
+    def test_list_different_type_elements(self):
+        """testing if a list that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The list contains different type of elements.
+        """
+        module = astroid.parse("""[1, 2, 2.5, 3, 'cheese']""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.List)]
+        self.assertEqual([List], result)
+
+    def test_tuple_same_type_elements(self):
+        """testing if a tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The tuple contains 2 same type of elements.
+        """
+        module = astroid.parse("""(1, 2)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual([Tuple[int, int]], result)
+
+    def test_tuple_diff_type_elements(self):
+        """testing if a tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The tuple contains 2 different type of elements.
+        """
+        module = astroid.parse("""('GPA', 4.0)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual([Tuple[str, float]], result)
+
+    def test_dict_same_type_elements(self):
+        """testing if a dict that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The dict contains same type of elements.
+
+        Note: parameter of Dict[] must be 2 or 0. Even if a Dict object only
+        contains a single type(call it type1), the type_constraints of this
+        Dict object has to be set as Dict[type1, type1].
+        """
+        module = astroid.parse("""{'a':'one', 'b':'two'}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Dict)]
+        self.assertEqual([Dict[str, str]], result)
+
+    def test_dict_2_diff_type_elements(self):
+        """testing if a dict that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The dict contains only two different types of elements.
+
+        Note: The reason that a Dict object with 2 different types of elements
+        has type_constraints Dict[type1, type2] instead of the general type
+        Dict is, when use Typing.Dict, parameter of Dict[] must be 2 or 0.
+        Therefore, if the Dict object only contains 1 type, we have to
+        return Dict[type1, type1] with a repetition of type1, so I think it
+        will be reasonable to show 2 different types as well.
+        """
+        module = astroid.parse("""{'a': 1, 'b': 2}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Dict)]
+        self.assertEqual([Dict[str, int]], result)
+
+    def test_dict_multi_diff_type_elements(self):
+        """testing if a dict that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The dict contains more than 2 different types of elements.
+        """
+        module = astroid.parse("""{'a': 1, 0.25:True}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Dict)]
+        self.assertEqual([Dict], result)
+
+    def test_multi_unary(self):
+        module = astroid.parse("""-(+(-(+(-1))))""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.UnaryOp)]
+        # There are 5 Unary Operators, and each one of them has the
+        # type_constraints int.
+        self.assertEqual([int, int, int, int, int], result)
+
+    def test_binop_multiple_operands_same_type(self):
+        """testing if a binary operator that's been passed into
+        TypeVisitor has the correct type_constraints attribute
+        when multiple operands have same types.
+        """
+        module = astroid.parse("""1 + 2 + 3 + 4 + 5""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        # There are 4 Binary Operators, and each one of them has the
+        # type_constraints int.
+        self.assertEqual([int, int, int ,int], result)
+
+    def test_binop_multiple_operands_different_type(self):
+        """testing if a binary operator that's been passed into
+        TypeVisitor has the correct type_constraints attribute
+        when multiple operands have different types.
+        """
+        module = astroid.parse("""1 + 2 + 3 + 4 - 5.5""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float, int, int, int], result)
+
+    def test_binop_multiple_operands_different_type_with_brackets(self):
+        """testing if a binary operator that's been passed into
+        TypeVisitor has the correct type_constraints attribute
+        when multiple operands have different types with brackets.
+        """
+        module = astroid.parse("""1 + 2 + 3 + 4 - (5.5 + 4.5)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([float, int, int, int, float], result)
+
+    def test_tuple_same_type_multi_elements(self):
+        """testing if a tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The tuple contains same type of multiple elements.
+        """
+        module = astroid.parse("""(1, 2, 3, 4, 5, 6)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual([Tuple[int, int, int, int, int, int]], result)
+
+    def test_nested_list(self):
+        """testing if a nested list that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+        """
+        module = astroid.parse("""[1, [[2, 2.5], [3, 'a']]]""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.List)]
+        self.assertEqual(List, result[0])
+
+    def test_dict_with_key_tuple_value_list(self):
+        """testing if a dict that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The dict contains list and tuple.
+        """
+        module = astroid.parse("""{(0, 1): [3, 4], (1, 1): [3, 2], (1, 0
+        ): [7, 8, 5], (1, 2): [0, 0, 0], (1, 3): [2, 3, 4]}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Dict)]
+        self.assertEqual([Dict[Tuple[int, int], List[int]]], result)
+
+    def test_dict_mixed(self):
+        """testing if a dict that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The dict contains binop, list, tuple, unaryop, str, bool, nested
+        tuple and nested list.
+        """
+        module = astroid.parse("""{(['l', 'a'], 'b'): 'c', (4, 7): 2+5,
+        (True): False, ('h', ('i', ('2'))): -7, [1, [3, 4]]: ("that's it")}""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Dict)]
+        self.assertEqual([Dict], result)
+
+    def test_tuple_diff_type_elements(self):
+        """testing if a tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute.
+
+        The tuple contains different type of multiple elements.
+        """
+        module = astroid.parse("""('a', 4.0, 'b', 'c', 'd', True)""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual([Tuple[str, float, str, str, str, bool]], result)
+
+    def test_nested_tuple(self):
+        """testing if a nested tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute..
+        """
+        module = astroid.parse("""(1, (2, (3, '4')))""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual(Tuple[int, Tuple[int, Tuple[int, str]]], result[0])
+
+    def test_nested_tuple_list(self):
+        """testing if a nested tuple that's been passed into TypeVisitor
+        has the correct type_constraints attribute..
+        """
+        module = astroid.parse("""(1, [2, (3, '4')], [True, False,['str1',
+        'str2', 6.99, ('bacon', 'salad')]], (False, 'chicken'))""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Tuple)]
+        self.assertEqual(Tuple[int, List, List, Tuple[bool, str]], result[0])
+
+    def test_subscript0(self):
+        test_block = """
+        list_a = [1, 2, [1, 2, 3], 4]
+        list_a[2]
+        """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([List[int]], result)
+
+    def test_subscript0(self):
+        test_block = """
+        list_a = [1, 2, 'string', 4]
+        list_a[2]
+        """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([str], result)
+
+    def test_subscript1(self):
+        test_block = """
+        list_a = [1, 2, [True, True, False], 4]
+        list_a[2]
+        """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([List[bool]], result)
+
+    def test_subscript2(self):
+        test_block = """
+        tuple_a = ('a', 'b', 'Happy', 'Halloweeeeeen!')
+        tuple_a[2]
+        """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([str], result)
+
+    def test_subscript3(self):
+        test_block = """
+            tuple_a = ('a', 'b', ('Happy', 'Halloweeeeeen!'))
+            tuple_a[2][0]
+            """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([str, Tuple[str, str]], result)
+
+    def test_subscript4(self):
+        test_block = """
+            dict_a = {'index_1' : 'book', 'index_2': None, 'index_3': 'cat'}
+            dict_a['index_2']
+            """
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([type(None)], result)
+
+    def test_subscript5(self):
+        test_block = """
+            string_a = "I'm a string tester!"
+            string_a[1]
+            """
+        # problem encountered: we should be able to directly
+        module = astroid.parse(test_block)
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.Subscript)]
+        self.assertEqual([str], result)
 
 
 if __name__ == '__main__':

--- a/tests/type_inference/type_inference_visitor_unittest.py
+++ b/tests/type_inference/type_inference_visitor_unittest.py
@@ -87,8 +87,7 @@ class TypeInferenceVisitorTest(unittest.TestCase):
         """
         module = astroid.parse("""6 + 0.3""")
         self.type_visitor.visit(module)
-        result = [n.type_constraints for n in module.nodes_of_class(
-            node_classes.BinOp)]
+        result = [n.type_constraints for n in module.nodes_of_class(node_classes.BinOp)]
         self.assertEqual([float], result)
 
     def test_unary(self):
@@ -338,6 +337,13 @@ class MoreTupleTests(unittest.TestCase):
         # Instantiate a visitor, and register the transform functions to it.
         self.type_visitor = register_type_constraints_setter()
 
+    def test_str(self):
+        module = astroid.parse("""[1, 2, 'aaa' + 'bbb']""")
+        self.type_visitor.visit(module)
+        result = [n.type_constraints for n in module.nodes_of_class(
+            node_classes.BinOp)]
+        self.assertEqual([str], result)
+
     def test_str_multiplication(self):
         module = astroid.parse("""[1, 2, 'ccc' * 3]""")
         self.type_visitor.visit(module)
@@ -378,7 +384,7 @@ class MoreTupleTests(unittest.TestCase):
         self.type_visitor.visit(module)
         result = [n.type_constraints for n in module.nodes_of_class(
             node_classes.BinOp)]
-        self.assertEqual([Tuple[int, int]], result)
+        self.assertEqual([Tuple[int, int, int, int]], result)
 
     def test_mixed_tuple(self):
         module = astroid.parse("""('a', 'b') + (1, 2)""")


### PR DESCRIPTION
BinOp Components: 
- Supports List/Tuple/String Concatenation using `+` or `*` operators.
- Operators includes `+,  -,  *,  /,  **,  //,  %`.
- Raise `ValueError` exception when invalid operations are detected, for instance, `'abc' * 'sss`, `[1, 2] * [3, 4]`.

Other Node Types:
- Compare Node
- Subscript Node
- List, Tuple, Dict Node
- Const Node
- UnaryOp Node
