### PR TITLE
Create snippets for messages C0326, C0301, and fix R1705.

### DIFF
--- a/python_ta/patches/messages.py
+++ b/python_ta/patches/messages.py
@@ -13,7 +13,7 @@ def patch_messages():
                         confidence=UNDEFINED):
         old_add_message(self, msg_descr, line, node, args, confidence)
         msg_info = self.msgs_store.check_message_id(msg_descr)
-        self.reporter.handle_node(msg_info, node)
+        self.reporter.handle_node(msg_info, node, args)
 
     MessagesHandlerMixIn.add_message = new_add_message
 

--- a/python_ta/patches/messages.py
+++ b/python_ta/patches/messages.py
@@ -13,7 +13,10 @@ def patch_messages():
                         confidence=UNDEFINED):
         old_add_message(self, msg_descr, line, node, args, confidence)
         msg_info = self.msgs_store.check_message_id(msg_descr)
-        self.reporter.handle_node(msg_info, node, args)
+        msg_formatted = msg_info.msg
+        if args:
+            msg_formatted %= args  # populate format string, with tuple of str
+        self.reporter.handle_node(msg_info, node, msg_formatted.partition('\n')[0])
 
     MessagesHandlerMixIn.add_message = new_add_message
 

--- a/python_ta/patches/messages.py
+++ b/python_ta/patches/messages.py
@@ -13,10 +13,7 @@ def patch_messages():
                         confidence=UNDEFINED):
         old_add_message(self, msg_descr, line, node, args, confidence)
         msg_info = self.msgs_store.check_message_id(msg_descr)
-        msg_formatted = msg_info.msg
-        if args:
-            msg_formatted %= args  # populate format string, with tuple of str
-        self.reporter.handle_node(msg_info, node, msg_formatted.partition('\n')[0])
+        self.reporter.handle_node(msg_info, node)
 
     MessagesHandlerMixIn.add_message = new_add_message
 

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -23,7 +23,7 @@ def render_generic(msg, source_lines=None):
             yield (start_line, slice(start_col, end_col), LineType.ERROR, source_lines[start_line-1])
         else:
             yield (start_line, slice(start_col, None), LineType.ERROR, source_lines[start_line-1])
-            yield from ((line, slice(None, None), LineType.ERROR, source_lines[line-1]) for line in range(start_line, start_col))
+            yield from ((line, slice(None, None), LineType.ERROR, source_lines[line-1]) for line in range(start_line+1, end_line))
             yield (end_line, slice(None, end_col), LineType.ERROR, source_lines[end_line-1])
 
         # Display up to 2 lines after node for context:

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -11,7 +11,7 @@ def render_message(msg, source_lines):
 
 def render_generic(msg, source_lines=None):
     """Default rendering for a message."""
-    if hasattr(msg, 'node'):
+    if hasattr(msg, 'node') and msg.node is not None:
         node = msg.node
         start_line, start_col = node.fromlineno, node.col_offset
         end_line, end_col = node.end_lineno, node.end_col_offset
@@ -32,7 +32,7 @@ def render_generic(msg, source_lines=None):
     else:
         line = msg.line
         yield from render_context(line - 2, line, source_lines)
-        yield (line, slice(None, None), LineType.ERROR)
+        yield (line, slice(None, None), LineType.ERROR, source_lines[line - 1])
         yield from render_context(line + 1, line + 3, source_lines)
 
 
@@ -65,7 +65,7 @@ def render_trailing_newlines(msg, source_lines=None):
 
 def render_context(start, stop, source_lines):
     """Helper for rendering context lines."""
-    start, stop = max(start, 0), min(stop, len(source_lines))
+    start, stop = max(start, 1), min(stop, len(source_lines))
     yield from ((line, slice(None, None), LineType.CONTEXT, source_lines[line-1])
                 for line in range(start, stop))
 

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -73,17 +73,15 @@ def render_context(start, stop, source_lines):
 def render_bad_whitespace(msg, source_lines=None):
     """Extract column information from caret position within message string"""
     start, stop = None, None
-    for line in msg.args[-1].split('\n'):
-        if '^' in line:
-            start = line.index('^')
-            stop = start + 1
-            break
+    last_line = msg.msg.split('\n')[-1]
+    if '^' in last_line:
+        start = last_line.index('^')
+        stop = start + 1
 
     line = msg.line
     yield from render_context(line - 2, line, source_lines)
     yield (line, slice(start, stop), LineType.ERROR, source_lines[line - 1])
     yield from render_context(line + 1, line + 3, source_lines)
-
 
 
 CUSTOM_MESSAGES = {

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -70,9 +70,26 @@ def render_context(start, stop, source_lines):
                 for line in range(start, stop))
 
 
+def render_bad_whitespace(msg, source_lines=None):
+    """Extract column information from caret position within message string"""
+    start, stop = None, None
+    for line in msg.args[-1].split('\n'):
+        if '^' in line:
+            start = line.index('^')
+            stop = start + 1
+            break
+
+    line = msg.line
+    yield from render_context(line - 2, line, source_lines)
+    yield (line, slice(start, stop), LineType.ERROR, source_lines[line - 1])
+    yield from render_context(line + 1, line + 3, source_lines)
+
+
+
 CUSTOM_MESSAGES = {
     'missing-docstring': render_missing_docstring,
-    'trailing-newlines': render_trailing_newlines
+    'trailing-newlines': render_trailing_newlines,
+    'bad-whitespace': render_bad_whitespace,
 }
 
 

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -6,7 +6,7 @@ from collections import defaultdict, namedtuple
 from .node_printers import LineType, render_message
 
 OUTPUT_FILENAME = 'pyta_output'
-NewMessage = namedtuple('NewMessage', Message._fields + ('node', 'snippet', 'msg_truncated'))
+NewMessage = namedtuple('NewMessage', Message._fields + ('node', 'snippet'))
 
 # Checks to enable for basic_check (trying to find errors
 # and forbidden constructs only)
@@ -101,18 +101,18 @@ class PlainReporter(BaseReporter):
         else:
             self._style_messages.append(msg)
 
-    def handle_node(self, msg, node, msg_truncated):
+    def handle_node(self, msg, node):
         """Add node attribute to last message."""
         if msg.msgid in ERROR_CHECKS or msg.symbol in ERROR_CHECKS:
             if (self._error_messages and
                     self._error_messages[-1].msg_id == msg.msgid and
                     not isinstance(self._error_messages[-1], NewMessage)):
-                self._error_messages[-1] = NewMessage(*self._error_messages[-1], node, '', msg_truncated)
+                self._error_messages[-1] = NewMessage(*self._error_messages[-1], node, '')
         else:
             if (self._style_messages and
                     self._style_messages[-1].msg_id == msg.msgid and
                     not isinstance(self._style_messages[-1], NewMessage)):
-                self._style_messages[-1] = NewMessage(*self._style_messages[-1], node, '', msg_truncated)
+                self._style_messages[-1] = NewMessage(*self._style_messages[-1], node, '')
 
     def sort_messages(self):
         """Sort the messages by their type (message id)."""
@@ -208,9 +208,11 @@ class PlainReporter(BaseReporter):
                 if i == max_messages:
                     break
 
+                # Use only explanation, without redundant accessory information
+                msg_truncated = msg.msg.split('\n')[0]
                 result += 2 * self._SPACE
                 result += self._colourify('bold', '[Line {}] {}'
-                            .format(msg.line, msg.msg_truncated)) + self._BREAK
+                            .format(msg.line, msg_truncated)) + self._BREAK
 
                 try:
                     # Messages with code snippets

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -98,7 +98,7 @@ class PlainReporter(BaseReporter):
         else:
             self._style_messages.append(msg)
 
-    def handle_node(self, msg, node):
+    def handle_node(self, msg, node, args):
         """Add node attribute to last message."""
         if msg.msgid in ERROR_CHECKS or msg.symbol in ERROR_CHECKS:
             if (self._error_messages and


### PR DESCRIPTION
• Add snippets to messages for C0326 bad-whitespace, C0301 line-too-long. Add `msg_truncated` attribute to namedtuple object. Print message from the `msg.msg_truncated` property now.

• Fix off by one error on line 68, that would wrap around to the last [-1] line and display it as line 0.

• R1705 `no-else-return` was missing some lines, and double counting others. This fix makes the snippet great again.

• Also fixes C0330 to remove redundant ` }\n| |^` from message output.