### PR TITLE
Allow the Name node to pass the checker.

### DIFF
--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -55,7 +55,7 @@ def _get_child_disallowed_global_var_nodes(node):
     global, non-constant variable. 
     """
     node_list = []
-    if ((isinstance(node, astroid.AssignName) or isinstance(node, astroid.Name)) 
+    if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call))) 
         and not re.match(CONST_NAME_RGX, node.name)):
         return [node]
     for child_node in node.get_children():


### PR DESCRIPTION
The `nodes/Break.py` example was triggering the E9997 error from
the global variable checker. For instance the range() call, which
should be allowed.