### PR TITLE
Prevent message line from falling down into next line.

### DIFF
--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -200,9 +200,10 @@ class PlainReporter(BaseReporter):
         for msg_id in messages:
             result += self._colourify(fore_colour, msg_id)
             result += self._colourify('bold', ' ({})  '.format(messages[msg_id][0].symbol))
-            result += 'Number of occurrences: {}.{}'.format(len(messages[msg_id]), self._BREAK)
+            result += 'Number of occurrences: {}.'.format(len(messages[msg_id]))
             if max_messages != float('inf') and max_messages < len(messages[msg_id]):
-                result += ' First {} shown.'.format(max_messages)
+                result += ' (First {} shown).'.format(max_messages)
+            result += self._BREAK
 
             for i, msg in enumerate(messages[msg_id]):
                 if i == max_messages:


### PR DESCRIPTION
When the number of messages is limited in config, `pyta-number-of-messages`, the indication was falling below in to the next line. Fixed.

Old,
```
C0111 (missing-docstring)  Number of occurrences: 4.
 First 2 shown.  [Line 1] Missing module docstring
  <omitted>
  [Line 1] Missing function docstring
```
New,
```
C0111 (missing-docstring)  Number of occurrences: 4. (First 2 shown).
  [Line 1] Missing module docstring
  <omitted>
  [Line 1] Missing function docstring
```