### PR TITLE
Remove redundant `     }\n|   |^` from message output.

### DIFF
--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -213,6 +213,10 @@ class PlainReporter(BaseReporter):
                     msg_text = msg_text.partition('\n')[0]
                     messages[msg_id][i] = msg._replace(msg=msg_text)
                     msg = messages[msg_id][i]
+                if msg.symbol == 'bad-continuation':  # fix Pylint inconsistency
+                    msg_text = msg_text.partition('\n')[0]
+                    messages[msg_id][i] = msg._replace(msg=msg_text)
+                    msg = messages[msg_id][i]
 
                 result += 2 * self._SPACE
                 result += self._colourify('bold', '[Line {}] {}'


### PR DESCRIPTION
Example,
```
C0330 (bad-continuation)  Number of occurrences: 1.
  [Line 9] Wrong hanging indentation.
     }
|   |^
    7      'b': 1,
    8      'c': 2
    9       }
```

is now simply,
```
C0330 (bad-continuation)  Number of occurrences: 1.
  [Line 9] Wrong hanging indentation.
    7      'b': 1,
    8      'c': 2
    9       }
```

with the close brace still highlighted by color reporter (not shown).