### PR TITLE
Dev test classdef

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -371,6 +371,16 @@ class TypeInferer:
         elt_type = self.type_constraints.lookup_concrete(node.elt.type_constraints.type)
         node.type_constraints = TypeInfo(Set[elt_type])
 
+    def visit_classdef(self, node):
+        # for each instance, unify all it's attributes
+        # we cannot visit the AssignAttr nodes and unify because we lose env
+        # best way is to visit each ClassDef node, get all it's instances
+        # and unify accordingly.. actually each attribute should have a
+        # SINGLE TYPE you byungshin.
+        # so we just go through each instance_attrs element and
+        #   do a lookup of the attrname in the ClassDef's env and unify it
+        #   with the parent Assign node's value node's type
+
     def visit_module(self, node):
         node.type_constraints = TypeInfo(NoType)
         # print('All sets:', self.type_constraints._sets)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -335,7 +335,11 @@ class TypeInferer:
             func_t = self.type_constraints.lookup_concrete(
                 node.frame().locals[func_name][0].type_environment.locals['__init__'])
             arg_types = [_ForwardRef(func_name)] + [arg.type_constraints.type for arg in node.args]
-            self.type_constraints.unify_call(func_t, *arg_types)
+            try:
+                self.type_constraints.unify_call(func_t, *arg_types)
+            except Exception:
+                # TODO: Same issue as AssignAttr node visitor; bad unify to be fixed later - pass for now.
+                pass
             node.type_constraints = TypeInfo(_ForwardRef(func_name))
         else:
             func_t = self.type_constraints.lookup_concrete(node.frame().type_environment.locals[func_name])

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -119,6 +119,14 @@ class TypeInferer:
     ##############################################################################
     # Literals
     ##############################################################################
+    def _find_attribute_type(self, node, instance_name, attribute_name):
+        """Given the node, class name and attribute name, return the type of the attribute."""
+        class_type = self.type_constraints.lookup_concrete(self._closest_frame(node, instance_name)
+                                                           .type_environment.lookup_in_env(instance_name))
+        class_name = class_type.__forward_arg__
+        class_env = self._closest_frame(node, class_name).locals[class_name][0].type_environment
+        return self.type_constraints.lookup_concrete(class_env.lookup_in_env(attribute_name))
+
     def visit_const(self, node):
         """Populate type constraints for astroid nodes for num/str/bool/None/bytes literals."""
         node.type_constraints = TypeInfo(type(node.value))

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -299,18 +299,9 @@ class TypeInferer:
                     target_type_var = node.frame().type_environment.lookup_in_env(target_node.name)
                     self.type_constraints.unify(target_type_var, node.value.type_constraints.type)
                 elif isinstance(target_node, astroid.AssignAttr):
-                    # TODO: check for annotations? should this be done in ClassDef instead?
-                    if target_node.expr.name == 'self':
-                        # this is a special case and is handled by the Call node visitor.
-                        pass
-                    else:
-                        # every Assign node will have a single Name node associated with it
-                        attr_type = self._find_attribute_type(target_node, target_node.expr.name, target_node.attrname)
-                        try:
-                            self.type_constraints.unify(attr_type, target_node.parent.value.type_constraints.type)
-                        except Exception: # TODO: Bad to just catch Exception; change type of exception in base?
-                            # TODO: Futhermore, is this the behaviour we want?
-                            pass
+                    # every Assign node will have a single Name node associated with it
+                    attr_type = self._find_attribute_type(target_node, target_node.expr.name, target_node.attrname)
+                    self.type_constraints.unify(attr_type, target_node.parent.value.type_constraints.type)
         node.type_constraints = TypeInfo(NoType)
 
     def visit_return(self, node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -72,6 +72,9 @@ class TypeInferer:
     def _set_function_def_environment(self, node):
         """Method to set environment of a FunctionDef node."""
         node.type_environment = Environment()
+        # self is a special case
+        if node.args.args[0].name == 'self' and isinstance(node.parent, astroid.ClassDef):
+            node.type_environment.locals['self'] = _ForwardRef(node.parent.name)
         self._populate_local_env(node)
         node.type_environment.locals['return'] = self.type_constraints.fresh_tvar()
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -335,11 +335,7 @@ class TypeInferer:
             func_t = self.type_constraints.lookup_concrete(
                 node.frame().locals[func_name][0].type_environment.locals['__init__'])
             arg_types = [_ForwardRef(func_name)] + [arg.type_constraints.type for arg in node.args]
-            try:
-                self.type_constraints.unify_call(func_t, *arg_types)
-            except Exception:
-                # TODO: Same issue as AssignAttr node visitor; bad unify to be fixed later - pass for now.
-                pass
+            self.type_constraints.unify_call(func_t, *arg_types)
             node.type_constraints = TypeInfo(_ForwardRef(func_name))
         else:
             func_t = self.type_constraints.lookup_concrete(node.frame().type_environment.locals[func_name])

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -73,7 +73,7 @@ class TypeInferer:
         """Method to set environment of a FunctionDef node."""
         node.type_environment = Environment()
         # self is a special case
-        if node.args.args[0].name == 'self' and isinstance(node.parent, astroid.ClassDef):
+        if node.args.args and node.args.args[0].name == 'self' and isinstance(node.parent, astroid.ClassDef):
             node.type_environment.locals['self'] = _ForwardRef(node.parent.name)
         self._populate_local_env(node)
         node.type_environment.locals['return'] = self.type_constraints.fresh_tvar()

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -29,21 +29,5 @@ def test_classdef_attribute_assign():
             assert attribute_type == value_type
 
 
-def test_classdef_method_call():
-    """Test whether type of the method call are properly being set"""
-    program = f'class Network:\n' \
-              f'    def __init__(self, name, id):\n' \
-              f'        self.name = name\n' \
-              f'        self.id = id' \
-              f'    def change_name ' \
-              f'\n' \
-              f'rogers = Network(\'Rogers\', 5)\n' \
-              f'rogers.name, rogers.id = \'BoB\', 10\n' \
-              f'\n'
-    module, inferer = cs._parse_text(program)
-    # get the functionDef node - there is only one in this test case.
-    classdef_node = next(module.nodes_of_class(astroid.ClassDef))
-    a = 5
-
 if __name__ == '__main__':
     nose.main()

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -14,33 +14,36 @@ def test_classdef_attribute_assign():
               f'        self.name = name\n' \
               f'        self.id = id' \
               f'\n' \
-              f'rogers = Network(\'Rogers\', 5)\n' \
-              f'rogers.name = \'BoB\'\n' \
-              f'self = Network(\'asdf\', 5)\n' \
-              f'self.name = \'asdfaBoB\'\n' \
+              f'rogers = Network("Rogers", 5)\n' \
+              f'rogers.name = "BoB"\n' \
+              f'self = Network("asdf", 5)\n' \
+              f'self.name = "asdfaBoB"\n' \
               f'\n'
     module, inferer = cs._parse_text(program)
     classdef_node = next(module.nodes_of_class(astroid.ClassDef))
-    for attribute_lst in list(classdef_node.instance_attrs.values()):
+    for attribute_lst in classdef_node.instance_attrs.values():
         for instance in attribute_lst:
             attribute_type = inferer.type_constraints\
                 .lookup_concrete(classdef_node.type_environment.lookup_in_env(instance.attrname))
             value_type = inferer.type_constraints.lookup_concrete(instance.parent.value.type_constraints.type)
             assert attribute_type == value_type
 
-# def test_classdef_method_call():
-#     program = f'class Network:\n' \
-#               f'    def __init__(self, name, id):\n' \
-#               f'        self.name = name\n' \
-#               f'        self.id = id' \
-#               f'\n' \
-#               f'rogers = Network(\'Rogers\', 5)\n' \
-#               f'rogers.name, rogers.id = \'BoB\', 10\n' \
-#               f'\n'
-#     module, inferer = cs._parse_text(program)
-#     # get the functionDef node - there is only one in this test case.
-#     classdef_node = next(module.nodes_of_class(astroid.ClassDef))
-#     a = 5
+
+def test_classdef_method_call():
+    """Test whether type of the method call are properly being set"""
+    program = f'class Network:\n' \
+              f'    def __init__(self, name, id):\n' \
+              f'        self.name = name\n' \
+              f'        self.id = id' \
+              f'    def change_name ' \
+              f'\n' \
+              f'rogers = Network(\'Rogers\', 5)\n' \
+              f'rogers.name, rogers.id = \'BoB\', 10\n' \
+              f'\n'
+    module, inferer = cs._parse_text(program)
+    # get the functionDef node - there is only one in this test case.
+    classdef_node = next(module.nodes_of_class(astroid.ClassDef))
+    a = 5
 
 if __name__ == '__main__':
     nose.main()

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -1,0 +1,46 @@
+import astroid
+import nose
+from hypothesis import assume, given, settings
+import tests.custom_hypothesis_support as cs
+import hypothesis.strategies as hs
+from typing import Callable
+settings.load_profile("pyta")
+
+
+def test_classdef_attribute_assign():
+    """Test whether type of attributes are properly being set."""
+    program = f'class Network:\n' \
+              f'    def __init__(self, name, id):\n' \
+              f'        self.name = name\n' \
+              f'        self.id = id' \
+              f'\n' \
+              f'rogers = Network(\'Rogers\', 5)\n' \
+              f'rogers.name = \'BoB\'\n' \
+              f'self = Network(\'asdf\', 5)\n' \
+              f'self.name = \'asdfaBoB\'\n' \
+              f'\n'
+    module, inferer = cs._parse_text(program)
+    classdef_node = next(module.nodes_of_class(astroid.ClassDef))
+    for attribute_lst in list(classdef_node.instance_attrs.values()):
+        for instance in attribute_lst:
+            attribute_type = inferer.type_constraints\
+                .lookup_concrete(classdef_node.type_environment.lookup_in_env(instance.attrname))
+            value_type = inferer.type_constraints.lookup_concrete(instance.parent.value.type_constraints.type)
+            assert attribute_type == value_type
+
+# def test_classdef_method_call():
+#     program = f'class Network:\n' \
+#               f'    def __init__(self, name, id):\n' \
+#               f'        self.name = name\n' \
+#               f'        self.id = id' \
+#               f'\n' \
+#               f'rogers = Network(\'Rogers\', 5)\n' \
+#               f'rogers.name, rogers.id = \'BoB\', 10\n' \
+#               f'\n'
+#     module, inferer = cs._parse_text(program)
+#     # get the functionDef node - there is only one in this test case.
+#     classdef_node = next(module.nodes_of_class(astroid.ClassDef))
+#     a = 5
+
+if __name__ == '__main__':
+    nose.main()


### PR DESCRIPTION
- Set type constraint of ClassDef node to be NoType.
- Add to Assign node visitor to handle AssignAttr nodes to properly unify instance attributes.
- Add TODOs to deal with bad unify Exception arising from trying to unification when
    1. calling __init__ function during instantiation.
    2. assigning to an attribute that's already been assigned a different type.
- Fix whitespace formatting.