### PR TITLE
Output htmlreporter recursive linting

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -278,6 +278,7 @@ def _check(module_name='', level='all', local_config='', output=None):
                 linter.check(file_py)  # Lint !
                 current_reporter.print_messages(level)
                 current_reporter.reset_messages()  # Clear lists for any next file.
+        current_reporter.build_template()
     except Exception as e:
         print('Unexpected error encountered - please report this to david@cs.toronto.edu!')
         print('Error message: "{}"'.format(e))

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -3,11 +3,14 @@ import webbrowser
 
 from jinja2 import Environment, FileSystemLoader
 from datetime import datetime
+from base64 import b64encode
 
 from .color_reporter import ColorReporter
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-
+OUTPUT_DIR = os.getcwd()
+TEMPLATE_FILE = '/templates/template.txt'
+OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
     _SPACE = '&nbsp;'
@@ -32,20 +35,27 @@ class HTMLReporter(ColorReporter):
         self._colour_messages_by_type(style=False)
         self._colour_messages_by_type(style=True)
 
-        template = Environment(loader=FileSystemLoader(THIS_DIR)).get_template('templates/template.txt')
-        output_path = THIS_DIR + '/templates/output.html'
+        template = Environment(loader=FileSystemLoader(THIS_DIR)).get_template(TEMPLATE_FILE)
+
+        print(os.getcwd())
+
+        # Embed resources so the output html can go anywhere, independent of assets.
+        with open(THIS_DIR + '/templates/pyta_logo_markdown.png', 'rb+') as image_file:
+            # Encode img binary to base64 (+33% size), decode to remove the "b'"
+            pyta_logo_base64_encoded = b64encode(image_file.read()).decode()
 
         # Date/time (24 hour time) format:
         # Generated: ShortDay. ShortMonth. PaddedDay LongYear, Hour:Min:Sec
         dt = 'Generated: ' + str(datetime.now().
                                  strftime('%a. %b. %d %Y, %H:%M:%S'))
-        with open(output_path, 'w') as f:
+        with open(OUTPUT_DIR + '/' + OUTPUT_FILE, 'w') as f:
             f.write(template.render(date_time=dt,
                                     mod_name=self._module_name,
                                     code=self._sorted_error_messages,
-                                    style=self._sorted_style_messages))
+                                    style=self._sorted_style_messages,
+                                    pyta_logo=pyta_logo_base64_encoded))
         print('Opening your report in a browser...')
-        output_url = 'file:///{}/templates/output.html'.format(THIS_DIR)
+        output_url = 'file:///{}{}'.format(OUTPUT_DIR, '/' + OUTPUT_FILE)
         webbrowser.open(output_url)
 
     _display = None

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -66,6 +66,7 @@ class HTMLReporter(ColorReporter):
                                     pyta_logo=pyta_logo_base64_encoded,
                                     code_err_title=self.code_err_title,
                                     style_err_title=self.style_err_title,
+                                    no_err_message=self.no_err_message,
                                     messages_by_file=self.messages_by_file))
         print('Opening your report in a browser...')
         output_url = 'file:///{}'.format(output_path)

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -7,9 +7,8 @@ from base64 import b64encode
 
 from .color_reporter import ColorReporter
 
-THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-TEMPLATES_DIR = os.path.join(THIS_DIR, 'templates')
-TEMPLATE_FILE = os.path.join('templates', 'template.txt')
+TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
+TEMPLATE_FILE = 'template.txt'
 OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
@@ -35,7 +34,7 @@ class HTMLReporter(ColorReporter):
         self._colour_messages_by_type(style=False)
         self._colour_messages_by_type(style=True)
 
-        template = Environment(loader=FileSystemLoader(THIS_DIR)).get_template(TEMPLATE_FILE)
+        template = Environment(loader=FileSystemLoader(TEMPLATES_DIR)).get_template(TEMPLATE_FILE)
 
         # Embed resources so the output html can go anywhere, independent of assets.
         with open(os.path.join(TEMPLATES_DIR, 'pyta_logo_markdown.png'), 'rb+') as image_file:

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -8,8 +8,8 @@ from base64 import b64encode
 from .color_reporter import ColorReporter
 
 THIS_DIR = os.path.dirname(os.path.abspath(__file__))
-OUTPUT_DIR = os.getcwd()
-TEMPLATE_FILE = '/templates/template.txt'
+TEMPLATES_DIR = os.path.join(THIS_DIR, 'templates')
+TEMPLATE_FILE = os.path.join('templates', 'template.txt')
 OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
@@ -37,10 +37,8 @@ class HTMLReporter(ColorReporter):
 
         template = Environment(loader=FileSystemLoader(THIS_DIR)).get_template(TEMPLATE_FILE)
 
-        print(os.getcwd())
-
         # Embed resources so the output html can go anywhere, independent of assets.
-        with open(THIS_DIR + '/templates/pyta_logo_markdown.png', 'rb+') as image_file:
+        with open(os.path.join(TEMPLATES_DIR, 'pyta_logo_markdown.png'), 'rb+') as image_file:
             # Encode img binary to base64 (+33% size), decode to remove the "b'"
             pyta_logo_base64_encoded = b64encode(image_file.read()).decode()
 
@@ -48,14 +46,15 @@ class HTMLReporter(ColorReporter):
         # Generated: ShortDay. ShortMonth. PaddedDay LongYear, Hour:Min:Sec
         dt = 'Generated: ' + str(datetime.now().
                                  strftime('%a. %b. %d %Y, %H:%M:%S'))
-        with open(OUTPUT_DIR + '/' + OUTPUT_FILE, 'w') as f:
+        output_path = os.path.join(os.getcwd(), OUTPUT_FILE)
+        with open(output_path, 'w') as f:
             f.write(template.render(date_time=dt,
                                     mod_name=self._module_name,
                                     code=self._sorted_error_messages,
                                     style=self._sorted_style_messages,
                                     pyta_logo=pyta_logo_base64_encoded))
         print('Opening your report in a browser...')
-        output_url = 'file:///{}{}'.format(OUTPUT_DIR, '/' + OUTPUT_FILE)
+        output_url = 'file:///{}'.format(output_path)
         webbrowser.open(output_url)
 
     _display = None

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -1,5 +1,6 @@
 import os
 import webbrowser
+from collections import namedtuple
 
 from jinja2 import Environment, FileSystemLoader
 from datetime import datetime
@@ -25,6 +26,10 @@ class HTMLReporter(ColorReporter):
                   'gbold': '<span class="gbold">',
                   'reset': '</span>'}
 
+    def __init__(self, source_lines=None, module_name=''):
+        super().__init__(source_lines, module_name)
+        self.messages_by_file = []
+
     # Override this method
     def print_messages(self, level='all'):
         # Sort the messages.
@@ -34,6 +39,15 @@ class HTMLReporter(ColorReporter):
         self._colour_messages_by_type(style=False)
         self._colour_messages_by_type(style=True)
 
+        MessageSet = namedtuple('MessageSet', 'filename code style')
+        append_set = MessageSet(filename=self.filename_to_display(self.current_file_linted),
+                               code=dict(self._sorted_error_messages), 
+                               style=dict(self._sorted_style_messages))
+        self.messages_by_file.append(append_set)
+
+    def build_template(self):
+        """Output to the template after all messages."""
+        
         template = Environment(loader=FileSystemLoader(TEMPLATES_DIR)).get_template(TEMPLATE_FILE)
 
         # Embed resources so the output html can go anywhere, independent of assets.
@@ -49,9 +63,10 @@ class HTMLReporter(ColorReporter):
         with open(output_path, 'w') as f:
             f.write(template.render(date_time=dt,
                                     mod_name=self._module_name,
-                                    code=self._sorted_error_messages,
-                                    style=self._sorted_style_messages,
-                                    pyta_logo=pyta_logo_base64_encoded))
+                                    pyta_logo=pyta_logo_base64_encoded,
+                                    code_err_title=self.code_err_title,
+                                    style_err_title=self.style_err_title,
+                                    messages_by_file=self.messages_by_file))
         print('Opening your report in a browser...')
         output_url = 'file:///{}'.format(output_path)
         webbrowser.open(output_url)

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -72,6 +72,7 @@ class PlainReporter(BaseReporter):
     _COLOURING = {}
     code_err_title = '=== Code errors/forbidden usage (fix: high priority) ==='
     style_err_title = '=== Style/convention errors (fix: before submission) ==='
+    no_err_message = 'None!' + _BREAK*2
 
     def __init__(self, source_lines=None, module_name=''):
         """Reminder: see pylint BaseReporter for other instance variables init.
@@ -160,7 +161,7 @@ class PlainReporter(BaseReporter):
         if messages_result:
             result += messages_result
         else:
-            result += 'None!' + self._BREAK*2
+            result += self.no_err_message
 
         if level == 'all':
             result += self._colourify('style-heading', self.style_err_title + self._BREAK)
@@ -168,7 +169,7 @@ class PlainReporter(BaseReporter):
             if messages_result:
                 result += messages_result
             else:
-                result += 'None!' + self._BREAK*2
+                result += self.no_err_message
 
         output_stream = sys.stdout
         if self._output_filepath:

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -70,6 +70,8 @@ class PlainReporter(BaseReporter):
     _SPACE = ' '
     _BREAK = '\n'
     _COLOURING = {}
+    code_err_title = '=== Code errors/forbidden usage (fix: high priority) ==='
+    style_err_title = '=== Style/convention errors (fix: before submission) ==='
 
     def __init__(self, source_lines=None, module_name=''):
         """Reminder: see pylint BaseReporter for other instance variables init.
@@ -153,9 +155,7 @@ class PlainReporter(BaseReporter):
     def print_messages(self, level='all'):
         self.sort_messages()
 
-        result = self._colourify('code-heading',
-                                 '=== Code errors/forbidden usage '
-                                 '(fix: high priority) ===' + self._BREAK)
+        result = self._colourify('code-heading', self.code_err_title + self._BREAK)
         messages_result = self._colour_messages_by_type(style=False)
         if messages_result:
             result += messages_result
@@ -163,9 +163,7 @@ class PlainReporter(BaseReporter):
             result += 'None!' + self._BREAK*2
 
         if level == 'all':
-            result += self._colourify('style-heading',
-                                      '=== Style/convention errors '
-                                      '(fix: before submission) ===' + self._BREAK)
+            result += self._colourify('style-heading', self.style_err_title + self._BREAK)
             messages_result = self._colour_messages_by_type(style=True)
             if messages_result:
                 result += messages_result
@@ -306,3 +304,7 @@ class PlainReporter(BaseReporter):
         return text
 
     _display = None
+
+    def build_template(self):
+        """Override in html_reporter."""
+        pass

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -1,6 +1,8 @@
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="stylesheet.css">
+    <style type="text/css">
+        {% include "templates/stylesheet.css" %}
+    </style>
 </head>
 <body>
 
@@ -83,7 +85,7 @@
 </body>
 <div id="logo">
 		<a href="http://www.cs.toronto.edu/~david/pyta/" target="_blank">
-			<img src="pyta_logo_markdown.png" alt="PyTA logo" height="50"/>
+            <img src="data:image/png;base64,{{ pyta_logo }}" alt="PyTA logo" height="50"/>
 		</a>
 	</p>
 </div>

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -1,7 +1,7 @@
 <html>
 <head>
     <style type="text/css">
-        {% include "templates/stylesheet.css" %}
+        {% include "stylesheet.css" %}
     </style>
 </head>
 <body>

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -51,6 +51,8 @@
 						{% endif %}
 						</div>
 					{% endfor %}
+                {% else %}
+                    {{ no_err_message }}
 				{% endfor %}
 			</u1>
 
@@ -76,7 +78,9 @@
 						{% endif %}
 						</div>
 					{% endfor %}
-				{% endfor %}
+                {% else %}
+                    {{ no_err_message }}
+                {% endfor %}
 			</u1>
 
 		</div>

--- a/python_ta/reporters/templates/template.txt
+++ b/python_ta/reporters/templates/template.txt
@@ -6,14 +6,14 @@
 </head>
 <body>
 
-		<div id="preheader">
-			<div id="module">
-				Module analysed: {{ mod_name }}
-			</div>
-			<span id="date">
-				{{ date_time }}
-			</span>
+	<div id="preheader">
+		<div id="module">
+			Module analysed: {{ mod_name }}
 		</div>
+		<span id="date">
+			{{ date_time }}
+		</span>
+	</div>
 
 	<div id="header">
 		<div class="title">
@@ -24,22 +24,26 @@
 	<br/>
 
 	<div id="inside">
+
+        {% for file in messages_by_file %}
+
 		<div id="core">
 
+            <h3> {{ file.filename }} </h3>
 			<div id="code">
-				=== Code errors/forbidden usage (fix these right away!) ===
+				{{ code_err_title }}
 			</div>
 			<u1>
-				{% for message in code %}
-					<p/>
+				{% for message in file.code %}
 					<p style="font-size: 110%">
 						<span class="code_id">
-						<a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">{{ message }} ({{ code[message][0].symbol }})</a> </span>
-						&nbsp;&nbsp;Number of occurrences: {{ code[message]|length }}
+						    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">{{ message }} ({{ file.code[message][0].symbol }})</a> 
+                        </span>
+						&nbsp;&nbsp;Number of occurrences: {{ file.code[message]|length }}
 					</p>
-					{% for indiv in code[message] %}
+					{% for indiv in file.code[message] %}
 						<div style="font-weight:bold">
-						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
+						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }}
 						{% if indiv.snippet != '' %}
 							<p class="snippet">
 								{{ indiv.snippet }}
@@ -51,20 +55,20 @@
 			</u1>
 
 			<div id="style">
-			=== Style/convention errors (fix these before submission) ===
+			    {{ style_err_title }}
 			</div>
 
 			<u1>
-				{% for message in style %}
-					<p/>
+				{% for message in file.style %}
 					<p style="font-size: 110%">
 						<span class="style_id">
-						<a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">{{ message }} ({{ style[message][0].symbol }})</a> </span>
-						&nbsp;&nbsp;Number of occurrences: {{ style[message]|length }}
+						    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">{{ message }} ({{ file.style[message][0].symbol }})</a> 
+                        </span>
+						&nbsp;&nbsp;Number of occurrences: {{ file.style[message]|length }}
 					</p>
-					{% for indiv in style[message] %}
+					{% for indiv in file.style[message] %}
 						<div style="font-weight:bold">
-						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }} <p/>
+						&nbsp;&nbsp;[Line {{ indiv.line }}] {{ indiv.msg }}
 						{% if indiv.snippet != '' %}
 							<p class="snippet">
 								{{ indiv.snippet }}
@@ -76,6 +80,9 @@
 			</u1>
 
 		</div>
+
+        {% endfor %}
+
 		<a href="mailto:david@cs.toronto.edu">
 			<div id="report_bug">
 				Found a bug? Report it to Prof. Liu!


### PR DESCRIPTION
• Output the html file in current working directory.
• Display all files' messages in htmlreporter, when linting done on a directory. Previously multiple files unsupported by htmlreporter.