### PR TITLE
Make some suggested amendments to reporters and add to TODO

### DIFF
--- a/python_ta/reporters/TODO.md
+++ b/python_ta/reporters/TODO.md
@@ -19,10 +19,19 @@
 
 ## `HTMLReporter`
 
+* Fix the following `_COLOURING` dict entries, which need to be included so that HTMLReporter can call `_colour_messages_by_type` safely (currently useless):
+    * 'bold', 'code-heading', 'style-heading', 'code-name', 'style-name'
+
+* Use javascript to expand and close the source code of each error messages.
+
+* The ColorReporter shows the correct output for pylint.W0631_undefined_loop_variable, but the HTMLReporter doesn't.
+
+## Other
+
+* Consider changing ColorReporter & HTMLReporter's `_COLOURING` dict to an Enum.
+
 * Not all error messages are explained on the website: http://www.cs.toronto.edu/~david/pyta/:
 
     * `C0305 (trailing-newlines)`
 
-* Use javascript to expand and close the source code of each error messages.
-
-* `python_ta.checkall()` does not work on all code now. An unexpected error occurs and returns **ERROR: last_child is missing or is missing attributes.** when we call python_ta.checkall() on the student's code (from Assignment 3). Also, the ColorReporter shows the correct output for pylint.W0631_undefined_loop_variable, but the HTMLReporter doesn't.
+* `python_ta.check_all()` does not work on all code now. An unexpected error occurs and returns **ERROR: last_child is missing or is missing attributes.** when we call `python_ta.check_all()` on the student's code (from Assignment 3).

--- a/python_ta/reporters/TODO.md
+++ b/python_ta/reporters/TODO.md
@@ -13,6 +13,10 @@
     * `always-returning-in-a-loop`
     * `too-many-nested-blocks`
 
+* In the vaguely distant future, when more people reliably have Python 3.6,
+  change the ints in the LineType class definition into `enum.auto()` calls.
+    * (will need to be imported, of course)
+
 ## `HTMLReporter`
 
 * Not all error messages are explained on the website: http://www.cs.toronto.edu/~david/pyta/:

--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -1,4 +1,6 @@
 import sys
+from collections import defaultdict
+from enum import Enum
 
 from colorama import Fore, Style, Back
 from colorama import init
@@ -6,29 +8,34 @@ from colorama import init
 from .plain_reporter import PlainReporter
 
 # Messages that should be highlighted specially
-special = {"missing-docstring",
-           "trailing-newlines"}
+special = {'missing-docstring',
+           'trailing-newlines'}
 
 # Messages without a source code line to highlight
-no_hl = {"always-returning-in-a-loop",
-         "too-many-nested-blocks"}
+no_hl = {'always-returning-in-a-loop',
+         'too-many-nested-blocks'}
     # the "Invalid module name" subsection of "invalid-name" belongs here
 
 
 class ColorReporter(PlainReporter):
     _SPACE = ' '
-    _COLOURING = {"black": Fore.BLACK,  # or could be empty
-                  "highlight": Style.BRIGHT + Fore.BLACK + Back.CYAN,
-                  "grey": Fore.LIGHTBLACK_EX,
-                  "gbold": Style.BRIGHT + Fore.LIGHTBLACK_EX,
-                  "reset": Style.RESET_ALL}
+    _BREAK = '\n'
+    _COLOURING = {'black': Fore.BLACK,  # or could be empty
+                  'bold': Style.BRIGHT,
+                  'code-heading': Fore.RED + Style.BRIGHT,
+                  'style-heading': Fore.BLUE + Style.BRIGHT,
+                  'code-name': Fore.RED + Style.BRIGHT,
+                  'style-name': Fore.BLUE + Style.BRIGHT,
+                  'highlight': Style.BRIGHT + Fore.BLACK + Back.CYAN,
+                  'grey': Fore.LIGHTBLACK_EX,
+                  'gbold': Style.BRIGHT + Fore.LIGHTBLACK_EX,
+                  'reset': Style.RESET_ALL}
 
     # Override this method to add instance variables
     def __init__(self, number_of_messages, source_lines=None, module_name=''):
         super().__init__(number_of_messages, source_lines, module_name)
-        self._sorted_error_messages = {}
-        self._sorted_style_messages = {}
-
+        self._sorted_error_messages = defaultdict(list)
+        self._sorted_style_messages = defaultdict(list)
 
     # Override this method
     def print_messages(self, level='all'):
@@ -37,41 +44,32 @@ class ColorReporter(PlainReporter):
 
         self.sort_messages()
 
-        result = self._colourify(Fore.RED + Style.BRIGHT,
+        result = self._colourify('code-heading',
                                  '=== Code errors/forbidden usage '
                                  '(fix these right away!) ===\n')
         result += self._colour_messages_by_type(style=False)
 
         if level == 'all':
-            result += '\n' + self._colourify(Fore.BLUE + Style.BRIGHT,
-                                             '=== Style/convention errors '
-                                             '(fix these before submission) ===\n')
+            result += self._colourify('style-heading',
+                                      '=== Style/convention errors '
+                                      '(fix these before submission) ===\n')
             result += self._colour_messages_by_type(style=True)
 
         print(result)
 
     # Override this method
     def sort_messages(self):
-        # Sort the messages by their type
-        def sort_messages_by_type(messages):
-            messages.sort(key=lambda s: s[0])
-            sorted_messages = {}
-            # Count the number of occurrences and sort the msgs according to their id's
+        # Sort the messages by their type (message id)
+        def sort_messages_by_type(messages, sorted_messages):
             i = 0
             while i < len(messages):
                 current_id = messages[i].msg_id
-                count = 1
-                sorted_messages[current_id] = [messages[i]]
-                while i + 1 < len(messages) and messages[i + 1].msg_id == current_id:
-                    count += 1
-                    sorted_messages[current_id].append(messages[i + 1])
+                while i < len(messages) and messages[i].msg_id == current_id:
+                    sorted_messages[current_id].append(messages[i])
                     i += 1
 
-                i += 1
-            return sorted_messages
-
-        self._sorted_error_messages = sort_messages_by_type(self._error_messages)
-        self._sorted_style_messages = sort_messages_by_type(self._style_messages)
+        sort_messages_by_type(self._error_messages, self._sorted_error_messages)
+        sort_messages_by_type(self._style_messages, self._sorted_style_messages)
 
     _display = None   # because PyCharm is annoying about this
 
@@ -83,121 +81,118 @@ class ColorReporter(PlainReporter):
         :param bool style: True iff messages is a dict of style messages
         :return: str
         """
-        result = ""
+        result = ''
 
         if style:
             messages = self._sorted_style_messages
-            fore_colour = Fore.BLUE
+            fore_colour = 'style-name'
         else:
             messages = self._sorted_error_messages
-            fore_colour = Fore.RED
+            fore_colour = 'code-name'
 
         for msg_id in messages:
-            code = self._colourify(fore_colour + Style.BRIGHT, msg_id)
-            result += code + ' ({})  '.format(messages[msg_id][0].symbol)
+            result += self._colourify(fore_colour, msg_id)
+            result += self._colourify('bold', ' ({})  '.format(messages[msg_id][0].symbol))
             result += 'Number of occurrences: {}.\n\n'.format(len(messages[msg_id]))
 
             for i, msg in enumerate(messages[msg_id]):
                 msg_text = msg.msg
-                if msg.symbol == "bad-whitespace":  # fix Pylint inconsistency
+                if msg.symbol == 'bad-whitespace':  # fix Pylint inconsistency
                     msg_text = msg_text.partition('\n')[0]
                     messages[msg_id][i] = msg._replace(msg=msg_text)
                     msg = messages[msg_id][i]
 
-                result += 4 * self._SPACE
-                result += self._colourify(Style.BRIGHT, '[Line {}] {}'.format(
+                result += 2 * self._SPACE
+                result += self._colourify('bold', '[Line {}] {}'.format(
                     msg.line, msg.msg)) + '\n'
 
                 try:
                     # Messages with code snippets
                     if not (msg.symbol in no_hl or
-                            msg.msg.startswith("Invalid module")):
-
-                        if hasattr(msg, "node") and msg.node is not None:
-                            start = max(msg.node.fromlineno, 1)
-                            end = msg.node.end_lineno
-                        else:
-                            # Some message types don't have a node, including:
-                            # - line-too-long
-                            # - bad-whitespace
-                            # - trailing-newlines
-                            start = end = msg.line
-
-                        result += '\n' + 4 * self._SPACE
-                        result += self._colourify(Style.BRIGHT,
-                                                  'Your Code Starts Here:\n')
-                        result += '\n'
-
-                        code_snippet = ""
-
-                        # Non-special prints first error line with 'e', other
-                        # lines with 'o'.
-                        # Special prints each message specially.
-                        # Both print 2 lines of context before and after
-                        # (code boundaries permitting).
-
-                        # Print up to 2 lines before start - 1 for context:
-                        for l in range(max(start - 3, 0), start - 1):
-                            code_snippet += self._add_line(msg, l, 'c')
-
-                        if msg.symbol == "trailing-newlines":
-                            code_snippet += self._add_line(msg, start - 1, 'n')
-                        elif msg.msg.startswith("Missing function docstring"):
-                            code_snippet += self._add_line(
-                                msg, start - 1, 'e')
-                            code_snippet += self._add_line(msg, start, 'd')
-                            end = start  # to print context after function header
-                        elif msg.msg.startswith("Missing module docstring"):
-                            # Perhaps instead of start, use line 0?
-                            code_snippet += self._add_line(msg, start - 1, 'd')
-                            end = 0  # to print context after
-                        else:  # so msg isn't in special at all
-                            code_snippet += self._add_line(msg, start - 1, 'e')
-                            for line in range(start, end):
-                                code_snippet += self._add_line(msg, line, 'o')
-
-                        # Print up to 2 lines after end - 1 for context:
-                        for l in range(end, min(end + 2, len(self._source_lines))):
-                            code_snippet += self._add_line(msg, l, 'c')
-
-                        result += code_snippet + '\n'
+                            msg.msg.startswith('Invalid module')):
+                        code_snippet = self._build_snippet(msg)
+                        result += code_snippet
                         try:
                             messages[msg_id][i] = msg._replace(snippet=code_snippet)
-                        except ValueError as e:
-                            # raise ValueError("Non-NewMessage message has "
-                            #                  "no 'snippet' attribute") from e
+                        except ValueError:
                             pass
-
                 except AttributeError:
                     pass
-
                 result += '\n'
         return result
+
+    def _build_snippet(self, msg):
+        """
+        Generates and returns a code snippet for the given Message object,
+        formatted appropriately according to line type.
+
+        :param Message msg: the message for which a code snippet is built
+        :return: str
+        """
+        if hasattr(msg, 'node') and msg.node is not None:
+            start = max(msg.node.fromlineno, 1)
+            end = msg.node.end_lineno
+        else:
+            # Some message types don't have a node, including:
+            # - line-too-long
+            # - bad-whitespace
+            # - trailing-newlines
+            start = end = msg.line
+
+        code_snippet = ''
+
+        # Non-special prints first error line with 'e', other
+        # lines with 'o'.
+        # Special prints each message specially.
+        # Both print 2 lines of context before and after
+        # (code boundaries permitting).
+
+        # Print up to 2 lines before start - 1 for context:
+        for l in range(max(start - 3, 0), start - 1):
+            code_snippet += self._add_line(msg, l, LineType.CONTEXT)
+
+        if msg.symbol == 'trailing-newlines':
+            code_snippet += self._add_line(msg, start - 1, LineType.NUMBERONLY)
+        elif msg.msg.startswith('Missing function docstring'):
+            code_snippet += self._add_line(
+                msg, start - 1, LineType.ERROR)
+            code_snippet += self._add_line(msg, start, LineType.DOCSTRING)
+            end = start  # to print context after function header
+        elif msg.msg.startswith('Missing module docstring'):
+            # Perhaps instead of start, use line 0?
+            code_snippet += self._add_line(msg, start - 1, LineType.DOCSTRING)
+            end = 0  # to print context after
+        else:  # so msg isn't in special at all
+            code_snippet += self._add_line(msg, start - 1, LineType.ERROR)
+            for line in range(start, end):
+                code_snippet += self._add_line(msg, line, LineType.OTHER)
+
+        # Print up to 2 lines after end - 1 for context:
+        for l in range(end, min(end + 2, len(self._source_lines))):
+            code_snippet += self._add_line(msg, l, LineType.CONTEXT)
+
+        return code_snippet
 
     def _add_line(self, msg, n, linetype):
         """
         Format given source code line as specified and return as str.
-        Use linetype='n' to print only the highlighted line number of the line.
-        Use linetype='.' to elide line (with proper indentation).
-        Use linetype='d' to show a "YOUR DOCSTRING HERE" message.
 
         Called by _colour_messages_by_type, relies on _colourify.
         Now applicable both to ColorReporter and HTMLReporter.
 
         :param int n: index of line in self._source_lines to add
-        :param str linetype: e/c/o/n/./d for
-            error/context/other/number-only/ellipsis/docstring
+        :param LineType linetype: enum member indicating way to format line
         :return: str
         """
-        snippet = ""
-        spaces = 4 * self._SPACE
+        snippet = ''
+        spaces = 2 * self._SPACE
         text = self._source_lines[n].rstrip('\n\r')
         # Pad line number with spaces to even out indent:
-        number = "{:>3}".format(n + 1)
+        number = '{:>3}'.format(n + 1)
 
-        if linetype == "e":  # (error)
-            snippet += spaces + self._colourify("gbold", number)
-            if hasattr(msg, "node") and msg.node is not None:
+        if linetype == LineType.ERROR:
+            snippet += spaces + self._colourify('gbold', number)
+            if hasattr(msg, 'node') and msg.node is not None:
                 start_col = msg.node.col_offset
                 end_col = msg.node.end_col_offset
             else:
@@ -205,41 +200,39 @@ class ColorReporter(PlainReporter):
                 start_col = -len(text.lstrip(' '))  # negative to count from end
                 end_col = len(text)
 
-            snippet += spaces + self._colourify("black", text[:start_col])
-            snippet += self._colourify("highlight",
+            snippet += spaces + self._colourify('black', text[:start_col])
+            snippet += self._colourify('highlight',
                                        text[start_col:end_col])
-            snippet += self._colourify("black", text[end_col:])
+            snippet += self._colourify('black', text[end_col:])
 
-        elif linetype == "c":  # (context)
-            snippet += spaces + self._colourify("grey", number)
-            snippet += spaces + self._colourify("grey", text)
+        elif linetype == LineType.CONTEXT:
+            snippet += spaces + self._colourify('grey', number)
+            snippet += spaces + self._colourify('grey', text)
 
-        elif linetype == "o":  # (other)
-            snippet += spaces + self._colourify("grey", number)
+        elif linetype == LineType.OTHER:
+            snippet += spaces + self._colourify('grey', number)
             snippet += spaces + text
 
-        elif linetype == "n":  # (number only)
-            snippet += spaces + self._colourify("highlight", number)
+        elif linetype == LineType.NUMBERONLY:
+            snippet += spaces + self._colourify('highlight', number)
 
-        elif linetype == '.':  # (ellipsis)
-            snippet += spaces + self._colourify("gbold", number)
+        elif linetype == LineType.ELLIPSIS:
+            snippet += spaces + self._colourify('gbold', number)
             snippet += spaces
             space_c = len(text) - len(text.lstrip(' '))
             snippet += space_c * self._SPACE
-            snippet += self._colourify("black", '. . .')
+            snippet += self._colourify('black', '. . .')
             # Need spaces in between dots to prevent PyCharm thinking
             # that the '...' is actually a line-continuation prompt.
 
-        elif linetype == 'd':  # (docstring)
-            snippet += self._SPACE * 11  # 11 spaces
+        elif linetype == LineType.DOCSTRING:
+            snippet += self._SPACE * 7  # 2-space indent, 3-space number, 2-space indent
             space_c = len(text) - len(text.lstrip(' '))
             snippet += space_c * self._SPACE
-            snippet += self._colourify("highlight",
+            snippet += self._colourify('highlight',
                                        '''""" YOUR DOCSTRING HERE """''')
-        else:
-            print("ERROR: unrecognised _add_line option")
 
-        snippet += '\n' if spaces == '    ' else '<br/>'
+        snippet += self._BREAK
         return snippet
 
     @classmethod
@@ -256,15 +249,20 @@ class ColorReporter(PlainReporter):
         :param str text: text to be coloured
         :return str
         """
-        try:
-            colour = cls._COLOURING[colour_class]
-        except KeyError:
-            colour = colour_class
-
+        colour = cls._COLOURING[colour_class]
         new_text = text.lstrip(' ')
         space_count = len(text) - len(new_text)
-        if cls._SPACE == '&nbsp;':
+        if cls._SPACE != ' ':
             new_text = new_text.replace(' ', cls._SPACE)
         return ((space_count * cls._SPACE) + colour + new_text +
-                cls._COLOURING["reset"])
+                cls._COLOURING['reset'])
 
+
+class LineType(Enum):
+    """ An enumeration for _add_line method line types. """
+    ERROR = 1       # line with error
+    CONTEXT = 2     # non-error/other line added for context
+    OTHER = 3       # line included in source but not error
+    NUMBERONLY = 4  # only highlighted line number
+    ELLIPSIS = 5    # code replaced with ellipsis
+    DOCSTRING = 6   # docstring needed warning

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -11,11 +11,17 @@ THIS_DIR = os.path.dirname(os.path.abspath(__file__))
 
 class HTMLReporter(ColorReporter):
     _SPACE = '&nbsp;'
-    _COLOURING = {"black": '<span class="black">',
-                  "highlight": '<span class="highlight">',
-                  "grey": '<span class="grey">',
-                  "gbold": '<span class="gbold">',
-                  "reset": '</span>'}
+    _BREAK = '<br/>'
+    _COLOURING = {'black': '<span class="black">',
+                  'bold': '<span>',
+                  'code-heading': '<span>',
+                  'style-heading': '<span>',
+                  'code-name': '<span>',
+                  'style-name': '<span>',
+                  'highlight': '<span class="highlight">',
+                  'grey': '<span class="grey">',
+                  'gbold': '<span class="gbold">',
+                  'reset': '</span>'}
 
     # Override this method
     def print_messages(self, level='all'):
@@ -31,13 +37,15 @@ class HTMLReporter(ColorReporter):
 
         # Date/time (24 hour time) format:
         # Generated: ShortDay. ShortMonth. PaddedDay LongYear, Hour:Min:Sec
-        dt = "Generated: " + str(datetime.now().
-                                 strftime("%a. %b. %d %Y, %H:%M:%S"))
+        dt = 'Generated: ' + str(datetime.now().
+                                 strftime('%a. %b. %d %Y, %H:%M:%S'))
         with open(output_path, 'w') as f:
             f.write(template.render(date_time=dt,
                                     mod_name=self._module_name,
                                     code=self._sorted_error_messages,
                                     style=self._sorted_style_messages))
-        print("Opening your report in a browser...")
+        print('Opening your report in a browser...')
         output_url = 'file:///{}/templates/output.html'.format(THIS_DIR)
         webbrowser.open(output_url)
+
+    _display = None


### PR DESCRIPTION
The following suggested changes were completed (numbering consistent with ROP A4 feedback page):
1. The overall formatting of the ColorReporter output takes up too much vertical space per error message. Work on reducing the number of blank lines that appear. Consider reducing indentation of text output to 2 spaces instead of 4. **(removed most blank lines, reduced indent)**
2. The heading "Your Code Starts Here" should not have every word capitalized. Moreover, I don't actually think this heading is necessary at all in either reporter type. It should be pretty clear based on formatting which parts are the student code. **(removed heading)**
3. The style of bolding in ColorReporter doesn't match the logical structure of headings. For example, the short name of the message (e.g., "trailing-newlines") is not bolded, but the actual error message itself is. **(bolded short name)**
4. Speaking of trailing-newlines, I'd recommend showing *all* the trailing newlines (including the last one) to make it more obvious what the problem is. **(not easily fixable, see issue #153)**
---
6. The use of the `_COLOURING` dictionary is excellent. However, it can be made even better by putting *all* styling information in there. For example, this same dictionary should be used to format all the headings, including the `=== Code errors ... ===` and `=== Style errors ... ===` headings. 
**(added to `_COLOURING`, removed try-except in `_colourify`)**
7. `sort_messages`:
    - the variable `count` is unnecessary **(gone)**
    - it is no longer necessary to sort the existing messages (`messages.sort`) before adding them to the dictionary **(gone)**
    - you can use a `defaultdict` class here to store the messages, with the default value being an empty list **(added to constructor, `while` loop reworked)**
8. `_colour_messages_by_type` & `_add_line`:
    - these methods are far too long, and should be split up into helper methods **(split `_colour_messages_by_type`, but splitting `_add_line` seems too inefficient)**
    - don't use single letters as arguments to `_add_line`. Instead, define an `Enum` class to represent the different types **(added, plus TODO for future)**
9. Use another class attribute to represent a line break (either `\n` or `<br/>`) **(added)**
---
11. In general, use single-quotes for string literals, not double-quotes. **(fixed)**

Left:
- [ ] Suggestion 5 (the `assigning_to_self_example` error) needs to be worked on.
- [ ] Suggestion 10 ("The source lines should be processed in the constructor to remove newline characters.") would add an extra iteration through the source lines, without any apparent gain, so this is left for now.
- [ ] Suggestions 12-20 remain.
- Some reporter TODOs added as well.