### PR TITLE
Reimplement iterables visitors

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -133,31 +133,32 @@ class TypeInferer:
             node.type_constraints = TypeInfo(NoType)
 
     def visit_list(self, node):
-        # node_types contains types of elements inside list.
-        node_type = node.elts[0].type_constraints.type
-        for elt in node.elts:
-            node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
-        node.type_constraints = TypeInfo(List[node_type])
-
-    def visit_set(self, node):
-        node_type = node.elts[0].type_constraints.type
-        for elt in node.elts:
-            node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
-        node.type_constraints = TypeInfo(List[node_type])
-
-    def visit_set(self, node):
-        node_types = {node_child.type_constraints.type for node_child in node.elts}
-        if len(node_types) == 1:
-            node.type_constraints = TypeInfo(List[node_types.pop()])
-        else:
+        if len(node.elts) == 0:
             node.type_constraints = TypeInfo(List[Any])
+        else:
+            node_type = node.elts[0].type_constraints.type
+            for elt in node.elts:
+                node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
+            node.type_constraints = TypeInfo(List[node_type])
+
+    def visit_set(self, node):
+        if len(node.elts) == 0:
+            node.type_constraints = TypeInfo(Set[Any])
+        else:
+            node_type = node.elts[0].type_constraints.type
+            for elt in node.elts:
+                node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
+            node.type_constraints = TypeInfo(List[node_type])
 
     def visit_dict(self, node):
-        key_type, val_type = node.items[0][0].type_constraints.type, node.items[0][1].type_constraints.type
-        for key_node, val_node in node.items:
-            key_type = self.type_constraints.least_general_unifier(key_node.type_constraints.type, key_type)
-            val_type = self.type_constraints.least_general_unifier(val_node.type_constraints.type, val_type)
-        node.type_constraints = TypeInfo(Dict[key_type, val_type])
+        if len(node.items) == 0:
+            node.type_constraints = TypeInfo(Dict[Any, Any])
+        else:
+            key_type, val_type = node.items[0][0].type_constraints.type, node.items[0][1].type_constraints.type
+            for key_node, val_node in node.items:
+                key_type = self.type_constraints.least_general_unifier(key_node.type_constraints.type, key_type)
+                val_type = self.type_constraints.least_general_unifier(val_node.type_constraints.type, val_type)
+            node.type_constraints = TypeInfo(Dict[key_type, val_type])
 
     def visit_index(self, node):
         node.type_constraints = node.value.type_constraints

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -107,18 +107,18 @@ class TypeInferer:
             node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
         node.type_constraints = TypeInfo(List[node_type])
 
-    def visit_dict(self, node):
-        # node_types contains types of elements inside Dict.
-        key_types = {key.type_constraints.type for key, _ in node.items}
-        value_types = {value.type_constraints.type for _, value in node.items}
+    def visit_set(self, node):
+        node_type = node.elts[0].type_constraints.type
+        for elt in node.elts:
+            node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
+        node.type_constraints = TypeInfo(List[node_type])
 
-        # If all the keys have the same type and all the values have the same type,
-        # set the type constraint to a Dict of the two types.
-        # Else, just use the general Dict type.
-        if len(key_types) == 1 and len(value_types) == 1:
-            node.type_constraints = TypeInfo(Dict[key_types.pop(), value_types.pop()])
-        else:
-            node.type_constraints = TypeInfo(Dict[Any, Any])
+    def visit_dict(self, node):
+        key_type, val_type = node.items[0][0].type_constraints.type, node.items[0][1].type_constraints.type
+        for key_node, val_node in node.items:
+            key_type = self.type_constraints.least_general_unifier(key_node.type_constraints.type, key_type)
+            val_type = self.type_constraints.least_general_unifier(val_node.type_constraints.type, val_type)
+        node.type_constraints = TypeInfo(Dict[key_type, val_type])
 
     def visit_index(self, node):
         node.type_constraints = node.value.type_constraints

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -102,15 +102,10 @@ class TypeInferer:
 
     def visit_list(self, node):
         # node_types contains types of elements inside list.
-        node_types = {node_child.type_constraints.type for node_child in node.elts}
-        # If list has more than one type, just set node.type_constraints to List.
-        # If list has only one type T, set the node.type_constraints to be List[T].
-        if len(node_types) == 1:
-            # node_types.pop() returns the only element in the set, which is a
-            # type object.
-            node.type_constraints = TypeInfo(List[node_types.pop()])
-        else:
-            node.type_constraints = TypeInfo(List[Any])
+        node_type = node.elts[0].type_constraints.type
+        for elt in node.elts:
+            node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
+        node.type_constraints = TypeInfo(List[node_type])
 
     def visit_dict(self, node):
         # node_types contains types of elements inside Dict.

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -148,7 +148,7 @@ class TypeInferer:
             node_type = node.elts[0].type_constraints.type
             for elt in node.elts:
                 node_type = self.type_constraints.least_general_unifier(elt.type_constraints.type, node_type)
-            node.type_constraints = TypeInfo(List[node_type])
+            node.type_constraints = TypeInfo(Set[node_type])
 
     def visit_dict(self, node):
         if len(node.items) == 0:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -217,6 +217,71 @@ class TypeConstraints:
             self.unify(arg_type, param_type)
         return self._type_eval(new_func_type.__args__[-1])
 
+    def least_general_unifier(self, t1, t2):
+        if isinstance(t1, TypeVar) and isinstance(t2, TypeVar):
+            i1 = self._find(t1)
+            i2 = self._find(t2)
+            if issubclass(i1, i2):
+                return i2
+            elif issubclass(i2, i1):
+                return i1
+            else:
+                return Any
+        elif isinstance(t1, TypeVar):
+            i1 = self._find(t1)
+            if issubclass(i1, t2):
+                return t2
+            elif issubclass(t2, i1):
+                return i1
+            else:
+                return Any
+        elif isinstance(t2, TypeVar):
+            self.least_general_unifier(t2, t1)
+        elif isinstance(t1, GenericMeta) and isinstance(t2, GenericMeta):
+            self._least_general_unifier_generic(t1, t2)
+        elif isinstance(t1, CallableMeta) and isinstance(t2, CallableMeta):
+            rtype = self._least_general_unifier_call(t1, *t2.__args__[:-1])
+            self.least_general_unifier(rtype, t2.__args__[-1])
+        elif isinstance(t1, TupleMeta) and isinstance(t2, TupleMeta):
+            self._least_general_unifier_tuple(t1, t2)
+        elif t1.__class__.__name__ == '_Union' or t2.__class__.__name__ == '_Union':
+            pass
+        elif t1 == Any or t2 == Any:
+            return Any
+        elif issubclass(t1, t2):
+            return t2
+        elif issubclass(t2, t1):
+            return t1
+        elif t1 != t2:
+            return Any
+
+    def _least_general_unifier_generic(self, t1: GenericMeta, t2: GenericMeta):
+        """Unify two generic types."""
+        if not _geqv(t1, t2):
+            raise TypeInferenceError('bad unify')
+        elif t1.__args__ is not None and t2.__args__ is not None:
+            for a1, a2 in zip(t1.__args__, t2.__args__):
+                self.least_general_unifier(a1, a2)
+
+    def _least_general_unifier_tuple(self, t1: TupleMeta, t2: TupleMeta):
+        tup1, tup2 = t1.__tuple_params__, t2.__tuple_params__
+        if not tup1 or not tup2:
+            return
+        elif len(tup1) != len(tup2):
+            raise TypeInferenceError('unable to unify Tuple types')
+        else:
+            for elem1, elem2 in zip(tup1, tup2):
+                self.least_general_unifier(elem1, elem2)
+
+    def _least_general_unifier_call(self, func_type, *arg_types):
+        if len(func_type.__args__) - 1 != len(arg_types):
+            raise TypeInferenceError('Wrong number of arguments')
+        new_tvars = {tvar: self.fresh_tvar() for tvar in getattr(func_type, 'polymorphic_tvars', [])}
+        new_func_type = literal_substitute(func_type, new_tvars)
+        for arg_type, param_type in zip(arg_types, new_func_type.__args__[:-1]):
+            self.least_general_unifier(arg_type, param_type)
+        return self._type_eval(new_func_type.__args__[-1])
+
     def _type_eval(self, t):
         """Evaluate a type. Used for tuples."""
         if isinstance(t, TuplePlus):

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -294,9 +294,10 @@ subscriptable_expr = hs.one_of(
 # Helper functions for testing
 def _parse_text(source: Union[str, NodeNG]) -> Tuple[astroid.Module, TypeInferer]:
     """Parse source code text and output an AST with type inference performed."""
-    # TODO: Python parses sets as dictionaries by default. How to cast into Set?
-    # if isinstance(source, astroid.Set):
-    #     source = f'set({source.as_string()})'
+    # TODO: apparently no literal syntax for empty set in Python3, also cannot do set()
+    # TODO: Deal with special case later.
+    # if isinstance(source, astroid.Set) and len(list(source.elts)) == 0:
+    #     source = f'{set({})}'
     if not isinstance(source, str):  # It's an astroid node
         source = source.as_string()
     module = astroid.parse(source)

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -178,6 +178,24 @@ def index_node(draw, value=const_node(hs.integers())):
 
 
 @hs.composite
+def set_node(draw, elt=const_node(), **kwargs):
+    """Return a Set node with elements drawn from elt.
+    """
+    node = astroid.Set()
+    node.postinit(draw(hs.sets(elt, **kwargs)))
+    return node
+
+
+@hs.composite
+def setcomp_node(draw, elt=const_node(),
+                  generators=hs.lists(comprehension_node(),
+                                      min_size=1, average_size=1)):
+    node = astroid.SetComp()
+    node.postinit(draw(elt), draw(generators))
+    return node
+
+
+@hs.composite
 def list_node(draw, elt=const_node(), **kwargs):
     """Return a List node with elements drawn from elt.
     """
@@ -271,6 +289,9 @@ subscriptable_expr = hs.one_of(
 # Helper functions for testing
 def _parse_text(source: Union[str, NodeNG]) -> Tuple[astroid.Module, TypeInferer]:
     """Parse source code text and output an AST with type inference performed."""
+    # TODO: Python parses sets as dictionaries by default. How to cast into Set?
+    # if isinstance(source, astroid.Set):
+    #     source = f'set({source.as_string()})'
     if not isinstance(source, str):  # It's an astroid node
         source = source.as_string()
     module = astroid.parse(source)

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -271,6 +271,11 @@ def simple_homogeneous_list_node(draw, **kwargs):
     return list_node(const_node(t()), **kwargs).example()
 
 
+@hs.composite
+def simple_homogeneous_set_node(draw, **kwargs):
+    t = draw(primitive_types)
+    return set_node(const_node(t()), **kwargs).example()
+
 expr = hs.one_of(
     const_node(),
     dict_node(min_size=1),

--- a/tests/test_type_inference/test_assignments.py
+++ b/tests/test_type_inference/test_assignments.py
@@ -118,6 +118,11 @@ def test_assign_complex(variables, values):
      with a homogeneous list as the value.
     """
     assume(type(values[0]) != type(values[1]) and len(variables) == len(values))
+    val_types = [type(val) for val in values]
+    if int in val_types:
+        assume(bool not in val_types)
+    if bool in val_types:
+        assume(int not in val_types)
     program = ("x = ["
                + ", ".join([repr(val) for val in values])
                + "]\n"

--- a/tests/test_type_inference/test_for.py
+++ b/tests/test_type_inference/test_for.py
@@ -26,6 +26,11 @@ def test_for_heterogeneous_list(iterable):
      iterating over a heterogeneous list.
     """
     assume(type(iterable[0]) != type(iterable[1]))
+    val_types = [type(val) for val in iterable]
+    if int in val_types:
+        assume(bool not in val_types)
+    if bool in val_types:
+        assume(int not in val_types)
     program = f'for elt in {iterable}:\n' \
               f'    x = elt\n'
     module, TypeInferrer = cs._parse_text(program)

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -52,6 +52,7 @@ def test_homogeneous_dict(dictionary):
 def test_heterogeneous_dict(dictionary):
     """Test Dictionary nodes representing a dictionary with some key:value pairs of different types."""
     assume(not isinstance(list(dictionary.keys())[0], type(list(dictionary.keys())[1])))
+    assume(not isinstance(list(dictionary.values())[0], type(list(dictionary.values())[1])))
     key_types = [type(key) for key in dictionary.keys()]
     val_types = [type(val) for val in dictionary.values()]
     if int in key_types:

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -48,16 +48,33 @@ def test_random_lists(lst):
     cs._verify_type_setting(module, astroid.List, List[Any])
 
 
-# TODO: Add test cases for Set nodes.
-# @given(cs.set_node())
-# def test_set(node):
-#     """Test Set nodes representing a set of valuesi."""
-#     module, _ = cs._parse_text(node)
-#     set_node = list(module.nodes_of_class(astroid.Set))[0]
-#     if len(set_node.elts) == 0:
-#         assert set_node.type_constraints.type == Set[Any]
-#     else:
-#         cs._verify_type_setting(module, astroid.Set, Set[type(node.elts[0].value)])
+@given(cs.simple_homogeneous_set_node())
+def test_homogeneous_set(node):
+    """Test Set nodes representing a set of homogeneous values."""
+    module, _ = cs._parse_text(node)
+    set_node = list(module.nodes_of_class(astroid.Set))[0]
+    if len(set_node.elts) == 0:
+        assert set_node.type_constraints.type == Set[Any]
+    else:
+        try:
+            cs._verify_type_setting(module, astroid.Set, Set[type(set_node.elts[0].value)])
+        except AttributeError:
+            cs._verify_type_setting(module, astroid.Set, Set[type(set_node.elts[0].operand.value)])
+
+
+@given(cs.set_node(min_size=2))
+def test_random_set(node):
+    """Test Set nodes representing a set of heterogeneous values."""
+    assume(not isinstance(list(node.elts)[0].value, type(list(node.elts)[1].value)))
+    assume(not isinstance(list(node.elts)[1].value, type(list(node.elts)[0].value)))
+    val_types = [type(val.value) for val in node.elts]
+    if int in val_types:
+        assume(bool not in val_types)
+    if bool in val_types:
+        assume(int not in val_types)
+    module, _ = cs._parse_text(node)
+    set_node = list(module.nodes_of_class(astroid.Set))[0]
+    cs._verify_type_setting(module, astroid.Set, Set[Any])
 
 
 @given(cs.simple_homogeneous_dict_node(min_size=1))

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -52,6 +52,12 @@ def test_homogeneous_dict(dictionary):
 def test_heterogeneous_dict(dictionary):
     """Test Dictionary nodes representing a dictionary with some key:value pairs of different types."""
     assume(not isinstance(list(dictionary.keys())[0], type(list(dictionary.keys())[1])))
+    key_types = [type(key) for key in dictionary.keys()]
+    val_types = [type(val) for val in dictionary.values()]
+    if int in key_types:
+        assume(bool not in key_types)
+    if int in val_types:
+        assume(bool not in val_types)
     module, _ = cs._parse_text(str(dictionary))
     cs._verify_type_setting(module, astroid.Dict, Dict[Any, Any])
 

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -33,6 +33,10 @@ def test_homogeneous_lists(lst):
 def test_random_lists(lst):
     """Test List nodes representing a list of values of different primitive types."""
     assume(not isinstance(lst[0], type(lst[1])))
+    # bools and ints become unified; assume we have one or the other for this test case.
+    lst_types = [type(elt) for elt in lst]
+    if int in lst_types:
+        assume(bool not in lst_types)
     module, _ = cs._parse_text(str(lst))
     cs._verify_type_setting(module, astroid.List, List[Any])
 
@@ -101,6 +105,7 @@ def test_tuple_expr(expr):
 @given(cs.random_list(min_size=2))
 def test_list_expr(expr):
     """Test visitor for expression node representing a list"""
+    assume(type(expr[0]) != type(expr[1]))
     module, _ = cs._parse_text(repr(expr))
     cs._verify_node_value_typematch(module)
 

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -38,6 +38,7 @@ def test_homogeneous_lists(lst):
 def test_random_lists(lst):
     """Test List nodes representing a list of values of different primitive types."""
     assume(not isinstance(lst.elts[0].value, type(lst.elts[1].value)))
+    assume(not isinstance(lst.elts[1].value, type(lst.elts[0].value)))
     val_types = [type(val.value) for val in lst.elts]
     if int in val_types:
         assume(bool not in val_types)
@@ -78,6 +79,8 @@ def test_heterogeneous_dict(node):
     values = [item.value for _, item in node.items]
     assume(not isinstance(keys[0], type(keys[1])))
     assume(not isinstance(values[0], type(values[1])))
+    assume(not isinstance(keys[1], type(keys[0])))
+    assume(not isinstance(values[1], type(values[0])))
     key_types = [type(key.value) for key, _ in node.items]
     val_types = [type(val.value) for _, val in node.items]
     if int in key_types:

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -2,7 +2,7 @@ import astroid
 import nose
 from hypothesis import assume, given, settings
 import tests.custom_hypothesis_support as cs
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Set, Tuple
 settings.load_profile("pyta")
 
 
@@ -27,32 +27,63 @@ def test_tuple(t_tuple):
 def test_homogeneous_lists(lst):
     """Test List nodes representing a list of values of the same primitive type."""
     module, _ = cs._parse_text(lst)
-    cs._verify_type_setting(module, astroid.List, List[type(lst.elts[0].value)])
+    list_node = list(module.nodes_of_class(astroid.List))[0]
+    if len(list_node.elts) == 0:
+        assert list_node.type_constraints.type == List[Any]
+    else:
+        cs._verify_type_setting(module, astroid.List, List[type(lst.elts[0].value)])
 
 
 @given(cs.list_node(min_size=2))
 def test_random_lists(lst):
     """Test List nodes representing a list of values of different primitive types."""
     assume(not isinstance(lst.elts[0].value, type(lst.elts[1].value)))
+    val_types = [type(val.value) for val in lst.elts]
+    if int in val_types:
+        assume(bool not in val_types)
+    if bool in val_types:
+        assume(int not in val_types)
     module, _ = cs._parse_text(lst)
     cs._verify_type_setting(module, astroid.List, List[Any])
+
+
+# TODO: Add test cases for Set nodes.
+# @given(cs.set_node())
+# def test_set(node):
+#     """Test Set nodes representing a set of valuesi."""
+#     module, _ = cs._parse_text(node)
+#     set_node = list(module.nodes_of_class(astroid.Set))[0]
+#     if len(set_node.elts) == 0:
+#         assert set_node.type_constraints.type == Set[Any]
+#     else:
+#         cs._verify_type_setting(module, astroid.Set, Set[type(node.elts[0].value)])
 
 
 @given(cs.simple_homogeneous_dict_node(min_size=1))
 def test_homogeneous_dict(dictionary):
     """Test Dictionary nodes representing a dictionary with all key:value pairs of same types."""
     module, _ = cs._parse_text(dictionary)
-    first_key, first_value = next(((k, v) for k, v in dictionary.items))
-    cs._verify_type_setting(module, astroid.Dict, Dict[type(first_key.value), type(first_value.value)])
+    dict_node = list(module.nodes_of_class(astroid.Dict))[0]
+    if len(dict_node.items) == 0:
+        assert dict_node.type_constraints.type == Dict[Any, Any]
+    else:
+        first_key, first_value = next(((k, v) for k, v in dictionary.items))
+        cs._verify_type_setting(module, astroid.Dict, Dict[type(first_key.value), type(first_value.value)])
 
 
 @given(cs.dict_node(min_size=2))
 def test_heterogeneous_dict(node):
     """Test Dictionary nodes representing a dictionary with some key:value pairs of different types."""
     keys = [item.value for item, _ in node.items]
-    values = [item.value for item, _ in node.items]
+    values = [item.value for _, item in node.items]
     assume(not isinstance(keys[0], type(keys[1])))
     assume(not isinstance(values[0], type(values[1])))
+    key_types = [type(key.value) for key, _ in node.items]
+    val_types = [type(val.value) for _, val in node.items]
+    if int in key_types:
+        assume(bool not in val_types)
+    if bool in key_types:
+        assume(int not in val_types)
     module, _ = cs._parse_text(node)
     cs._verify_type_setting(module, astroid.Dict, Dict[Any, Any])
 

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -40,7 +40,10 @@ def test_subscript_homogeneous_list_slice(input_list, slice):
 @given(cs.random_list(min_size=2), cs.random_slice_indices())
 def test_subscript_heterogeneous_list_slice(input_list, slice):
     """Test visitor of Subscript node representing slicing of heterogeneous list."""
-    assume(not isinstance(input_list[0], type(input_list[1])))
+    assume(type(input_list[0]) != type(input_list[1]))
+    lst_types = [type(elt) for elt in input_list]
+    if int in lst_types:
+        assume(bool not in lst_types)
     input_slice = ':'.join([str(index) if index else '' for index in slice])
     program = f'{input_list}[{input_slice}]'
     module, _ = cs._parse_text(program)


### PR DESCRIPTION
- Implement helper to return least general unifier of two types.
- Update List, Dict, Set node visitors to use helper and set type constraints.
- Update test cases assumptions (bool and int unified).