### PR TITLE
Dev test functiondef annotation

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -204,6 +204,7 @@ class TypeInferer:
                 .create_in_env(self.type_constraints, 'globals', node.name)
             node.type_constraints = TypeInfo(self._closest_frame(node, node.name)
                                              .type_environment.lookup_in_env(node.name))
+            self._closest_frame(node, node.name).type_environment.create_in_env(self.type_constraints, 'globals', node.name)
 
     ##############################################################################
     # Operation nodes

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,7 +4,8 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _gorg, _geqv, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations
+from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment\
+    , TypeConstraints, TypeInferenceError, parse_annotations
 from ..typecheck.type_store import TypeStore
 
 
@@ -319,12 +320,9 @@ class TypeInferer:
         arg_types = [self.type_constraints.lookup_concrete(node.type_environment.lookup_in_env(arg))
                      for arg in node.argnames()]
         if any(annotation is not None for annotation in node.args.annotations):
-            # TODO: UNIFICATION WORK FROM PARSED ANNOTATIONS
             func_type = parse_annotations(node)
-            # TODO: Unify tvars in FunctionDef's environment with given annotations
             [self.type_constraints.unify(arg_type, annotation) for arg_type
                 , annotation in zip(arg_types, func_type.__args__[:-1])]
-            # TODO: Unify FunctionDef's tvar with Callable
             self.type_constraints.unify(self._closest_frame(node, node.name)
                                         .type_environment.lookup_in_env(node.name), func_type)
         else:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -188,7 +188,10 @@ class TypeInferer:
         closest_scope = node
         if node.parent:
             closest_scope = node.parent
-            if hasattr(closest_scope, 'type_environment') and name in closest_scope.type_environment.locals:
+            if hasattr(closest_scope, 'type_environment') and (
+                            name in closest_scope.type_environment.locals or
+                            name in closest_scope.type_environment.globals or
+                            name in closest_scope.type_environment.nonlocals):
                 return closest_scope
             else:
                 return self._closest_frame(closest_scope, name)
@@ -204,7 +207,6 @@ class TypeInferer:
                 .create_in_env(self.type_constraints, 'globals', node.name)
             node.type_constraints = TypeInfo(self._closest_frame(node, node.name)
                                              .type_environment.lookup_in_env(node.name))
-            self._closest_frame(node, node.name).type_environment.create_in_env(self.type_constraints, 'globals', node.name)
 
     ##############################################################################
     # Operation nodes

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,7 +4,7 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _gorg, _geqv, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError
+from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations
 from ..typecheck.type_store import TypeStore
 
 
@@ -318,20 +318,28 @@ class TypeInferer:
     def visit_functiondef(self, node):
         arg_types = [self.type_constraints.lookup_concrete(node.type_environment.lookup_in_env(arg))
                      for arg in node.argnames()]
-
-        # Check whether this is a method in a class
-        if isinstance(node.parent, astroid.ClassDef) and isinstance(arg_types[0], TypeVar):
-            self.type_constraints.unify(arg_types[0], _ForwardRef(node.parent.name))
-
-        # check if return nodes exist; there is a return statement in function body.
-        if len(list(node.nodes_of_class(astroid.Return))) == 0:
-            func_type = Callable[arg_types, None]
+        if any(annotation is not None for annotation in node.args.annotations):
+            # TODO: UNIFICATION WORK FROM PARSED ANNOTATIONS
+            func_type = parse_annotations(node)
+            # TODO: Unify tvars in FunctionDef's environment with given annotations
+            [self.type_constraints.unify(arg_type, annotation) for arg_type
+                , annotation in zip(arg_types, func_type.__args__[:-1])]
+            # TODO: Unify FunctionDef's tvar with Callable
+            self.type_constraints.unify(self._closest_frame(node, node.name)
+                                        .type_environment.lookup_in_env(node.name), func_type)
         else:
-            rtype = self.type_constraints.lookup_concrete(node.type_environment.lookup_in_env('return'))
-            func_type = Callable[arg_types, rtype]
-        func_type.polymorphic_tvars = [arg for arg in arg_types
-                                       if isinstance(arg, TypeVar)]
-        self.type_constraints.unify(node.parent.frame().type_environment.lookup_in_env(node.name), func_type)
+            # Check whether this is a method in a class
+            if isinstance(node.parent, astroid.ClassDef) and isinstance(arg_types[0], TypeVar):
+                self.type_constraints.unify(arg_types[0], _ForwardRef(node.parent.name))
+
+            # check if return nodes exist; there is a return statement in function body.
+            if len(list(node.nodes_of_class(astroid.Return))) == 0:
+                func_type = Callable[arg_types, None]
+            else:
+                rtype = self.type_constraints.lookup_concrete(node.type_environment.lookup_in_env('return'))
+                func_type = Callable[arg_types, rtype]
+            func_type.polymorphic_tvars = [arg for arg in arg_types if isinstance(arg, TypeVar)]
+            self.type_constraints.unify(self._closest_frame(node, node.name).type_environment.lookup_in_env(node.name), func_type)
         node.type_constraints = TypeInfo(NoType)
 
     def visit_call(self, node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,8 +4,7 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _gorg, _geqv, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment\
-    , TypeConstraints, TypeInferenceError, parse_annotations
+from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations
 from ..typecheck.type_store import TypeStore
 
 
@@ -324,8 +323,8 @@ class TypeInferer:
                      for arg in node.argnames()]
         if any(annotation is not None for annotation in node.args.annotations):
             func_type = parse_annotations(node)
-            [self.type_constraints.unify(arg_type, annotation) for arg_type
-                , annotation in zip(arg_types, func_type.__args__[:-1])]
+            for arg_type, annotation in zip(arg_types, func_type.__args__[:-1]):
+                self.type_constraints.unify(arg_type, annotation)
             self.type_constraints.unify(self._closest_frame(node, node.name)
                                         .type_environment.lookup_in_env(node.name), func_type)
         else:

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -51,6 +51,11 @@ comparator_operator_equality = hs.sampled_from(comparator_symbols_equality)
 binary_bool_operator = hs.sampled_from(['and', 'or'])
 unary_bool_operator = hs.sampled_from(['not'])
 
+# Strategies for generating builtin type names
+annotation_names = ['bool', 'bytearray', 'bytes', 'complex', 'dict', 'enumerate'
+                    , 'float', 'frozenset', 'int', 'list', 'set', 'str', 'tuple']
+annotation = hs.sampled_from(annotation_names)
+
 
 def valid_identifier(**kwargs):
     """Return a strategy which generates a valid Python Identifier"""

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -52,9 +52,9 @@ binary_bool_operator = hs.sampled_from(['and', 'or'])
 unary_bool_operator = hs.sampled_from(['not'])
 
 # Strategies for generating builtin type names
-annotation_types = [bool, bytearray, bytes, complex, dict, enumerate
-                    , float, frozenset, int, list, set, str, tuple]
-annotation = hs.sampled_from(annotation_types)
+builtin_types = [bool, bytearray, bytes, complex, dict, enumerate,
+                    float, frozenset, int, list, set, str, tuple]
+annotation = hs.sampled_from(builtin_types).map(lambda s: s.__name__)
 
 
 def valid_identifier(**kwargs):
@@ -296,10 +296,7 @@ def arguments_node(draw, annotated=False):
     n = draw(hs.integers(min_value=1, max_value=5))
     args = draw(hs.lists(name_node(None), min_size=n, max_size=n))
     if annotated:
-        # TODO: annotations have to be Name nodes BOI
         annotations = draw(hs.lists(name_node(annotation), min_size=n, max_size=n))
-        for i in range(len(annotations)):
-            annotations[i].name = annotations[i].name.__name__
     else:
         annotations = None
     node = astroid.Arguments()

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -52,9 +52,9 @@ binary_bool_operator = hs.sampled_from(['and', 'or'])
 unary_bool_operator = hs.sampled_from(['not'])
 
 # Strategies for generating builtin type names
-annotation_names = ['bool', 'bytearray', 'bytes', 'complex', 'dict', 'enumerate'
-                    , 'float', 'frozenset', 'int', 'list', 'set', 'str', 'tuple']
-annotation = hs.sampled_from(annotation_names)
+annotation_types = [bool, bytearray, bytes, complex, dict, enumerate
+                    , float, frozenset, int, list, set, str, tuple]
+annotation = hs.sampled_from(annotation_types)
 
 
 def valid_identifier(**kwargs):
@@ -283,11 +283,11 @@ def simple_homogeneous_set_node(draw, **kwargs):
 
 
 @hs.composite
-def name_node(draw, names):
-    if not names:
+def name_node(draw, name=None):
+    if not name:
         node = astroid.Name(draw(valid_identifier()))
     else:
-        node = astroid.Name(draw(names))
+        node = astroid.Name(draw(name))
     return node
 
 
@@ -298,6 +298,8 @@ def arguments_node(draw, annotated=False):
     if annotated:
         # TODO: annotations have to be Name nodes BOI
         annotations = draw(hs.lists(name_node(annotation), min_size=n, max_size=n))
+        for i in range(len(annotations)):
+            annotations[i].name = annotations[i].name.__name__
     else:
         annotations = None
     node = astroid.Arguments()

--- a/tests/test_type_inference/test_function_def_inference.py
+++ b/tests/test_type_inference/test_function_def_inference.py
@@ -90,22 +90,7 @@ def test_functiondef_annotated_simple_return(function_name, arguments, annotatio
         function_type_var = module.type_environment.lookup_in_env(function_name)
         function_type = inferer.type_constraints.lookup_concrete(function_type_var)
         actual_arg_types, actual_return_type = inferer.type_constraints.types_in_callable(function_type)
-        assert expected_arg_types == actual_arg_types
-
-
-def test_functiondef_annotated_concrete_simple_return():
-    """Test whether type annotations are set properly for a FunctionDef node representing a function definition
-    with type annotations."""
-    program = f'def f(a: str, b: int) -> str:\n' \
-              f'    return a\n' \
-              f''
-    module, inferer = cs._parse_text(program)
-    functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
-    # TODO: convert to hypothesis, can iterate over args[i]
-    arg_name = functiondef_node.args.args[0].name
-    actual_type = inferer.type_constraints.lookup_concrete(functiondef_node.type_environment.lookup_in_env(arg_name))
-    # TODO: hard-coded? better way to test this? WE DO NOT WANT TO USE EVAL (also only works for builtins)
-    assert actual_type.__name__ == functiondef_node.args.annotations[0].name
+        assert expected_arg_types == actual_arg_types and functiondef_node.returns.name == actual_return_type.__name__
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_function_def_inference.py
+++ b/tests/test_type_inference/test_function_def_inference.py
@@ -67,8 +67,13 @@ def test_function_def_args_simple_return(function_name, arguments):
 def test_functiondef_annotated_simple_return(functiondef_node):
     """Test whether type annotations are set properly for a FunctionDef node representing a function definition
     with type annotations."""
+    arg_names = [arg.name for arg in functiondef_node.args.args]
+    assume(functiondef_node.name not in arg_names)
+    for arg in functiondef_node.args.args:
+        assume(arg_names.count(arg.name) == 1)
     module, inferer = cs._parse_text(functiondef_node)
     functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
+    # arguments and annotations are not changing, so test this once.
     for i in range(len(functiondef_node.args.annotations)):
         arg_name = functiondef_node.args.args[i].name
         expected_type = inferer.type_constraints.lookup_concrete(functiondef_node.type_environment.lookup_in_env(arg_name))

--- a/tests/test_type_inference/test_function_def_inference.py
+++ b/tests/test_type_inference/test_function_def_inference.py
@@ -13,14 +13,6 @@ def _parse_to_function(function_name, args_list, return_statement):
            f'    return {return_statement}'
 
 
-def _parse_to_annotated_function(function_name, args_list, return_statement, annotations):
-    """Helper to parse given data into function definition."""
-    args_annotations = zip(args_list, annotations[:-1])
-    pre_process = [f'{arg}: {annotation}' for arg, annotation in args_annotations]
-    return f'def {function_name}({", ".join(pre_process)}) -> {annotations[-1]}:' \
-           f'    return {return_statement}'
-
-
 def _parse_to_function_no_return(function_name, args_list, function_body):
     """Helper to parse given data into function definition."""
     return f'def {function_name}({", ".join(args_list)}):\n' \

--- a/tests/test_type_inference/test_function_def_inference.py
+++ b/tests/test_type_inference/test_function_def_inference.py
@@ -13,6 +13,14 @@ def _parse_to_function(function_name, args_list, return_statement):
            f'    return {return_statement}'
 
 
+def _parse_to_annotated_function(function_name, args_list, return_statement, annotations):
+    """Helper to parse given data into function definition."""
+    args_annotations = zip(args_list, annotations[:-1])
+    pre_process = [f'{arg}: {annotation}' for arg, annotation in args_annotations]
+    return f'def {function_name}({", ".join(pre_process)}) -> {annotations[-1]}:' \
+           f'    return {return_statement}'
+
+
 def _parse_to_function_no_return(function_name, args_list, function_body):
     """Helper to parse given data into function definition."""
     return f'def {function_name}({", ".join(args_list)}):\n' \
@@ -52,6 +60,52 @@ def test_function_def_args_simple_return(function_name, arguments):
         return_type_var = function_def_node.type_environment.lookup_in_env(argument)
         expected_return_type = inferer.type_constraints.lookup_concrete(return_type_var)
         assert Callable[actual_arg_types, actual_return_type] == Callable[expected_arg_types, expected_return_type]
+
+
+@given(cs.valid_identifier(), hs.lists(cs.valid_identifier(), min_size=2), hs.lists(cs.annotation, min_size=3))
+def test_functiondef_annotated_simple_return(function_name, arguments, annotations):
+    """Test whether type annotations are set properly for a FunctionDef node representing a function definition
+    with type annotations."""
+    # TODO: 2 test cases?... one for args, one for return?
+    assume(function_name not in arguments and len(arguments) == len(annotations) - 1)
+    [assume(annotation is not None) for annotation in annotations]
+    program = _parse_to_annotated_function(function_name
+                                           , arguments, (arguments[0]), annotations)
+    module, inferer = cs._parse_text(program)
+    functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
+    # arguments and annotations are not changing, so test this once.
+    for i in range(len(functiondef_node.args.annotations)):
+        arg_name = functiondef_node.args.args[i].name
+        actual_type = inferer.type_constraints.lookup_concrete(functiondef_node.type_environment.lookup_in_env(arg_name))
+        assert actual_type.__name__ == functiondef_node.args.annotations[i].name
+    # test return type annotations
+    for i in range(len(arguments)):
+        annotations[-1] = annotations[i]
+        program = _parse_to_annotated_function(function_name
+                                               , arguments, (arguments[i]), annotations)
+        module, inferer = cs._parse_text(program)
+        functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
+        expected_arg_type_vars = [functiondef_node.type_environment.lookup_in_env(argument) for argument in arguments]
+        expected_arg_types = [inferer.type_constraints.lookup_concrete(type_var) for type_var in expected_arg_type_vars]
+        function_type_var = module.type_environment.lookup_in_env(function_name)
+        function_type = inferer.type_constraints.lookup_concrete(function_type_var)
+        actual_arg_types, actual_return_type = inferer.type_constraints.types_in_callable(function_type)
+        assert expected_arg_types == actual_arg_types
+
+
+def test_functiondef_annotated_concrete_simple_return():
+    """Test whether type annotations are set properly for a FunctionDef node representing a function definition
+    with type annotations."""
+    program = f'def f(a: str, b: int) -> str:\n' \
+              f'    return a\n' \
+              f''
+    module, inferer = cs._parse_text(program)
+    functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
+    # TODO: convert to hypothesis, can iterate over args[i]
+    arg_name = functiondef_node.args.args[0].name
+    actual_type = inferer.type_constraints.lookup_concrete(functiondef_node.type_environment.lookup_in_env(arg_name))
+    # TODO: hard-coded? better way to test this? WE DO NOT WANT TO USE EVAL (also only works for builtins)
+    assert actual_type.__name__ == functiondef_node.args.annotations[0].name
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Add strategy to generate annotations. 
- Extend FunctionDef node visitor to handle function definition annotations.
- Add test case for function definition annotations.