### PR TITLE
Add to _check() API to accept a dict of config options for Checkers.

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -74,10 +74,10 @@ def _load_pylint_plugins(current_reporter, local_config, pep8):
         # Use default config file in the python_ta package.
         linter.read_config_file(os.path.join(os.path.dirname(__file__), '.pylintrc'))
 
-    # Override part of the default config, with a dict of config options.
-    if isinstance(local_config, dict):
-        for key in local_config:
-            linter.global_set_option(key, local_config[key])
+        # Override part of the default config, with a dict of config options.
+        if isinstance(local_config, dict):
+            for key in local_config:
+                linter.global_set_option(key, local_config[key])
 
     linter.load_config_file()
     return linter

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -67,13 +67,18 @@ def _load_pylint_plugins(current_reporter, local_config, pep8):
     if pep8:
         linter.load_plugin_modules(['python_ta/checkers/pycodestyle_checker'])
 
+    if isinstance(local_config, str) and local_config != '':
+        # Use config file at the specified path instead of the default.
+        linter.read_config_file(local_config)
+    else:
+        # Use default config file in the python_ta package.
+        linter.read_config_file(os.path.join(os.path.dirname(__file__), '.pylintrc'))
+
+    # Override part of the default config, with a dict of config options.
     if isinstance(local_config, dict):
         for key in local_config:
             linter.global_set_option(key, local_config[key])
-    elif local_config != '':
-        linter.read_config_file(local_config)
-    else:
-        linter.read_config_file(os.path.join(os.path.dirname(__file__), '.pylintrc'))
+
     linter.load_config_file()
     return linter
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -40,27 +40,19 @@ if sys.version_info < (3, 4, 0):
 def check_errors(module_name='', reporter=ColorReporter, number_of_messages=5,
                  config=''):
     """Check a module for errors, printing a report.
-
-    The name of the module should be the name of a module,
-    or the path to a Python file.
     """
-    _check(module_name=module_name, reporter=reporter, number_of_messages=number_of_messages, level='error', local_config_file=config)
+    _check(module_name=module_name, reporter=reporter, number_of_messages=number_of_messages, level='error', local_config=config)
 
 
 def check_all(module_name='', reporter=ColorReporter, number_of_messages=5,
               config=''):
-    """Check a module for errors and style warnings, printing a report.
-
-    The name of the module should be passed in as a string,
-    without a file extension (.py).
-    """
+    """Check a module for errors and style warnings, printing a report."""
     _check(module_name, reporter, number_of_messages, level='all',
-           local_config_file=config)
+           local_config=config)
 
 
-def _load_pylint_plugins(current_reporter, local_config_file, pep8):
-    """Register checker plugins for pylint. Return linter.
-    """
+def _load_pylint_plugins(current_reporter, local_config, pep8):
+    """Register checker plugins for pylint. Return linter."""
     linter = lint.PyLinter(reporter=current_reporter)
     linter.load_default_plugins()
     linter.load_plugin_modules(['python_ta/checkers/forbidden_import_checker',
@@ -75,8 +67,11 @@ def _load_pylint_plugins(current_reporter, local_config_file, pep8):
     if pep8:
         linter.load_plugin_modules(['python_ta/checkers/pycodestyle_checker'])
 
-    if local_config_file != '':
-        linter.read_config_file(local_config_file)
+    if isinstance(local_config, dict):
+        for key in local_config:
+            linter.global_set_option(key, local_config[key])
+    elif local_config != '':
+        linter.read_config_file(local_config)
     else:
         linter.read_config_file(os.path.join(os.path.dirname(__file__), '.pylintrc'))
     linter.load_config_file()
@@ -112,13 +107,17 @@ def _verify_pre_check(filepath):
 
 
 def _check(module_name='', reporter=ColorReporter, number_of_messages=5, level='all',
-           local_config_file='', pep8=False):
+           local_config='', pep8=False):
     """Check a module for problems, printing a report.
 
-    <level> is used to specify which checks should be made.
+    The `module_name` can take several inputs:
+    - a string of the directory, or file to check (`.py` extension is optional). 
+    - a list of strings of directories or files.
+    - or not provided, to check the current python file.
 
-    The name of the module should be the name of a module,
-    or path(s) to Python file(s) or directory(ies).
+    `level` is used to specify which checks should be made.
+
+    `local_config` is a dict of config options, or string of a config file name.
     """
     valid_module_names = []
 
@@ -136,7 +135,8 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5, level='
         return
 
     current_reporter = reporter(number_of_messages)
-    linter = _load_pylint_plugins(current_reporter, local_config_file, pep8)
+    linter = _load_pylint_plugins(current_reporter, local_config, pep8)
+    
     patch_all()  # Monkeypatch pylint
 
     for item in module_name:
@@ -170,7 +170,6 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5, level='
         print('Unexpected error encountered - please report this to david@cs.toronto.edu!')
         print('Error message: "{}"'.format(e))
         raise e
-
 
 
 def doc(msg_id):


### PR DESCRIPTION
We can now pass a keyword argument, a dict of config options, to `check_all()` or `check_errors()`.

An example of the dict of config options is:
```python
CONFIG = {
    # [ELIF]
    'max-nested-blocks': 3,
    # [FORMAT]
    'max-line-length': 80,
    # [FORBIDDEN IMPORT]
    'allowed-import-modules': ['doctest', 'unittest', 'hypothesis', 'python_ta'],
    # [FORBIDDEN IO]
    'allowed-io': None,
    # [MESSAGES CONTROL]
    'disable': ['R0401', 'R0901', 'R0903', 'R0904', 'R0911', 'R0916', 'W0402', 
                'W0403', 'W0410', 'W1501', 'W1502', 'W1505', 'E1300', 'E1301', 
                'E1302', 'E1304', 'W1300', 'W1301', 'W1302', 'W1304', 'E1124', 
                'E1125', 'E1129', 'E1132', 'W1402', 'W0105', 'E1303', 'W1306', 
                'W1307', 'E0116', 'E0114', 'E0112', 'E0115', 'E0106', 'E0113', 
                'E0111', 'E0105', 'E0100', 'E0117', 'W0150', 'W0120', 'W0124', 
                'W0108', 'W0123', 'W0122', 'W0110', 'C0122', 'C0200', 'W0141', 
                'W0640', 'W0623', 'W0614', 'W0604', 'W0603', 'W0602', 'W0601', 
                'E0604', 'E0603', 'E1200', 'E1201', 'E1202', 'W1201', 'E1205', 
                'E1206', 'similarities', 'newstyle', 'python3', 'W0512', 
                'C0403', 'C0401', 'C0402', 'E1701', 'E1700', 'W0332', 'C0327', 
                'C0328', 'E0202', 'E0241', 'E0704', 'W0211', 'W0232', 'W0511', 
                'R0204', 'C0303', 'W0231']
}
```