### PR TITLE
pylint-patch: protected-member-access

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -26,6 +26,7 @@ from astroid import MANAGER
 import pycodestyle
 
 from .reporters import ColorReporter
+from .patches import patch_all
 
 
 # Local version of website; will be updated later.
@@ -107,6 +108,9 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5, level='
     else:
         linter.read_config_file(os.path.join(os.path.dirname(__file__), '.pylintrc'))
     linter.load_config_file()
+
+    # Monkeypatch pylint
+    patch_all()
 
     # Make sure the program doesn't crash for students.
     # Could use some improvement for better logging and error reporting.

--- a/python_ta/patches/__init__.py
+++ b/python_ta/patches/__init__.py
@@ -1,0 +1,8 @@
+"""Monkeypatch pylint behaviour.
+"""
+from .checkers import patch_checkers
+
+
+def patch_all():
+    """Execute all patches defined in this module."""
+    patch_checkers()

--- a/python_ta/patches/checkers.py
+++ b/python_ta/patches/checkers.py
@@ -1,0 +1,33 @@
+"""Patch pylint checker behaviour.
+"""
+from pylint.checkers.classes import ClassChecker
+from pylint.checkers.utils import node_frame_class
+
+
+def patch_checkers():
+    """Run patches to modify built-in pylint checker behaviour."""
+    _override_check_protected_attribute_access()
+
+
+def _override_check_protected_attribute_access():
+    """Override protected-member-access check.
+
+    We find pylint's default protected-member-access check too restrictive in
+    method bodies; it only allows protected attribute access on the 'self'
+    parameter (and from the class itself).
+
+    We change this behaviour to allow access to any protected attribute that is
+    defined for this class. (This leads to false negatives unless we combine
+    this with type inference, but we're okay with that.)
+    """
+    old_check_protected_attribute_access =\
+        ClassChecker._check_protected_attribute_access
+
+    def _check(self, node):
+        attrname = node.attrname
+        klass = node_frame_class(node)
+        if klass is not None and attrname not in klass.instance_attrs:
+            old_check_protected_attribute_access(self, node)
+
+    ClassChecker._check_protected_attribute_access = _check
+

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     author='David Liu',
     author_email='david@cs.toronto.edu',
     license='MIT',
-    packages=['python_ta', 'python_ta.reporters', 'python_ta.checkers', 'python_ta.docstring'],
+    packages=['python_ta', 'python_ta.reporters', 'python_ta.checkers',
+              'python_ta.docstring', 'python_ta.patches'],
     install_requires=[
         'pycodestyle',
         'pylint',


### PR DESCRIPTION
This changes the behaviour of the pylint check W0212 (protected-member-access), to **allow** all protected instance attributes of a class to be accessed from within methods of that class. By default, only `self`, was allowed to access this.