### PR TITLE
Dev test multi assignment statement

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -181,17 +181,10 @@ def set_boolop_type_constraints(node):
 # Statements
 ##############################################################################
 def set_assign_type_constraints(node):
-    # multi-assignments in single statement
-    if len(node.targets) > 1:
-        for target_node in node.targets:
-            target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
-            TYPE_CONSTRAINTS.unify(target_type_var, node.value.type_constraints.type)
-            node.type_constraints = TypeInfo(NoType)
-    else:
-        # single assignment; a single AssignName target node on LHS
-        first_target = node.targets[0]
-        TYPE_CONSTRAINTS.unify(node.frame().type_environment.lookup_in_env(first_target.name),
-                               node.value.type_constraints.type)
+    # assignment(s) in single statement
+    for target_node in node.targets:
+        target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
+        TYPE_CONSTRAINTS.unify(target_type_var, node.value.type_constraints.type)
         node.type_constraints = TypeInfo(NoType)
 
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -181,23 +181,14 @@ def set_boolop_type_constraints(node):
 # Statements
 ##############################################################################
 def set_assign_type_constraints(node):
-    try:
-        # multi-assignments in single statement
-        if len(node.targets) > 1:
-            for target_node in node.targets:
-                target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
-                TYPE_CONSTRAINTS.unify(target_type_var, target_node.parent.value.type_constraints.type)
-                node.type_constraints = TypeInfo(NoType)
-        else:
-            # multi-target assignment statement
-            targets_list = node.targets[0].elts
-            for i in range(len(targets_list)):
-                target_node = targets_list[i]
-                target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
-                TYPE_CONSTRAINTS.unify(target_type_var, node.value.elts[i].type_constraints.type)
+    # multi-assignments in single statement
+    if len(node.targets) > 1:
+        for target_node in node.targets:
+            target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
+            TYPE_CONSTRAINTS.unify(target_type_var, node.value.type_constraints.type)
             node.type_constraints = TypeInfo(NoType)
-    except AttributeError:
-        # single assignment
+    else:
+        # single assignment; a single AssignName target node on LHS
         first_target = node.targets[0]
         TYPE_CONSTRAINTS.unify(node.frame().type_environment.lookup_in_env(first_target.name),
                                node.value.type_constraints.type)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -43,10 +43,13 @@ def set_const_type_constraints(node):
 
 
 def set_tuple_type_constraints(node):
-    # node_types contains types of elements inside tuple.
-    node.type_constraints = TypeInfo(
-        Tuple[tuple(x.type_constraints.type for x in node.elts)]
-    )
+    # If tuple is on RHS, find and set Tuple type
+    if node.ctx == astroid.Load:
+        node.type_constraints = TypeInfo(
+                Tuple[tuple(x.type_constraints.type for x in node.elts)])
+    else:
+        # Tuple is on LHS; has no type - yet.
+        node.type_constraints = TypeInfo(NoType)
 
 
 def set_list_type_constraints(node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -181,10 +181,27 @@ def set_boolop_type_constraints(node):
 # Statements
 ##############################################################################
 def set_assign_type_constraints(node):
-    first_target = node.targets[0]
-    TYPE_CONSTRAINTS.unify(node.frame().type_environment.lookup_in_env(first_target.name),
-                           node.value.type_constraints.type)
-    node.type_constraints = TypeInfo(NoType)
+    try:
+        # multi-assignments in single statement
+        if len(node.targets) > 1:
+            for target_node in node.targets:
+                target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
+                TYPE_CONSTRAINTS.unify(target_type_var, target_node.parent.value.type_constraints.type)
+                node.type_constraints = TypeInfo(NoType)
+        else:
+            # multi-target assignment statement
+            targets_list = node.targets[0].elts
+            for i in range(len(targets_list)):
+                target_node = targets_list[i]
+                target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
+                TYPE_CONSTRAINTS.unify(target_type_var, node.value.elts[i].type_constraints.type)
+            node.type_constraints = TypeInfo(NoType)
+    except AttributeError:
+        # single assignment
+        first_target = node.targets[0]
+        TYPE_CONSTRAINTS.unify(node.frame().type_environment.lookup_in_env(first_target.name),
+                               node.value.type_constraints.type)
+        node.type_constraints = TypeInfo(NoType)
 
 
 def set_return_type_constraints(node):

--- a/tests/type_inference/test_literals.py
+++ b/tests/type_inference/test_literals.py
@@ -146,6 +146,21 @@ def test_single_assign(variable, value):
     assert target_value.type_constraints.type == target_type
 
 
+@given(hs.lists(hs.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), min_size=1), hs.integers())
+def test_set_multi_assign(variables_list, value):
+    """Test environment setting visitors"""
+    program = ""
+    for variable_name in variables_list:
+        assume(not iskeyword(variable_name))
+        program += variable_name + " = "
+    program += repr(value)
+    module = _parse_text(program)
+    # get list of variable names in locals
+    for target_node in module.nodes_of_class(astroid.AssignName):
+        target_type_var = target_node.frame().type_environment.lookup_in_env(target_node.name)
+        assert TYPE_CONSTRAINTS.lookup_concrete(target_type_var) == type(value)
+
+
 def _parse_text(source: str) -> astroid.Module:
     """Parse source code text and output an AST with type inference performed."""
     module = astroid.parse(source)

--- a/tests/type_inference/test_literals.py
+++ b/tests/type_inference/test_literals.py
@@ -146,14 +146,14 @@ def test_single_assign(variable, value):
     assert target_value.type_constraints.type == target_type
 
 
-@given(hs.lists(hs.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), min_size=1), hs.integers())
+@given(hs.lists(hs.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), min_size=1), cs.primitive_values)
 def test_set_multi_assign(variables_list, value):
     """Test environment setting visitors"""
-    program = ""
     for variable_name in variables_list:
         assume(not iskeyword(variable_name))
-        program += variable_name + " = "
-    program += repr(value)
+    program = ""
+    program += (" = ").join(variables_list)
+    program += " = " + repr(value)
     module = _parse_text(program)
     # get list of variable names in locals
     for target_node in module.nodes_of_class(astroid.AssignName):

--- a/tests/type_inference/test_literals.py
+++ b/tests/type_inference/test_literals.py
@@ -151,11 +151,9 @@ def test_set_multi_assign(variables_list, value):
     """Test environment setting visitors"""
     for variable_name in variables_list:
         assume(not iskeyword(variable_name))
-    program = ""
-    program += (" = ").join(variables_list)
-    program += " = " + repr(value)
+    variables_list.append(repr(value))
+    program = (" = ").join(variables_list)
     module = _parse_text(program)
-    # get list of variable names in locals
     for target_node in module.nodes_of_class(astroid.AssignName):
         target_type_var = target_node.frame().type_environment.lookup_in_env(target_node.name)
         assert TYPE_CONSTRAINTS.lookup_concrete(target_type_var) == type(value)


### PR DESCRIPTION
- Extend Name node visitor to properly set type constraints for multi-assignment statements
    (ie. a = b= 3)
- Add test case for aforementioned type of statements.