### PR TITLE
Pass custom config options from `pylintrc` to checkers/reporters.

### DIFF
--- a/python_ta/.pylintrc
+++ b/python_ta/.pylintrc
@@ -1,3 +1,17 @@
+[CUSTOM PYTA OPTIONS]
+
+# Make sure to register custom options tuple first in `python_ta/__init__.py`
+# ===========================================================
+# Default max amount of messages for reporter to display.
+number-of-messages = 5
+
+# Set whether to use the pycodestyle checker.
+# Anything for a True/False, <yn> value should use in config file: y, yes, n, no
+pep8=no
+
+# Set the output format. Available pyta formats are: color, plain, html, stat
+output-format=plain
+
 [ELIF]
 
 # Set maximum allowed if nesting.

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -55,11 +55,11 @@ def _find_pylintrc():
     """Search bottom-up for a `.pylintrc` file provided in user location.
     Return absolute path to the file, or None.
     • When run in an IDE (like PyCharm), sys.argv contains the full path,
-        - sys.argv[0] is: /Users/fong/Desktop/pyta/f0/f1/f2/new.py
-        - os.getcwd() is: /Users/fong/Desktop/pyta/f0/f1/f2
+        - sys.argv[0] is: /<users>/<user>/<path_to>/dir1/dir2/file.py
+        - os.getcwd() is: /<users>/<user>/<path_to>/dir1/dir2
     • When run from the Command Line, we need to combine the two,
-        - sys.argv[0] is: `f2/new.py`
-        - os.getcwd() is: /Users/fong/Desktop/pyta/f0/f1
+        - sys.argv[0] is: `dir2/file.py`
+        - os.getcwd() is: /<users>/<user>/<path_to>/dir1
     For more info see, pylint.config.find_pylintrc
     """
     found_pylintrc_location = None

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -25,27 +25,27 @@ import pylint.utils
 
 from astroid import MANAGER
 
-from .reporters import ColorReporter
+from .reporters import *
 from .patches import patch_all
 
 # Local version of website; will be updated later.
 HELP_URL = 'http://www.cs.toronto.edu/~david/pyta/'
+
+REPORTERS = (ColorReporter, PlainReporter, HTMLReporter, StatReporter)
 
 # check the python version
 if sys.version_info < (3, 4, 0):
     print('You need Python 3.4 or later to run this script')
 
 
-def check_errors(module_name='', reporter=ColorReporter, config=''):
+def check_errors(module_name='', config=''):
     """Check a module for errors, printing a report."""
-    _check(module_name=module_name, reporter=reporter, level='error', 
-           local_config=config)
+    _check(module_name=module_name, level='error', local_config=config)
 
 
-def check_all(module_name='', reporter=ColorReporter, config=''):
+def check_all(module_name='', config=''):
     """Check a module for errors and style warnings, printing a report."""
-    _check(module_name=module_name, reporter=reporter, level='all',
-           local_config=config)
+    _check(module_name=module_name, level='all', local_config=config)
 
 
 def _find_pylintrc_same_locale(curr_dir):
@@ -63,10 +63,14 @@ def _find_pylintrc_same_locale(curr_dir):
     return found_pylintrc_location
 
 
-def _load_pylint_plugins(current_reporter, local_config, pep8):
+def _load_pylint_plugins(linter, local_config):
     """Register checker plugins for pylint. Return linter."""
-    linter = pylint.lint.PyLinter(reporter=current_reporter)
     linter.load_default_plugins()
+
+    # Register custom pyta reporters, `linter._reporters`
+    for reporter in REPORTERS:
+        linter.register_reporter(reporter)
+
     linter.load_plugin_modules(['python_ta/checkers/forbidden_import_checker',
                                 'python_ta/checkers/global_variables_checker',
                                 'python_ta/checkers/dynamic_execution_checker',
@@ -76,27 +80,29 @@ def _load_pylint_plugins(current_reporter, local_config, pep8):
                                 'python_ta/checkers/assigning_to_self_checker',
                                 'python_ta/checkers/always_returning_checker',
                                 'python_ta/checkers/type_inference_checker'])
-    if pep8:
+
+    if linter.config.pep8:
         linter.load_plugin_modules(['python_ta/checkers/pycodestyle_checker'])
 
     if isinstance(local_config, str) and local_config != '':
         # Use config file at the specified path instead of the default.
-        print('### Loaded your configuration file:', local_config)
         linter.read_config_file(local_config)
+        print('### Loaded your configuration file:', local_config)
     else:
         # Use default config file shipped with the python_ta package.
         pylintrc_location = os.path.join(os.path.dirname(__file__), '.pylintrc')
-        print('### Loaded default configuration file:', pylintrc_location)
         linter.read_config_file(pylintrc_location)
+        print('### Loaded default configuration file:', pylintrc_location)
 
         # Override part of the default config, with a dict of config options.
+        # Note: these configs are overridden by config file in user 's codebase
+        # location.
         if isinstance(local_config, dict):
-            print('### Loaded configuration dictionary.')
             for key in local_config:
                 linter.global_set_option(key, local_config[key])
+            print('### Loaded configuration dictionary.')
 
     linter.load_config_file()
-    return linter
 
 
 def _apply_nearest_config(linter=None, file_abs_path=''):
@@ -112,9 +118,9 @@ def _apply_nearest_config(linter=None, file_abs_path=''):
         curr_dir = os.path.dirname(file_abs_path)
     pylintrc_location = _find_pylintrc_same_locale(curr_dir)
     if pylintrc_location is not None:
-        print('### Loaded local configuration file:', pylintrc_location)
         # Always read and load, even if done already (do not cache).
         linter.read_config_file(pylintrc_location)
+        print('### Loaded local configuration file:', pylintrc_location)
         linter.load_config_file()
 
 
@@ -127,7 +133,7 @@ def _verify_pre_check(filepath):
         # Check for inline "pylint:" comment, which may indicate a student
         # trying to disable a check.
         with tokenize.open(filepath) as f:
-            for (tok_type,content,_,_,_) in tokenize.generate_tokens(f.readline):
+            for (tok_type, content, _, _, _) in tokenize.generate_tokens(f.readline):
                 if tok_type != tokenize.COMMENT:
                     continue
                 match = pylint.utils.OPTION_RGX.search(content)
@@ -145,9 +151,7 @@ def _verify_pre_check(filepath):
         return False
     return True
 
-
-def _check(module_name='', reporter=ColorReporter, number_of_messages=5, 
-           level='all', local_config='', pep8=False):
+def _check(module_name='', level='all', local_config=''):
     """Check a module for problems, printing a report.
 
     The `module_name` can take several inputs:
@@ -174,8 +178,27 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5,
         print('No checks run. Input to check, `{}`, has invalid type, must be a list of strings.\n'.format(module_name))
         return
 
-    current_reporter = reporter(number_of_messages)
-    linter = _load_pylint_plugins(current_reporter, local_config, pep8)
+    # see 'type' in pylint/config.py `VALIDATORS` dict.
+    new_options = (
+        ('pep8',
+            {'default': False,
+             'type': 'yn',
+             'metavar': '<yn>',
+             'help': 'Use the pycodestyle checker.'}),
+        ('number-of-messages',
+            {'default': 5,
+             'type': 'int',
+             'metavar': '<number_messages>',
+             'help': 'Display a certain number of messages to the user, without overwhelming them.'}),
+    )
+    
+    # Register new options to a checker here, allowing references to options in `.pylintrc` config file.
+    # These go into: `linter._all_options`, `linter._external_opts`
+    linter = pylint.lint.PyLinter(options=new_options)
+    _load_pylint_plugins(linter, local_config)
+    # Determine the type of reporter from the config setup.
+    linter._load_reporter()
+    current_reporter = linter.reporter
     
     patch_all()  # Monkeypatch pylint
 
@@ -199,16 +222,17 @@ def _check(module_name='', reporter=ColorReporter, number_of_messages=5,
 
         for descr in expanded_files:
             modname, filepath, is_arg = descr['name'], descr['path'], descr['isarg']
-            # Use config file in user 's codebase location.
-            # Load config file, where applicable (e.g. recursively check a dir)
+            # Load config file in user location
             _apply_nearest_config(linter, os.path.abspath(filepath))
+            # The local config may have set a new reporter
+            linter._load_reporter()
+            current_reporter = linter.reporter
             current_reporter.show_file_linted(modname)
             if not _verify_pre_check(filepath):
                 continue  # Check the other files
             linter.check(filepath)  # Lint !
             current_reporter.print_messages(level)
             current_reporter.reset_messages()  # Clear lists for any next file.
-
     except Exception as e:
         print('Unexpected error encountered - please report this to david@cs.toronto.edu!')
         print('Error message: "{}"'.format(e))

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -36,17 +36,15 @@ if sys.version_info < (3, 4, 0):
     print('You need Python 3.4 or later to run this script')
 
 
-def check_errors(module_name='', reporter=ColorReporter, number_of_messages=5,
-                 config=''):
-    """Check a module for errors, printing a report.
-    """
-    _check(module_name=module_name, reporter=reporter, number_of_messages=number_of_messages, level='error', local_config=config)
+def check_errors(module_name='', reporter=ColorReporter, config=''):
+    """Check a module for errors, printing a report."""
+    _check(module_name=module_name, reporter=reporter, level='error', 
+           local_config=config)
 
 
-def check_all(module_name='', reporter=ColorReporter, number_of_messages=5,
-              config=''):
+def check_all(module_name='', reporter=ColorReporter, config=''):
     """Check a module for errors and style warnings, printing a report."""
-    _check(module_name, reporter, number_of_messages, level='all',
+    _check(module_name=module_name, reporter=reporter, level='all',
            local_config=config)
 
 

--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -33,7 +33,7 @@ class ColorReporter(PlainReporter):
 
     # Override this method to add instance variables
     def __init__(self, number_of_messages, source_lines=None, module_name=''):
-        super().__init__(number_of_messages, source_lines, module_name)
+        super().__init__(source_lines, module_name)
         self._sorted_error_messages = defaultdict(list)
         self._sorted_style_messages = defaultdict(list)
 

--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -31,8 +31,9 @@ class ColorReporter(PlainReporter):
                   'gbold': Style.BRIGHT + Fore.LIGHTBLACK_EX,
                   'reset': Style.RESET_ALL}
 
-    # Override this method to add instance variables
-    def __init__(self, number_of_messages, source_lines=None, module_name=''):
+    name = 'color'
+
+    def __init__(self, source_lines=None, module_name=''):
         super().__init__(source_lines, module_name)
         self._sorted_error_messages = defaultdict(list)
         self._sorted_style_messages = defaultdict(list)
@@ -42,7 +43,6 @@ class ColorReporter(PlainReporter):
         self._sorted_error_messages.clear()
         self._sorted_style_messages.clear()
 
-    # Override this method
     def print_messages(self, level='all'):
         # Check if the OS currently running is Windows
         init(wrap=(sys.platform == 'win32'), strip=False)
@@ -68,7 +68,6 @@ class ColorReporter(PlainReporter):
 
         print(result)
 
-    # Override this method
     def sort_messages(self):
         # Sort the messages by their type (message id)
         def sort_messages_by_type(messages, sorted_messages):

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -23,6 +23,8 @@ class HTMLReporter(ColorReporter):
                   'gbold': '<span class="gbold">',
                   'reset': '</span>'}
 
+    name = 'html'
+
     # Override this method
     def print_messages(self, level='all'):
         # Sort the messages.

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -53,11 +53,10 @@ ERROR_CHECKS = [
 
 
 class PlainReporter(BaseReporter):
-    def __init__(self, number_of_messages, source_lines=None, module_name=''):
+    def __init__(self, source_lines=None, module_name=''):
         super().__init__()
         self._error_messages = []
         self._style_messages = []
-        self._number_of_messages = number_of_messages
         self._source_lines = source_lines or []
         self._module_name = module_name
 
@@ -117,10 +116,7 @@ class PlainReporter(BaseReporter):
                 messages = []
                 while i + 1 < len(message_list) and message_list[i + 1].msg_id == current_id:
                     count += 1
-                    if self._number_of_messages == 0:
-                        messages.append('[Line {}] {}'.format(message_list[i + 1].line, message_list[i + 1].msg))
-                    elif len(messages) < self._number_of_messages - 1:
-                        messages.append('[Line {}] {}'.format(message_list[i + 1].line, message_list[i + 1].msg))
+                    messages.append('[Line {}] {}'.format(message_list[i + 1].line, message_list[i + 1].msg))
                     message_list.pop(i + 1)
 
                 msg_new = message_list[i].msg
@@ -129,9 +125,6 @@ class PlainReporter(BaseReporter):
                     msg_new = message_list[i].msg + '\n    ' + '\n    '.join(messages)
 
                 obj_new = 'Number of occurrences: {}.'.format(count)
-
-                if self._number_of_messages != 0 and self._number_of_messages < count:
-                    obj_new = obj_new + ' First {} shown.'.format(self._number_of_messages)
 
                 message_list[i] = message_list[i]._replace(msg=msg_new, obj=obj_new)
                 i += 1

--- a/python_ta/reporters/stat_reporter.py
+++ b/python_ta/reporters/stat_reporter.py
@@ -6,16 +6,17 @@ class StatReporter(PlainReporter):
     error_messages = []
     style_messages = []
 
-    def __init__(self, number_of_messages, source_lines=None):
+    name = 'stat'
+
+    def __init__(self, source_lines=None):
         """Initialize a StatReporter.
 
         Clear the two class-level message lists.
 
-        @type number_of_messages: int
         @type source_lines: List[str]
         @rtype: None
         """
-        super().__init__(number_of_messages, source_lines)
+        super().__init__(source_lines)
         StatReporter.error_messages = []
         StatReporter.style_messages = []
 


### PR DESCRIPTION
We can now define custom config options in a `.pylintrc` file by passing in a tuple of options at the constructor of our Linter (which is a type of checker). This is similar to how PyLinter.options are set.

Class variable `name` is added to reporters to for compatibility with setting the Reporter using the `output-format` config option in our pylintrc, which is how pylint does it.

Config options are available in Reporters, by making the linter (checker) an instance variable of reporters.

