### PR TITLE
Add positionreporter

### DIFF
--- a/python_ta/.pylintrc
+++ b/python_ta/.pylintrc
@@ -10,7 +10,7 @@ pyta-number-of-messages = 5
 pyta-pep8 = no
 
 # Set the output format. Available pyta formats are: ColorReporter, 
-# PlainReporter, HTMLReporter, StatReporter
+# PlainReporter, HTMLReporter, StatReporter, PositionReporter
 pyta-reporter = ColorReporter
 
 [ELIF]

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -278,7 +278,7 @@ def _check(module_name='', level='all', local_config='', output=None):
                 linter.check(file_py)  # Lint !
                 current_reporter.print_messages(level)
                 current_reporter.reset_messages()  # Clear lists for any next file.
-        current_reporter.build_template()
+        current_reporter.output_blob()
     except Exception as e:
         print('Unexpected error encountered - please report this to david@cs.toronto.edu!')
         print('Error message: "{}"'.format(e))

--- a/python_ta/reporters/__init__.py
+++ b/python_ta/reporters/__init__.py
@@ -2,6 +2,7 @@ from .color_reporter import ColorReporter
 from .html_reporter import HTMLReporter
 from .plain_reporter import PlainReporter
 from .stat_reporter import StatReporter
+from .position_reporter import PositionReporter
 
 # Export tuple of reporter classes for python_ta init file.
-REPORTERS = (ColorReporter, PlainReporter, HTMLReporter, StatReporter)
+REPORTERS = (ColorReporter, PlainReporter, HTMLReporter, StatReporter, PositionReporter)

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -45,7 +45,7 @@ class HTMLReporter(ColorReporter):
                                style=dict(self._sorted_style_messages))
         self.messages_by_file.append(append_set)
 
-    def build_template(self):
+    def output_blob(self):
         """Output to the template after all messages."""
         
         template = Environment(loader=FileSystemLoader(TEMPLATES_DIR)).get_template(TEMPLATE_FILE)

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -303,6 +303,7 @@ class PlainReporter(BaseReporter):
 
     _display = None
 
-    def build_template(self):
-        """Override in html_reporter."""
+    def output_blob(self):
+        """Override in reporters that output collections of messages once at
+        the end of linting all files, rather than stream to std.out"""
         pass

--- a/python_ta/reporters/position_reporter.py
+++ b/python_ta/reporters/position_reporter.py
@@ -1,0 +1,80 @@
+import sys
+import json
+# from colorama import Fore, Style, Back, init
+from collections import defaultdict
+from .plain_reporter import PlainReporter
+
+
+class PositionReporter(PlainReporter):
+    _SPACE = ' '
+    _BREAK = '\n'
+
+    def __init__(self, source_lines=None, module_name=''):
+        super().__init__(source_lines, module_name)
+        self._output = {   
+            'total_genre_errors': 0,
+            'total_genre_styles': 0,
+            'total_results': 0,
+            'total_skipped': 0,
+            'skipped': [],
+            'results': []
+        }
+
+    def build_result(self, sorted_messages):
+        """Build a dict of message data for errors or styles, based on a
+        particular message id.
+        """
+        data_per_message = []
+        for msg_id in sorted_messages:
+            msg_data = {
+                'occurances': [],
+                'id': msg_id,
+                'title': sorted_messages[msg_id][0].symbol,
+                'msg': sorted_messages[msg_id][0].msg.split('\n')[0],
+                'num_occurances': len(sorted_messages[msg_id])
+            }
+            for msg_instance in sorted_messages[msg_id]:
+                if msg_instance.node:
+                    msg_data['has_node'] = True
+                    msg_data['occurances'].append({
+                        'lineno': msg_instance.node.fromlineno,
+                        'end_lineno': msg_instance.node.end_lineno,
+                        'col_offset': msg_instance.node.col_offset,
+                        'end_col_offset': msg_instance.node.end_col_offset
+                    })
+                else:
+                    # TODO: use more accurate location data.
+                    # [See some message-specific policies set `start` and `stop`
+                    # locations in `node_printers.py` -- Instead, for now use
+                    # location of the line.]
+                    msg_data['has_node'] = False
+                    if len(self._source_lines) is 0:
+                        continue
+                    msg_data['occurances'].append({
+                        'lineno': msg_instance.line,
+                        'end_lineno': msg_instance.line,
+                        'col_offset': msg_instance.column,
+                        'end_col_offset': len(self._source_lines[msg_instance.line])
+                    })
+            data_per_message.append(msg_data)
+        return data_per_message
+
+    def print_messages(self, level='all'):
+        """Collect data from all messages, using one result per file."""
+        self.sort_messages()
+        result = {
+            'filename': self.current_file_linted,
+            'num_errors': len(self._sorted_error_messages),
+            'num_styles': len(self._sorted_style_messages),
+            'msg_styles': self.build_result(self._sorted_style_messages),
+            'msg_errors': self.build_result(self._sorted_error_messages)
+        }
+        # Update total counts
+        self._output['total_genre_errors'] += result['num_errors']
+        self._output['total_genre_styles'] += result['num_styles']
+        self._output['total_results'] += 1
+        self._output['results'].append(result)
+
+    def output_blob(self):
+        """Output python dict to JSON."""
+        print(json.dumps(self._output, indent=4))

--- a/python_ta/reporters/position_reporter.py
+++ b/python_ta/reporters/position_reporter.py
@@ -22,16 +22,16 @@ class PositionReporter(PlainReporter):
         data_per_message = []
         for msg_id in sorted_messages:
             msg_data = {
-                'occurances': [],
+                'occurrences': [],
                 'id': msg_id,
                 'title': sorted_messages[msg_id][0].symbol,
                 'msg': sorted_messages[msg_id][0].msg.split('\n')[0],
-                'num_occurances': len(sorted_messages[msg_id])
+                'num_occurrences': len(sorted_messages[msg_id])
             }
             for msg_instance in sorted_messages[msg_id]:
                 if msg_instance.node:
                     msg_data['has_node'] = True
-                    msg_data['occurances'].append({
+                    msg_data['occurrences'].append({
                         'lineno': msg_instance.node.fromlineno,
                         'end_lineno': msg_instance.node.end_lineno,
                         'col_offset': msg_instance.node.col_offset,
@@ -43,9 +43,9 @@ class PositionReporter(PlainReporter):
                     # locations in `node_printers.py` -- Instead, for now use
                     # location of the line.]
                     msg_data['has_node'] = False
-                    if len(self._source_lines) is 0:
+                    if len(self._source_lines) == 0:
                         continue
-                    msg_data['occurances'].append({
+                    msg_data['occurrences'].append({
                         'lineno': msg_instance.line,
                         'end_lineno': msg_instance.line,
                         'col_offset': msg_instance.column,

--- a/python_ta/reporters/position_reporter.py
+++ b/python_ta/reporters/position_reporter.py
@@ -12,8 +12,6 @@ class PositionReporter(PlainReporter):
             'total_genre_errors': 0,
             'total_genre_styles': 0,
             'total_results': 0,
-            'total_skipped': 0,
-            'skipped': [],
             'results': []
         }
 

--- a/python_ta/reporters/position_reporter.py
+++ b/python_ta/reporters/position_reporter.py
@@ -51,7 +51,7 @@ class PositionReporter(PlainReporter):
                         'lineno': msg_instance.line,
                         'end_lineno': msg_instance.line,
                         'col_offset': msg_instance.column,
-                        'end_col_offset': len(self._source_lines[msg_instance.line])
+                        'end_col_offset': len(self._source_lines[msg_instance.line-1])
                     })
             data_per_message.append(msg_data)
         return data_per_message

--- a/python_ta/reporters/position_reporter.py
+++ b/python_ta/reporters/position_reporter.py
@@ -6,9 +6,6 @@ from .plain_reporter import PlainReporter
 
 
 class PositionReporter(PlainReporter):
-    _SPACE = ' '
-    _BREAK = '\n'
-
     def __init__(self, source_lines=None, module_name=''):
         super().__init__(source_lines, module_name)
         self._output = {   


### PR DESCRIPTION
Add reporter that outputs JSON formatted messages for each file linted in the call to `python_ta.check`.

The main purpose is for the 4 locations, `lineno, end_lineno, col_offset, end_col_offset`.

Notes:
• code "snippets" are currently not provided, as this may not be needed for the intended use.

• for now, `skipped` files ignored in the JSON unless we want to store this information in the reporters and change in our plain/color/html/position reporters in a future commit.
```
self._output = {   
    'total_skipped': 0,
    'skipped': []
}
```

• `NewMessage` messages without a `node` attribute don't have location data. For now the location of the whole line is used. TODO: use more accurate location data. [See some message-specific policies set `start` and `stop` locations in `node_printers.py`.] 