### PR TITLE
Reimplement set env

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -260,6 +260,8 @@ def register_type_constraints_setter():
 
 def _populate_type_env(node):
     """Helper to prevent overlap in populating locals and globals attributes in type environment of given node."""
+    if isinstance(node, astroid.FunctionDef):
+        node.type_environment = Environment(locals_={name: TYPE_CONSTRAINTS.fresh_tvar() for name in node.locals})
     node.type_environment = Environment(globals_={name: TYPE_CONSTRAINTS.fresh_tvar() for name in node.globals})
     for var_name in node.locals:
         if var_name in node.type_environment.get_globals():

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -258,11 +258,21 @@ def register_type_constraints_setter():
     return type_visitor
 
 
+def _populate_type_env(node):
+    """Helper to prevent overlap in populating locals and globals attributes in type environment of given node."""
+    node.type_environment = Environment(globals_={name: TYPE_CONSTRAINTS.fresh_tvar() for name in node.globals})
+    for var_name in node.locals:
+        if var_name in node.type_environment.get_globals():
+            var_value = node.type_environment.get_globals()[var_name]
+        else:
+            var_value = TYPE_CONSTRAINTS.fresh_tvar()
+        node.type_environment.add_to_locals(var_name, var_value)
+
+
 def _set_environment(node):
-    node.type_environment = Environment(locals_={name: TYPE_CONSTRAINTS.fresh_tvar() for name in node.locals},
-                                        globals_={name: TYPE_CONSTRAINTS.fresh_tvar() for name in node.globals})
+    _populate_type_env(node)
     if isinstance(node, astroid.FunctionDef):
-        node.type_environment.locals['return'] = TYPE_CONSTRAINTS.fresh_tvar()
+        node.type_environment.add_to_locals('return', TYPE_CONSTRAINTS.fresh_tvar())
 
 
 def environment_transformer() -> TransformVisitor:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -240,5 +240,37 @@ class Environment:
         self.nonlocals = nonlocals_ or {}
         self.globals = globals_ or {}
 
+
+    def get_locals(self):
+        """Helper method for accessing local variables in node's environment"""
+        # _locals? private attributes?
+        return self.locals
+
+
+    def add_to_locals(self, variable_name, variable_value):
+        """Helper to add a pair of variable name and value to the locals environment"""
+        self.locals[variable_name] = variable_value
+
+
+    def get_globals(self):
+        """Helper method for accessing global variables in node's environment"""
+        return self.globals
+
+
+    def add_to_globals(self, variable_name, variable_value):
+        """Helper to add a pair of variable name and value to the globals environment"""
+        self.globals[variable_name] = variable_value
+
+
+    def get_nonlocals(self):
+        """Helper method for accessing nonlocal variables in node's environment"""
+        return self.nonlocals
+
+
+    def add_to_nonlocals(self, variable_name, variable_value):
+        """Helper to add a pair of variable name and value to the globals environment"""
+        self.nonlocals[variable_name] = variable_value
+
+
     def __str__(self):
         return str(self.locals)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -241,7 +241,7 @@ class Environment:
         self.globals = globals_ or {}
 
 
-    def get_locals(self, var_name):
+    def get_locals(self):
         """Helper method for accessing local variables in node's environment"""
         # _locals? private attributes?
         return self.locals
@@ -252,7 +252,7 @@ class Environment:
         self.locals[variable_name] = variable_value
 
 
-    def get_globals(self, var_name):
+    def get_globals(self):
         """Helper method for accessing global variables in node's environment"""
         return self.globals
 
@@ -262,7 +262,7 @@ class Environment:
         self.globals[variable_name] = variable_value
 
 
-    def get_nonlocals(self, var_name):
+    def get_nonlocals(self):
         """Helper method for accessing nonlocal variables in node's environment"""
         return self.nonlocalsg
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -274,4 +274,3 @@ class Environment:
 
     def __str__(self):
         return str(self.locals)
-

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -241,10 +241,10 @@ class Environment:
         self.globals = globals_ or {}
 
 
-    def get_locals(self):
+    def get_locals(self, var_name):
         """Helper method for accessing local variables in node's environment"""
         # _locals? private attributes?
-        return self.locals
+        return self.locals[var_name]
 
 
     def add_to_locals(self, variable_name, variable_value):
@@ -252,9 +252,9 @@ class Environment:
         self.locals[variable_name] = variable_value
 
 
-    def get_globals(self):
+    def get_globals(self, var_name):
         """Helper method for accessing global variables in node's environment"""
-        return self.globals
+        return self.globals[var_name]
 
 
     def add_to_globals(self, variable_name, variable_value):
@@ -262,9 +262,9 @@ class Environment:
         self.globals[variable_name] = variable_value
 
 
-    def get_nonlocals(self):
+    def get_nonlocals(self, var_name):
         """Helper method for accessing nonlocal variables in node's environment"""
-        return self.nonlocals
+        return self.nonlocals[var_name]
 
 
     def add_to_nonlocals(self, variable_name, variable_value):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -244,7 +244,7 @@ class Environment:
     def get_locals(self, var_name):
         """Helper method for accessing local variables in node's environment"""
         # _locals? private attributes?
-        return self.locals[var_name]
+        return self.locals
 
 
     def add_to_locals(self, variable_name, variable_value):
@@ -254,7 +254,7 @@ class Environment:
 
     def get_globals(self, var_name):
         """Helper method for accessing global variables in node's environment"""
-        return self.globals[var_name]
+        return self.globals
 
 
     def add_to_globals(self, variable_name, variable_value):
@@ -264,7 +264,7 @@ class Environment:
 
     def get_nonlocals(self, var_name):
         """Helper method for accessing nonlocal variables in node's environment"""
-        return self.nonlocals[var_name]
+        return self.nonlocalsg
 
 
     def add_to_nonlocals(self, variable_name, variable_value):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -274,3 +274,4 @@ class Environment:
 
     def __str__(self):
         return str(self.locals)
+


### PR DESCRIPTION
- Reimplement set environment method using helpers from Environment class.
- Account for FunctionDef nodes, which have no globals attribute.