### PR TITLE
Node-docs-TODO last three nodes

### DIFF
--- a/nodes/Import.py
+++ b/nodes/Import.py
@@ -1,15 +1,28 @@
 """
 Import astroid node
 
-An import statement
+Represents an import statement. Unlike ImportFrom, Import node doesn't have
+the attribute "level".
 
 Attributes:
-    - names  (List[Alias])
-        - List of alias nodes. Each alias node has a name attribute and an
-          asname attribute.
+    - names  (List[Tuple])
+        - List of tuples of the names of the module that is being imported.
 
-Example:
-    - names  -> [Alias(astroid, ast)]
+Example 1:
+    - names  -> [('astroid', 'ast')]
+
+Example 2:
+    - names  -> [('sample_usage.pyta_stats', None)]
+
+Example 3:
+    - names  -> [('astroid', None), ('sample_usage', None)]
 """
 
+# Example 1:
 import astroid as ast
+
+# Example 2:
+import sample_usage.pyta_stats
+
+# Example 3:
+import astroid, sample_usage

--- a/nodes/ImportFrom.py
+++ b/nodes/ImportFrom.py
@@ -6,17 +6,41 @@ This node represents statement from x import y.
 Attributes:
     - modname  (str)
         - The name of the module that is being imported from.
-    - names    (List[Alias])
-        - List of alias nodes. Each alias node has a name attribute and an
-          asname attribute.
-    - level    (int)
+    - names    (List[Tuple])
+        - List of tuples of the names of the functions that are being imported.
+    - level    (int | NoneType)
         - An integer that holds the level of the relative import. 0 means
           absolute import.
 
-Example:
-    - module  -> "transforms"
-    - names   -> [Alias(TransformVisitor, tfv)]
-    - level   -> 0
+Example 1:
+    - modname  -> "transforms"
+    - names    -> [("TransformVisitor", "tfv")]
+    - level    -> None
+
+Example 2:
+    - modname  -> "sample_usage.pyta_stats"
+    - names    -> [("pyta_statistics", None), ("_print_stats", None)]
+    - level    -> None
+
+Example 3:
+    - modname  -> ""
+    - names    -> [("level_is_2", "l2")]
+    - level    -> 2
+
+Example 4:
+    - modname  -> ""
+    - names    -> [("level_is_3", "l3")]
+    - level    -> 3
 """
 
+# Example 1:
 from transforms import TransformVisitor as tfv
+
+# Example 2:
+from sample_usage.pyta_stats import pyta_statistics, _print_stats
+
+# Example 3:
+from .. import level_is_2 as l2
+
+# Example 4:
+from ... import level_is_3 as l3

--- a/nodes/Index.py
+++ b/nodes/Index.py
@@ -1,14 +1,27 @@
 """
 Index astroid node
 
-Simple subscripting with a single value.
+This node represents simple subscripting with a single value.
 
 Attributes:
-    - value  (Num)
-        - A Num node contains a single value.
+    - value  (Expr)
+        - The Expr node can be Const, UnaryOp, BinOp, etc.
 
-Example:
-    - value  -> Num(0)
+Example 1:
+    - value  -> Const(0)
+
+Example 2:
+    - value -> UnaryOp(-1)
+
+Example 3:
+    - value -> BinOp(1, 2)
 """
 
+# Example 1:
 x[0]
+
+# Example 2:
+x[-1]
+
+# Example 3:
+x[1+2]

--- a/nodes/TODO.md
+++ b/nodes/TODO.md
@@ -62,21 +62,6 @@ Finally, the variable name given in the example documentation is incorrect.
 
 The description of `value` should really reference the fact that these are literal constants rather than just computed values.
 
-## Import
-
-Not all imports need to have an alias (e.g., `import astroid` vs. `import astroid as ast`).
-It would be good to show an example of both, and how the attribute values differ.
-
-Also would be good to show having multiple imports on the same line.
-
-## ImportFrom
-
-Same comment as `Import`. Also worth investigating: is the `level` attribute on `Import` as well?
-
-## Index
-
-The type of `value` is more general; e.g., `x[1+2]`.
-
 ## ListComp
 
 It seems like the type of `Generators` should be `List[Comprehension]`,


### PR DESCRIPTION
I've finished fixing the documentations for the last three nodes (Import, ImportFrom, Index).
I also deleted those three nodes from TODO.md.

Side Notes: 
  One interesting thing that I found was that Import and ImportFrom don't have any attributes in the astroid fields (their attributes are in _other_fields); therefore, when I tried printing the astroid node tree for Import and ImportFrom, it showed that there weren't any attributes for those nodes. I needed to use the debugger in order to see more details about their attributes.