### PR TITLE
Function def inference

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -5,8 +5,9 @@ from typing import *
 from typing import CallableMeta, TupleMeta, Union, _gorg, _geqv
 from astroid.transforms import TransformVisitor
 from ..typecheck.base import op_to_dunder, lookup_method, Environment, TypeConstraints, TypeInferenceError
-from ..typecheck.type_store import TYPE_STORE
+from ..typecheck.type_store import TypeStore
 TYPE_CONSTRAINTS = TypeConstraints()
+TYPE_STORE = TypeStore(TYPE_CONSTRAINTS)
 
 
 class NoType:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -215,6 +215,15 @@ class TypeConstraints:
         arg_type_lst = [self.lookup_concrete(argument) for argument in callable_function.__args__]
         return arg_type_lst[:-1], arg_type_lst[-1]
 
+    def can_unify(self, t1, t2):
+        """Return true iff given argument types can be unified."""
+        if isinstance(t1, TypeVar) or isinstance(t2, TypeVar):
+            return True
+        elif t1 != t2:
+            return False
+        else:
+            return True
+
 
 def literal_substitute(t, type_map):
     """Make substitutions in t according to type_map, returning resulting type."""

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -6,7 +6,8 @@ TYPE_SHED_PATH = os.path.join(os.path.dirname(__file__), 'typeshed', 'builtins.p
 
 
 class TypeStore:
-    def __init__(self):
+    def __init__(self, type_constraints):
+        self.type_constraints = type_constraints
         contents = ''
         with open(TYPE_SHED_PATH) as f:
             contents = '\n'.join(f.readlines())
@@ -44,9 +45,8 @@ class TypeStore:
             found = False
             func_types_list = self.functions[operator]
             for func_type in func_types_list:
+                # check if args can be unified instead of checking if they are the same!
                 if func_type.__args__[:-1] == args:
                     return func_type
             if not found:
                 raise KeyError
-
-TYPE_STORE = TypeStore()

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -46,7 +46,14 @@ class TypeStore:
             func_types_list = self.functions[operator]
             for func_type in func_types_list:
                 # check if args can be unified instead of checking if they are the same!
-                if func_type.__args__[:-1] == args:
-                    return func_type
-            if not found:
+                unified = True
+                for t1, t2 in zip(func_type.__args__[:-1], args):
+                    if not self.type_constraints.can_unify(t1, t2):
+                        unified = False
+                        break
+                if unified:
+                    rtype = self.type_constraints.unify_call(func_type, *args)
+                    if rtype == func_type.__args__[-1]:
+                        return func_type
+            if not (unified or found):
                 raise KeyError

--- a/tests/type_inference/test_function_def_inference.py
+++ b/tests/type_inference/test_function_def_inference.py
@@ -5,9 +5,7 @@ import tests.custom_hypothesis_support as cs
 import hypothesis.strategies as hs
 from typing import Callable
 from python_ta.transforms.type_inference_visitor import TYPE_CONSTRAINTS
-from keyword import iskeyword
 settings.load_profile("pyta")
-
 
 
 def _parse_to_function(function_name, args_list, return_statement):

--- a/tests/type_inference/test_function_def_inference.py
+++ b/tests/type_inference/test_function_def_inference.py
@@ -1,0 +1,61 @@
+import astroid
+import nose
+from hypothesis import assume, given, settings
+import tests.custom_hypothesis_support as cs
+import hypothesis.strategies as hs
+from typing import Callable
+from python_ta.transforms.type_inference_visitor import TYPE_CONSTRAINTS
+from keyword import iskeyword
+settings.load_profile("pyta")
+
+
+
+def _parse_to_function(function_name, args_list, return_statement):
+    """Helper to parse given data into function definition."""
+    return f'def {function_name}({", ".join(args_list)}):' \
+           f'    return {return_statement}'
+
+
+def _parse_to_function_no_return(function_name, args_list, function_body):
+    """Helper to parse given data into function definition."""
+    return f'def {function_name}({", ".join(args_list)}):\n' \
+           f'    {function_body}'
+
+
+@given(cs.valid_identifier(), hs.lists(cs.valid_identifier(), min_size=1))
+def test_inference_args_simple_return(function_name, arguments):
+    """Test whether visitor was able to infer type of argument given function called on it in function body."""
+    assume(function_name not in arguments)
+    for argument in arguments:
+        program = _parse_to_function_no_return(function_name, arguments, ('return ' + argument + " + " + repr('bob')))
+        module = cs._parse_text(program)
+        # get the functionDef node - there is only one in this test case.
+        function_def_node = next(module.nodes_of_class(astroid.FunctionDef))
+        expected_arg_type_vars = [function_def_node.type_environment.lookup_in_env(argument) for argument in arguments]
+        expected_arg_types = [TYPE_CONSTRAINTS.lookup_concrete(type_var) for type_var in expected_arg_type_vars]
+        function_type_var = module.type_environment.lookup_in_env(function_name)
+        function_type = TYPE_CONSTRAINTS.lookup_concrete(function_type_var)
+        actual_arg_types, actual_return_type = TYPE_CONSTRAINTS.types_in_callable(function_type)
+        assert expected_arg_types == actual_arg_types
+
+
+@given(cs.valid_identifier(), hs.lists(cs.valid_identifier(), min_size=1))
+def test_function_def_args_simple_return(function_name, arguments):
+    """Test whether visitor was able to infer type of function given function called on it's arguments."""
+    assume(function_name not in arguments)
+    for argument in arguments:
+        program = _parse_to_function_no_return(function_name, arguments, ('return ' + argument + " + " + repr('bob')))
+        module = cs._parse_text(program)
+        function_def_node = next(module.nodes_of_class(astroid.FunctionDef))
+        expected_arg_type_vars = [function_def_node.type_environment.lookup_in_env(argument) for argument in arguments]
+        expected_arg_types = [TYPE_CONSTRAINTS.lookup_concrete(type_var) for type_var in expected_arg_type_vars]
+        function_type_var = module.type_environment.lookup_in_env(function_name)
+        function_type = TYPE_CONSTRAINTS.lookup_concrete(function_type_var)
+        actual_arg_types, actual_return_type = TYPE_CONSTRAINTS.types_in_callable(function_type)
+        return_type_var = function_def_node.type_environment.lookup_in_env(argument)
+        expected_return_type = TYPE_CONSTRAINTS.lookup_concrete(return_type_var)
+        assert Callable[actual_arg_types, actual_return_type] == Callable[expected_arg_types, expected_return_type]
+
+
+if __name__ == '__main__':
+    nose.main()


### PR DESCRIPTION
- Refactor imports; TYPE_CONSTRAINTS singleton is passed as attribute of TYPE_STORE to prevent circular import.
- Implement helper to check whether types can be unified without mutating; update function look-up method accordingly.
- Test whether type of argument/function are being inferred correctly given functions in the function body.