### PR TITLE
Dev test slice

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -90,10 +90,7 @@ def set_slice_type_constraints(node):
 def set_expr_type_constraints(node):
     """Expr nodes take the value of their child
     """
-    if hasattr(node.value, 'slice'):
-        node.type_constraints = node.value.value.type_constraints
-    else:
-        node.type_constraints = node.value.type_constraints
+    node.type_constraints = node.value.type_constraints
 
 
 def set_name_type_constraints(node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -83,6 +83,13 @@ def set_index_type_constraints(node):
     node.type_constraints = node.value.type_constraints
 
 
+def set_slice_type_constraints(node):
+    if node.lower:
+        node.type_constraints = node.lower.type_constraints
+    if node.upper:
+        node.type_constraints = node.upper.type_constraints
+
+
 def set_expr_type_constraints(node):
     """Expr nodes take the value of their child
     """
@@ -250,6 +257,8 @@ def register_type_constraints_setter():
                                     set_unaryop_type_constraints)
     type_visitor.register_transform(astroid.Index,
                                     set_index_type_constraints)
+    type_visitor.register_transform(astroid.Slice,
+                                    set_slice_type_constraints)
     type_visitor.register_transform(astroid.Subscript,
                                     set_subscript_type_constraints)
     type_visitor.register_transform(astroid.Compare,

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -84,16 +84,17 @@ def set_index_type_constraints(node):
 
 
 def set_slice_type_constraints(node):
-    if node.lower:
-        node.type_constraints = node.lower.type_constraints
-    if node.upper:
-        node.type_constraints = node.upper.type_constraints
+    if node.lower or node.upper:
+        node.type_constraints = slice
 
 
 def set_expr_type_constraints(node):
     """Expr nodes take the value of their child
     """
-    node.type_constraints = node.value.type_constraints
+    if hasattr(node.value, 'slice'):
+        node.type_constraints = node.value.value.type_constraints
+    else:
+        node.type_constraints = node.value.type_constraints
 
 
 def set_name_type_constraints(node):
@@ -138,7 +139,10 @@ def set_subscript_type_constraints(node):
     if hasattr(node.value, 'type_constraints') and hasattr(node.slice, 'type_constraints'):
         value_type = node.value.type_constraints.type
         value_type = TYPE_CONSTRAINTS.lookup_concrete(value_type)
-        arg_type = node.slice.type_constraints.type
+        try:
+            arg_type = node.slice.type_constraints.type
+        except AttributeError:
+            arg_type = node.slice.type_constraints
         op_name = '__getitem__'
 
         try:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -84,8 +84,7 @@ def set_index_type_constraints(node):
 
 
 def set_slice_type_constraints(node):
-    if node.lower or node.upper:
-        node.type_constraints = slice
+    node.type_constraints = TypeInfo(slice)
 
 
 def set_expr_type_constraints(node):
@@ -139,10 +138,7 @@ def set_subscript_type_constraints(node):
     if hasattr(node.value, 'type_constraints') and hasattr(node.slice, 'type_constraints'):
         value_type = node.value.type_constraints.type
         value_type = TYPE_CONSTRAINTS.lookup_concrete(value_type)
-        try:
-            arg_type = node.slice.type_constraints.type
-        except AttributeError:
-            arg_type = node.slice.type_constraints
+        arg_type = node.slice.type_constraints.type
         op_name = '__getitem__'
 
         try:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -190,7 +190,7 @@ class TypeConstraints:
         if isinstance(t, TypeVar):
             return self.lookup_concrete(t)
         if isinstance(t, GenericMeta) and t.__args__ is not None:
-            return _gorg(t)[self._type_eval(t.__args__[-1])]
+            return _gorg(t)[tuple(self._type_eval(argument) for argument in t.__args__)]
         else:
             return t
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -189,6 +189,9 @@ class TypeConstraints:
             return t.eval_type(self)
         if isinstance(t, TypeVar):
             return self.lookup_concrete(t)
+        if isinstance(t, GenericMeta) and hasattr(t, '__args__'):
+            return List[self._type_eval(t.__args__[-1])]
+            # TODO: Need to account for other generics? ie. Dictionaries, Tuples
         else:
             return t
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -189,9 +189,8 @@ class TypeConstraints:
             return t.eval_type(self)
         if isinstance(t, TypeVar):
             return self.lookup_concrete(t)
-        if isinstance(t, GenericMeta) and hasattr(t, '__args__'):
-            return List[self._type_eval(t.__args__[-1])]
-            # TODO: Need to account for other generics? ie. Dictionaries, Tuples
+        if isinstance(t, GenericMeta) and t.__args__ is not None:
+            return _gorg(t)[self._type_eval(t.__args__[-1])]
         else:
             return t
 

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -54,7 +54,8 @@ def random_slice_indices():
     """Return a strategy that generates indices of a slice."""
     index1 = hs.sampled_from([hs.integers(), hs.none()]).example()
     index2 = hs.sampled_from([hs.integers(), hs.none()]).example()
-    return hs.tuples(index1, index2)
+    index3 = hs.sampled_from([hs.integers(), hs.none()]).example()
+    return hs.tuples(index1, index2, index3)
 
 
 def homogeneous_list(**kwargs):

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -50,6 +50,13 @@ def tuple_strategy(**kwargs):
     return hs.lists(primitive_values, **kwargs).map(tuple)
 
 
+def random_slice_indices():
+    """Return a strategy that generates indices of a slice."""
+    index1 = hs.sampled_from([hs.integers(), hs.none()]).example()
+    index2 = hs.sampled_from([hs.integers(), hs.none()]).example()
+    return hs.tuples(index1, index2)
+
+
 def homogeneous_list(**kwargs):
     """Return a strategy which generates a list of uniform type."""
     return primitive_types.flatmap(lambda s: hs.lists(s(), **kwargs))

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -6,6 +6,7 @@ from python_ta.transforms.type_inference_visitor import register_type_constraint
 from keyword import iskeyword
 from python_ta.transforms.type_inference_visitor import TYPE_CONSTRAINTS
 from hypothesis import settings
+from typing import Any
 settings.register_profile("pyta", settings(max_examples=10))
 
 # Custom strategies for hypothesis testing framework

--- a/tests/type_inference/test_subscript.py
+++ b/tests/type_inference/test_subscript.py
@@ -13,10 +13,10 @@ def test_subscript_homogeneous_list_slice(input_list, slice):
     program = f'{input_list}[{input_slice}]'
     module = cs._parse_text(program)
     subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
+    assert subscript_node.type_constraints.type == List[type(input_list[0])]
 
 
-@given(cs.random_list(min_size=1), cs.random_slice_indices())
+@given(cs.random_list(min_size=2), cs.random_slice_indices())
 def test_subscript_heterogeneous_list_slice(input_list, slice):
     """Test visitor of Subscript node representing slicing of heterogeneous list."""
     assume(not isinstance(input_list[0], type(input_list[1])))
@@ -24,7 +24,7 @@ def test_subscript_heterogeneous_list_slice(input_list, slice):
     program = f'{input_list}[{input_slice}]'
     module = cs._parse_text(program)
     subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
+    assert subscript_node.type_constraints.type == List[Any]
 
 
 if __name__ == '__main__':

--- a/tests/type_inference/test_subscript.py
+++ b/tests/type_inference/test_subscript.py
@@ -1,6 +1,7 @@
 import astroid
 import nose
-from hypothesis import given, settings
+from hypothesis import given, settings, assume
+from typing import Any, List
 import tests.custom_hypothesis_support as cs
 import hypothesis.strategies as hs
 settings.load_profile("pyta")
@@ -22,6 +23,114 @@ def test_inference_dict_subscript(input_dict):
         module = cs._parse_text(program)
         subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
         assert subscript_node.type_constraints.type == type(input_dict[index])
+
+
+@given(cs.random_list(min_size=1), hs.integers())
+def test_subscript_lower_slice_random(input_list, index):
+    """Test type constraint of Subscript node representing a lower-slice of random list."""
+    assume(len(input_list) > index)
+    program = f'{input_list}[:{index}]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
+
+
+@given(cs.homogeneous_list(min_size=1), hs.integers())
+def test_subscript_lower_slice_homogeneous(input_list, index):
+    """Test type constraint of Subscript node representing a lower-slice of homogeneous list."""
+    assume(len(input_list) > index)
+    program = f'{input_list}[:{index}]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == List[type(input_list[0])]
+
+
+@given(cs.random_list(min_size=1), hs.integers(), hs.integers())
+def test_subscript_full_slice_random(input_list, index1, index2):
+    """Test type constraint of Subscript node representing a full-slice of random list."""
+    assume(len(input_list) > index2 > index1)
+    program = f'{input_list}[{index1}:{index2}]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    a = subscript_node.type_constraints.type
+    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
+
+
+@given(cs.homogeneous_list(min_size=1), hs.integers(), hs.integers())
+def test_subscript_full_slice_homogeneous(input_list, index1, index2):
+    """Test type constraint of Subscript node representing a full-slice of homogeneous list."""
+    assume(len(input_list) > index2 > index1)
+    program = f'{input_list}[{index1}:{index2}]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == List[type(input_list[0])]
+
+
+@given(cs.random_list(min_size=1), hs.integers())
+def test_subscript_upper_slice_random(input_list, index):
+    """Test type constraint of Subscript node representing a upper-slice of random list."""
+    assume(len(input_list) > index)
+    program = f'{input_list}[{index}:]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
+
+
+@given(cs.homogeneous_list(min_size=1), hs.integers())
+def test_subscript_upper_slice_homogeneous(input_list, index):
+    """Test type constraint of Subscript node representing a upper-slice of homogeneous list."""
+    assume(len(input_list) > index)
+    program = f'{input_list}[{index}:]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == List[type(input_list[0])]
+
+
+
+@given(cs.binary_bool_operator, hs.lists(cs.primitive_values, min_size=2))
+def test_homogeneous_binary_boolop(op, operand_list):
+    """Test type setting of binary BoolOp node(s) representing expression with same binary boolean operations."""
+    # get every permutation?
+    assume(len(operand_list) > 0)
+    pre_format_program = [repr(operand) for operand in operand_list]
+    program = (' ' + op + ' ').join(pre_format_program)
+    module = cs._parse_text(program)
+    boolop_node = list(module.nodes_of_class(astroid.BoolOp))[0]
+    operand_type = type(operand_list[0])
+    homogeneous = True
+    for operand in operand_list:
+        if type(operand) != operand_type:
+            homogeneous = False
+            break
+    if not homogeneous:
+        expected_type = Any
+    else:
+        expected_type = operand_type
+    assert boolop_node.type_constraints.type == expected_type
+
+
+@given(hs.lists(cs.binary_bool_operator), hs.lists(cs.primitive_values))
+def test_heterogeneous_binary_boolop(op_list, operand_list):
+    """Test type setting of binary BoolOp node(s) representing expression with different binary boolean operations."""
+    assume(len(op_list) > 0 and len(operand_list) == len(op_list) + 1)
+    pre_format_program = [str(pair) if pair != '' else repr(pair) for operand_op_pair in zip(operand_list[:-1], op_list)
+                          for pair in operand_op_pair]
+    pre_format_program.append(repr(operand_list[-1]))
+    program = ' '.join(pre_format_program)
+    module = cs._parse_text(program)
+    boolop_node = list(module.nodes_of_class(astroid.BoolOp))[0]
+    operand_type = type(operand_list[0])
+    homogeneous = True
+    for operand in operand_list:
+        if type(operand) != operand_type:
+            homogeneous = False
+            break
+    if not homogeneous:
+        expected_type = Any
+    else:
+        expected_type = operand_type
+    assert boolop_node.type_constraints.type == expected_type
+
 
 
 if __name__ == '__main__':

--- a/tests/type_inference/test_subscript.py
+++ b/tests/type_inference/test_subscript.py
@@ -3,7 +3,26 @@ import nose
 from hypothesis import given, settings, assume
 from typing import Any, List
 import tests.custom_hypothesis_support as cs
+import hypothesis.strategies as hs
 settings.load_profile("pyta")
+
+
+@given(cs.homogeneous_list(min_size=1), hs.integers())
+def test_inference_list_subscript(input_list, index):
+    """Test whether visitor properly set the type constraint of Subscript node representing list-index access."""
+    program = f'{input_list}[{index}]'
+    module = cs._parse_text(program)
+    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+    assert subscript_node.type_constraints.type == type(input_list[0])
+
+
+@given(cs.random_dict_variable_value(min_size=1))
+def test_inference_dict_subscript(input_dict):
+    for index in input_dict:
+        program = f'{input_dict}[{index}]'
+        module = cs._parse_text(program)
+        subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
+        assert subscript_node.type_constraints.type == type(input_dict[index])
 
 
 @given(cs.homogeneous_list(min_size=1), cs.random_slice_indices())

--- a/tests/type_inference/test_subscript.py
+++ b/tests/type_inference/test_subscript.py
@@ -3,7 +3,6 @@ import nose
 from hypothesis import given, settings, assume
 from typing import Any, List
 import tests.custom_hypothesis_support as cs
-import hypothesis.strategies as hs
 settings.load_profile("pyta")
 
 
@@ -20,90 +19,12 @@ def test_subscript_homogeneous_list_slice(input_list, slice):
 @given(cs.random_list(min_size=1), cs.random_slice_indices())
 def test_subscript_heterogeneous_list_slice(input_list, slice):
     """Test visitor of Subscript node representing slicing of heterogeneous list."""
+    assume(not isinstance(input_list[0], type(input_list[1])))
     input_slice = ':'.join([str(index) if index else '' for index in slice])
     program = f'{input_list}[{input_slice}]'
     module = cs._parse_text(program)
     subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
     assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
-
-
-@given(cs.homogeneous_list(min_size=1), hs.integers())
-def test_inference_list_subscript(input_list, index):
-    """Test whether visitor properly set the type constraint of Subscript node representing list-index access."""
-    program = f'{input_list}[{index}]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == type(input_list[0])
-
-
-@given(cs.random_dict_variable_value(min_size=1))
-def test_inference_dict_subscript(input_dict):
-    for index in input_dict:
-        program = f'{input_dict}[{index}]'
-        module = cs._parse_text(program)
-        subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-        assert subscript_node.type_constraints.type == type(input_dict[index])
-
-
-@given(cs.random_list(min_size=1), hs.integers())
-def test_subscript_lower_slice_random(input_list, index):
-    """Test type constraint of Subscript node representing a lower-slice of random list."""
-    assume(len(input_list) > index)
-    program = f'{input_list}[:{index}]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
-
-
-@given(cs.homogeneous_list(min_size=1), hs.integers())
-def test_subscript_lower_slice_homogeneous(input_list, index):
-    """Test type constraint of Subscript node representing a lower-slice of homogeneous list."""
-    assume(len(input_list) > index)
-    program = f'{input_list}[:{index}]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[type(input_list[0])]
-
-
-@given(cs.random_list(min_size=1), hs.integers(), hs.integers())
-def test_subscript_full_slice_random(input_list, index1, index2):
-    """Test type constraint of Subscript node representing a full-slice of random list."""
-    assume(len(input_list) > index2 > index1)
-    program = f'{input_list}[{index1}:{index2}]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    a = subscript_node.type_constraints.type
-    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
-
-
-@given(cs.homogeneous_list(min_size=1), hs.integers(), hs.integers())
-def test_subscript_full_slice_homogeneous(input_list, index1, index2):
-    """Test type constraint of Subscript node representing a full-slice of homogeneous list."""
-    assume(len(input_list) > index2 > index1)
-    program = f'{input_list}[{index1}:{index2}]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[type(input_list[0])]
-
-
-@given(cs.random_list(min_size=1), hs.integers())
-def test_subscript_upper_slice_random(input_list, index):
-    """Test type constraint of Subscript node representing a upper-slice of random list."""
-    assume(len(input_list) > index)
-    program = f'{input_list}[{index}:]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[cs._type_of_list(input_list)]
-
-
-@given(cs.homogeneous_list(min_size=1), hs.integers())
-def test_subscript_upper_slice_homogeneous(input_list, index):
-    """Test type constraint of Subscript node representing a upper-slice of homogeneous list."""
-    assume(len(input_list) > index)
-    program = f'{input_list}[{index}:]'
-    module = cs._parse_text(program)
-    subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-    assert subscript_node.type_constraints.type == List[type(input_list[0])]
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Implement visitor for Slice node.
- Register Slice node visitor
- Extend eval_type for Generics; works for all Generics using _gorg
- Add test cases for Subscript node representing List slices.
- Add helper to return strategy for generating slice indices.