### PR TITLE
fixed naming inconsistency

### DIFF
--- a/python_ta/checkers/IO_Function_checker.py
+++ b/python_ta/checkers/IO_Function_checker.py
@@ -13,7 +13,7 @@ class IOFunctionChecker(BaseChecker):
 
     __implements__ = IAstroidChecker
 
-    name = 'IO-functions'
+    name = 'IO_Function'
     msgs = {'E9998': ('Used IO function %s',
                       'IO-function-not-allowed',
                       'Used when you use the IO functions "print", "open" or'

--- a/python_ta/checkers/always_returning_checker.py
+++ b/python_ta/checkers/always_returning_checker.py
@@ -10,10 +10,11 @@ from pylint.checkers.utils import check_messages
 class AlwaysReturnChecker(BaseChecker):
 
     __implements__ = IAstroidChecker
-
-    name = 'always_return'
+    # name is the same as file name but without _checker part
+    name = 'always_returning'
+    # use dashes for connecting words in message symbol
     msgs = {'E9996': ('Always returning an object or none in the loop at this line',
-                      'always_returning_in_a_loop',
+                      'always-returning-in-a-loop',
                       'Used when you always return an object or none in a loop, '
                       'this may cause the loop to only run once.'),
            }
@@ -53,15 +54,16 @@ class AlwaysReturnChecker(BaseChecker):
         else:
             return False
 
-    @check_messages("always_returning_in_a_loop")
+    # pass in message symbol as a parameter of check_messages
+    @check_messages("always-returning-in-a-loop")
     def visit_for(self, node):
         if self._check_always_return(node):
-            self.add_message('always_returning_in_a_loop', node=node)
+            self.add_message('always-returning-in-a-loop', node=node)
 
-    @check_messages("always_returning_in_a_loop")
+    @check_messages("always-returning-in-a-loop")
     def visit_while(self, node):
         if self._check_always_return(node):
-            self.add_message("always_returning_in_a_loop", node=node)
+            self.add_message("always-returning-in-a-loop", node=node)
 
 
 def register(linter):

--- a/python_ta/checkers/assigning_to_self_checker.py
+++ b/python_ta/checkers/assigning_to_self_checker.py
@@ -11,21 +11,21 @@ class AssigningToSelfChecker(BaseChecker):
 
     __implements__ = IAstroidChecker
 
-    name = 'always_return'
+    name = 'assigning_to_self'
     msgs = {'E9990': ('Assigning value to self on line %s',
-                      'assigning_to_self',
+                      'assigning-to-self',
                       'Used when you assign a value to self'),
            }
 
     # this is important so that your checker is executed before others
     priority = -1
 
-    @check_messages('assigning_to_self')
+    @check_messages('assigning-to-self')
     def visit_assign(self, node):
         target = node.targets[0]
         if isinstance(target, astroid.AssignName) and target.name == 'self':
             args = node.lineno
-            self.add_message('assigning_to_self', node=node, args=args)
+            self.add_message('assigning-to-self', node=node, args=args)
 
 
 def register(linter):

--- a/python_ta/checkers/dynamic_execution_checker.py
+++ b/python_ta/checkers/dynamic_execution_checker.py
@@ -10,6 +10,7 @@ FORBIDDEN_BUILTIN = ["compile", "eval", "exec"]
 
 
 class DynamicExecutionChecker(BaseChecker):
+
     __implements__ = IAstroidChecker
 
     name = 'dynamic_execution'
@@ -28,7 +29,7 @@ class DynamicExecutionChecker(BaseChecker):
 
     priority = -1
 
-    @check_messages('dynamic_execution')
+    @check_messages('dynamic-execution-not-allowed')
     def visit_call(self, node):
         if isinstance(node.func, astroid.Name):
             name = node.func.name

--- a/python_ta/checkers/forbidden_import_checker.py
+++ b/python_ta/checkers/forbidden_import_checker.py
@@ -7,9 +7,10 @@ from colorama import Fore, Style
 
 
 class ForbiddenImportChecker(BaseChecker):
+
     __implements__ = IAstroidChecker
 
-    name = 'forbidden import'
+    name = 'forbidden_import'
     msgs = {'E9999':
                 ('You may not import any modules - you imported ' + Fore.BLUE +
                  '%s' + Style.RESET_ALL + ' on line %s.',

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -1,5 +1,4 @@
 """checker for global variables
-
 """
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
@@ -9,6 +8,7 @@ from pylint.checkers.base import CONST_NAME_RGX
 
 
 class GlobalVariablesChecker(BaseChecker):
+
     __implements__ = IAstroidChecker
 
     name = 'global_variables'

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -6,9 +6,10 @@ from ast import literal_eval
 
 
 class InvalidRangeIndexChecker(BaseChecker):
+
     __implements__ = IAstroidChecker
 
-    name = 'custom'
+    name = 'invalid_range_index'
     msgs = {'E9993':
                 ('You should not use invalid range index on line %s',
                  'invalid-range-index',


### PR DESCRIPTION
- The name of a checker is the same as its file name but without the _checker part (underscore is used for name).
-  Dashes are used for connecting words in a message symbol.
- The parameter of decorator function check_messages() is the message symbol.
