### PR TITLE
Fix ast patches when there is a syntax error

### DIFF
--- a/python_ta/patches/messages.py
+++ b/python_ta/patches/messages.py
@@ -24,11 +24,12 @@ def patch_linter_transform():
 
     def new_get_ast(self, filepath, modname):
         ast = old_get_ast(self, filepath, modname)
-        with open(filepath) as f:
-            source_code = f.readlines()
-        ending_transformer = TransformVisitor()
-        register_transforms(source_code, ending_transformer)
-        ending_transformer.visit(ast)
+        if ast is not None:
+            with open(filepath) as f:
+                source_code = f.readlines()
+            ending_transformer = TransformVisitor()
+            register_transforms(source_code, ending_transformer)
+            ending_transformer.visit(ast)
         return ast
 
     PyLinter.get_ast = new_get_ast

--- a/python_ta/patches/type.py
+++ b/python_ta/patches/type.py
@@ -9,14 +9,12 @@ def patch_type_inference_transform():
 
     def new_get_ast(self, filepath, modname):
         ast = old_get_ast(self, filepath, modname)
-        type_inferer = TypeInferer()
-        env_transformer = type_inferer.environment_transformer()
-        env_transformer.visit(ast)
-        type_transformer = type_inferer.type_inference_transformer()
-        try:
+        if ast is not None:
+            type_inferer = TypeInferer()
+            env_transformer = type_inferer.environment_transformer()
+            type_transformer = type_inferer.type_inference_transformer()
+            env_transformer.visit(ast)
             type_transformer.visit(ast)
-        except:
-            pass
         return ast
 
     PyLinter.get_ast = new_get_ast

--- a/python_ta/patches/type.py
+++ b/python_ta/patches/type.py
@@ -13,8 +13,11 @@ def patch_type_inference_transform():
             type_inferer = TypeInferer()
             env_transformer = type_inferer.environment_transformer()
             type_transformer = type_inferer.type_inference_transformer()
-            env_transformer.visit(ast)
-            type_transformer.visit(ast)
+            try:
+                env_transformer.visit(ast)
+                type_transformer.visit(ast)
+            except:
+                pass
         return ast
 
     PyLinter.get_ast = new_get_ast


### PR DESCRIPTION
This change allows our transforms to handle the case when a syntax error causes the original `PyLinter.get_ast` method to return `None`.