### PR TITLE
Augment type constraints

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -58,7 +58,7 @@ class TypeInferer:
     def _set_module_environment(self, node):
         """Method to set environment of a Module node."""
         node.type_environment = Environment(
-            globals_={name: self.type_constraints.fresh_tvar() for name in node.globals})
+            globals_={name: self.type_constraints.fresh_tvar(node) for name in node.globals})
         self._populate_local_env(node)
 
     def _set_classdef_environment(self, node):
@@ -230,7 +230,7 @@ class TypeInferer:
                               {arg_types}', node))
 
         try:
-            return_type = self.type_constraints.unify_call(func_type, *arg_types)
+            return_type = self.type_constraints.unify_call(node, func_type, *arg_types)
         except TypeInferenceError:
             return TypeInfo(
                 TypeErrorInfo('Bad unify_call of function {func_call} given\
@@ -292,7 +292,7 @@ class TypeInferer:
                 target_type_tuple = zip(node.targets[0].elts, node.value.elts)
                 for target_node, value in target_type_tuple:
                     target_tvar = node.frame().type_environment.lookup_in_env(target_node.name)
-                    self.type_constraints.unify(target_tvar, value.type_constraints.type)
+                    self.type_constraints.unify(target_tvar, value.type_constraints.type, node)
             else:
                 value_tvar = node.frame().type_environment.lookup_in_env(node.value.name)
                 value_type = self.type_constraints.lookup_concrete(value_tvar)
@@ -306,7 +306,7 @@ class TypeInferer:
                 if isinstance(target_node, astroid.AssignName):
                     target_type_var = self.type_constraints.lookup_concrete(
                         node.frame().type_environment.lookup_in_env(target_node.name))
-                    self.type_constraints.unify(target_type_var, node.value.type_constraints.type)
+                    self.type_constraints.unify(target_type_var, node.value.type_constraints.type, node)
                 elif isinstance(target_node, astroid.AssignAttr):
                     # every Assign node will have a single Name node associated with it
                     attr_type = self.type_constraints.lookup_concrete(

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -132,7 +132,7 @@ class TypeInferer:
     def lookup_type(self, node, name):
         """Given a variable name, return its concrete type in the closest scope relative to given node."""
         tvar = self._closest_frame(node, name).type_environment.lookup_in_env(name)
-        return self.type_constraints.lookup_concrete(tvar)[0]
+        return self.type_constraints.lookup_concrete(tvar)
 
     def visit_const(self, node):
         """Populate type constraints for astroid nodes for num/str/bool/None/bytes literals."""
@@ -206,7 +206,7 @@ class TypeInferer:
             node.type_constraints = TypeInfo(self.lookup_type(node, node.name))
         except KeyError:
             self._closest_frame(node, node.name).type_environment\
-                .create_in_env(self.type_constraints, 'globals', node.name)
+                .create_in_env(self.type_constraints, 'globals', node.name, node)
             node.type_constraints = TypeInfo(self.lookup_type(node, node.name))
 
     ##############################################################################

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -419,7 +419,7 @@ class TypeInferer:
     def visit_annassign(self, node):
         variable_type = self.type_constraints.lookup_concrete(
             self._closest_frame(node, node.target.name).type_environment.lookup_in_env(node.target.name))
-        self.type_constraints.unify(variable_type, _node_to_type(node.annotation.name))
+        self.type_constraints.unify(node, variable_type, _node_to_type(node.annotation.name))
         node.type_constraints = TypeInfo(NoType)
 
     def visit_module(self, node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -419,7 +419,7 @@ class TypeInferer:
     def visit_annassign(self, node):
         variable_type = self.type_constraints.lookup_concrete(
             self._closest_frame(node, node.target.name).type_environment.lookup_in_env(node.target.name))
-        self.type_constraints.unify(node, variable_type, _node_to_type(node.annotation.name))
+        self.type_constraints.unify(variable_type, _node_to_type(node.annotation.name), node)
         node.type_constraints = TypeInfo(NoType)
 
     def visit_module(self, node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -96,7 +96,7 @@ class TypeInferer:
         """Environment setter for SetComp node representing a set comprehension expression"""
         node.type_environment = Environment()
         for name in node.locals:
-            node.type_environment.locals[name] = self.type_constraints.fresh_tvar()
+            node.type_environment.locals[name] = self.type_constraints.fresh_tvar(node)
 
     def _populate_local_env(self, node):
         """Helper to populate locals attributes in type environment of given node."""

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -351,7 +351,7 @@ class TypeInferer:
             func_t = node.func.type_constraints.type
             arg_types = [self.lookup_type(node.func.expr, node.func.expr.name)]
             arg_types += [arg.type_constraints.type for arg in node.args]
-            ret_type = self.type_constraints.unify_call(func_t, *arg_types)
+            ret_type = self.type_constraints.unify_call(node, func_t, *arg_types)
             node.type_constraints = TypeInfo(ret_type)
         else:
             func_name = node.func.name
@@ -359,12 +359,12 @@ class TypeInferer:
                 func_t = self.type_constraints \
                     .lookup_concrete(node.frame().locals[func_name][0].type_environment.locals['__init__'])
                 arg_types = [_ForwardRef(func_name)] + [arg.type_constraints.type for arg in node.args]
-                self.type_constraints.unify_call(func_t, *arg_types)
+                self.type_constraints.unify_call(node, func_t, *arg_types)
                 node.type_constraints = TypeInfo(_ForwardRef(func_name))
             else:
                 func_t = self.lookup_type(node, func_name)
                 arg_types = [arg.type_constraints.type for arg in node.args]
-                ret_type = self.type_constraints.unify_call(func_t, *arg_types)
+                ret_type = self.type_constraints.unify_call(node, func_t, *arg_types)
                 node.type_constraints = TypeInfo(ret_type)
 
     def visit_for(self, node):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -76,7 +76,7 @@ class TypeInferer:
         if node.args.args and node.args.args[0].name == 'self' and isinstance(node.parent, astroid.ClassDef):
             node.type_environment.locals['self'] = _ForwardRef(node.parent.name)
         self._populate_local_env(node)
-        node.type_environment.locals['return'] = self.type_constraints.fresh_tvar()
+        node.type_environment.locals['return'] = self.type_constraints.fresh_tvar(node)
 
     def _set_listcomp_environment(self, node):
         """Set the environment of a ListComp node representing a list

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -190,8 +190,8 @@ class TypeInferer:
         """Helper method to find the closest ancestor node containing name relative to the given node."""
         closest_scope = node
         if hasattr(closest_scope, 'type_environment') and (
-                            name in closest_scope.type_environment.locals or
-                            name in closest_scope.type_environment.globals or
+                        name in closest_scope.type_environment.locals or
+                        name in closest_scope.type_environment.globals or
                         name in closest_scope.type_environment.nonlocals):
             return closest_scope
         if node.parent:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -132,7 +132,7 @@ class TypeInferer:
     def lookup_type(self, node, name):
         """Given a variable name, return its concrete type in the closest scope relative to given node."""
         tvar = self._closest_frame(node, name).type_environment.lookup_in_env(name)
-        return self.type_constraints.lookup_concrete(tvar)
+        return self.type_constraints.lookup_concrete(tvar)[0]
 
     def visit_const(self, node):
         """Populate type constraints for astroid nodes for num/str/bool/None/bytes literals."""
@@ -304,7 +304,7 @@ class TypeInferer:
             # assignment(s) in single statement
             for target_node in node.targets:
                 if isinstance(target_node, astroid.AssignName):
-                    target_type_var = self.lookup_type(target_node.name)
+                    target_type_var = self.lookup_type(target_node, target_node.name)
                     self.type_constraints.unify(target_type_var, node.value.type_constraints.type, node)
                 elif isinstance(target_node, astroid.AssignAttr):
                     # every Assign node will have a single Name node associated with it
@@ -320,7 +320,7 @@ class TypeInferer:
         node.type_constraints = TypeInfo(NoType)
 
     def visit_functiondef(self, node):
-        arg_types = [self.lookup_type(arg) for arg in node.argnames()]
+        arg_types = [self.lookup_type(node, arg) for arg in node.argnames()]
         if any(annotation is not None for annotation in node.args.annotations):
             func_type = parse_annotations(node)
             for arg_type, annotation in zip(arg_types, func_type.__args__[:-1]):
@@ -335,7 +335,7 @@ class TypeInferer:
             if len(list(node.nodes_of_class(astroid.Return))) == 0:
                 func_type = Callable[arg_types, None]
             else:
-                rtype = self.lookup_type('return')
+                rtype = self.lookup_type(node, 'return')
                 func_type = Callable[arg_types, rtype]
             func_type.polymorphic_tvars = [arg for arg in arg_types if isinstance(arg, TypeVar)]
             self.type_constraints.unify(self.lookup_type(node, node.name), func_type, node)
@@ -344,7 +344,7 @@ class TypeInferer:
     def visit_call(self, node):
         if isinstance(node.func, astroid.Attribute):
             func_t = node.func.type_constraints.type
-            arg_types = [self.lookup_type(node.func.expr.name)]
+            arg_types = [self.lookup_type(node.func.expr, node.func.expr.name)]
             arg_types += [arg.type_constraints.type for arg in node.args]
             ret_type = self.type_constraints.unify_call(func_t, *arg_types)
             node.type_constraints = TypeInfo(ret_type)
@@ -357,7 +357,7 @@ class TypeInferer:
                 self.type_constraints.unify_call(func_t, *arg_types)
                 node.type_constraints = TypeInfo(_ForwardRef(func_name))
             else:
-                func_t = self.lookup_type(func_name)
+                func_t = self.lookup_type(node, func_name)
                 arg_types = [arg.type_constraints.type for arg in node.args]
                 ret_type = self.type_constraints.unify_call(func_t, *arg_types)
                 node.type_constraints = TypeInfo(ret_type)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -83,7 +83,7 @@ class TypeInferer:
         comprehension expression."""
         node.type_environment = Environment()
         for name in node.locals:
-            node.type_environment.locals[name] = self.type_constraints.fresh_tvar()
+            node.type_environment.locals[name] = self.type_constraints.fresh_tvar(node)
 
     def _set_dictcomp_environment(self, node):
         """Environment setter for DictComp node representing a dictionary

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -90,7 +90,7 @@ class TypeInferer:
         comprehension expression."""
         node.type_environment = Environment()
         for name in node.locals:
-            node.type_environment.locals[name] = self.type_constraints.fresh_tvar()
+            node.type_environment.locals[name] = self.type_constraints.fresh_tvar(node)
 
     def _set_setcomp_environment(self, node):
         """Environment setter for SetComp node representing a set comprehension expression"""
@@ -104,7 +104,7 @@ class TypeInferer:
             try:
                 var_value = node.type_environment.lookup_in_env(var_name)
             except KeyError:
-                var_value = self.type_constraints.fresh_tvar()
+                var_value = self.type_constraints.fresh_tvar(node)
             node.type_environment.locals[var_name] = var_value
 
     ###########################################################################
@@ -275,7 +275,7 @@ class TypeInferer:
                                                             left_value.type_constraints.type,
                                                             right_value.type_constraints.type)
                 left_value = right_value
-                return_types.add(self.type_constraints.unify_call(function_type, left_value.type_constraints.type,
+                return_types.add(self.type_constraints.unify_call(node, function_type, left_value.type_constraints.type,
                                                               right_value.type_constraints.type))
         if len(return_types) == 1:
             node.type_constraints = TypeInfo(return_types.pop())

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -163,7 +163,6 @@ class TypeConstraints:
             i1, n1 = self._find(t1)
             i2, n2 = self._find(t2)
             if i1 != i2:
-                # TODO: update the tuple containing the tvar being unified (i2)
                 self._sets[i2].remove((t2, n2))
                 self._sets[i2].add((t2, node))
                 self._sets[i1].update(self._sets[i2])

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -160,8 +160,8 @@ class TypeConstraints:
 
     def unify(self, t1, t2, node):
         if isinstance(t1, TypeVar) and isinstance(t2, TypeVar):
-            i1, n1 = self._find(t1)
-            i2, n2 = self._find(t2)
+            i1, _ = self._find(t1)
+            i2, _ = self._find(t2)
             if i1 != i2:
                 self._sets[i1].update(self._sets[i2])
                 self._sets.pop(i2)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -150,10 +150,12 @@ class TypeConstraints:
     def _find(self, t):
         """Return the index of the set containing t."""
         for i, type_node_set in enumerate(self._sets):
-            if t in list(zip(*type_node_set))[0]:
-                for _type, _node in type_node_set:
-                    if t == _type:
-                        return i, _node
+            for j, _tuple in enumerate(type_node_set):
+                if t in tuple(_tuple):
+                    if isinstance(tuple(_tuple)[0], astroid.ALL_NODE_CLASSES):
+                        return i, tuple(_tuple)[0]
+                    else:
+                        return i, tuple(_tuple)[1]
         return -1, None
 
     def unify(self, t1, t2, node):
@@ -311,7 +313,10 @@ class TypeConstraints:
         _set = self._sets[i]
         the_set = []
         for i, _tuple in enumerate(_set):
-            the_set.append(tuple(_tuple)[0])
+            if isinstance(tuple(_tuple)[0], astroid.ALL_NODE_CLASSES):
+                the_set.append(tuple(_tuple)[1])
+            else:
+                the_set.append(tuple(_tuple)[0])
 
         rep = None
         for t in the_set:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -163,8 +163,6 @@ class TypeConstraints:
             i1, n1 = self._find(t1)
             i2, n2 = self._find(t2)
             if i1 != i2:
-                self._sets[i2].remove((t2, n2))
-                self._sets[i2].add((t2, node))
                 self._sets[i1].update(self._sets[i2])
                 self._sets.pop(i2)
         elif isinstance(t1, TypeVar):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -308,7 +308,10 @@ class TypeConstraints:
             return tvar
 
         i, _ = self._find(tvar)
-        the_set = self._sets[i]
+        _set = self._sets[i]
+        the_set = []
+        for i, _tuple in enumerate(_set):
+            the_set.append(tuple(_tuple)[0])
 
         rep = None
         for t in the_set:
@@ -432,14 +435,14 @@ class Environment:
         else:
             raise KeyError
 
-    def create_in_env(self, type_constraints, environment, variable_name):
+    def create_in_env(self, type_constraints, environment, variable_name, node):
         """Helper to create a fresh Type Var and adding the variable to appropriate environment."""
         if environment == 'locals':
-            self.locals[variable_name] = type_constraints.fresh_tvar()
+            self.locals[variable_name] = type_constraints.fresh_tvar(node)
         elif environment == 'globals':
-            self.globals[variable_name] = type_constraints.fresh_tvar()
+            self.globals[variable_name] = type_constraints.fresh_tvar(node)
         elif environment == 'nonlocals':
-            self.nonlocals[variable_name] = type_constraints.fresh_tvar()
+            self.nonlocals[variable_name] = type_constraints.fresh_tvar(node)
 
     def __str__(self):
         return str(self.locals)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -140,35 +140,39 @@ class TypeConstraints:
         self._count = 0
         self._sets = []
 
-
-    def fresh_tvar(self) -> TypeVar:
-        """Return a fresh type variable."""
+    def fresh_tvar(self, node) -> TypeVar:
+        """Return a fresh type variable with the node it was created in."""
         tvar = TypeVar('_T' + str(self._count))
-        self._sets.append({tvar})
+        self._sets.append({(tvar, node)})
         self._count += 1
         return tvar
 
-    def _find(self, t: TypeVar) -> int:
+    def _find(self, t):
         """Return the index of the set containing t."""
-        for i, type_set in enumerate(self._sets):
-            if t in type_set:
-                return i
-        return -1
+        for i, type_node_set in enumerate(self._sets):
+            if t in list(zip(*type_node_set))[0]:
+                for _type, _node in type_node_set:
+                    if t == _type:
+                        return i, _node
+        return -1, None
 
-    def unify(self, t1, t2):
+    def unify(self, t1, t2, node):
         if isinstance(t1, TypeVar) and isinstance(t2, TypeVar):
-            i1 = self._find(t1)
-            i2 = self._find(t2)
+            i1, n1 = self._find(t1)
+            i2, n2 = self._find(t2)
             if i1 != i2:
+                # TODO: update the tuple containing the tvar being unified (i2)
+                self._sets[i2].remove((t2, n2))
+                self._sets[i2].add((t2, node))
                 self._sets[i1].update(self._sets[i2])
                 self._sets.pop(i2)
         elif isinstance(t1, TypeVar):
-            i1 = self._find(t1)
-            self._sets[i1].add(t2)
+            i1, n1 = self._find(t1)
+            self._sets[i1].add((t2, node))
         elif isinstance(t2, TypeVar):
-            self.unify(t2, t1)
+            self.unify(t2, t1, node)
         elif isinstance(t1, GenericMeta) and isinstance(t2, GenericMeta):
-            self._unify_generic(t1, t2)
+            self._unify_generic(t1, t2, node)
         elif isinstance(t1, CallableMeta) and isinstance(t2, CallableMeta):
             rtype = self.unify_call(t1, *t2.__args__[:-1])
             self.unify(rtype, t2.__args__[-1])
@@ -187,13 +191,13 @@ class TypeConstraints:
         elif t1 != t2:
             raise Exception(str(t1) + ' ' + str(t2))
 
-    def _unify_generic(self, t1: GenericMeta, t2: GenericMeta):
+    def _unify_generic(self, t1: GenericMeta, t2: GenericMeta, node):
         """Unify two generic types."""
         if not _geqv(t1, t2):
             raise TypeInferenceError('bad unify')
         elif t1.__args__ is not None and t2.__args__ is not None:
             for a1, a2 in zip(t1.__args__, t2.__args__):
-                self.unify(a1, a2)
+                self.unify(a1, a2, node)
 
     def _unify_tuple(self, t1: TupleMeta, t2: TupleMeta):
         tup1, tup2 = t1.__tuple_params__, t2.__tuple_params__
@@ -205,7 +209,7 @@ class TypeConstraints:
             for elem1, elem2 in zip(tup1, tup2):
                 self.unify(elem1, elem2)
 
-    def unify_call(self, func_type, *arg_types):
+    def unify_call(self, node, func_type, *arg_types):
         """Unify a function call with the given function type and argument types.
 
         Return a result type.
@@ -215,10 +219,10 @@ class TypeConstraints:
             raise TypeInferenceError('Wrong number of arguments')
 
         # Substitute polymorphic type variables
-        new_tvars = {tvar: self.fresh_tvar() for tvar in getattr(func_type, 'polymorphic_tvars', [])}
+        new_tvars = {tvar: self.fresh_tvar(node) for tvar in getattr(func_type, 'polymorphic_tvars', [])}
         new_func_type = literal_substitute(func_type, new_tvars)
         for arg_type, param_type in zip(arg_types, new_func_type.__args__[:-1]):
-            self.unify(arg_type, param_type)
+            self.unify(arg_type, param_type, node)
         return self._type_eval(new_func_type.__args__[-1])
 
     def least_general_unifier(self, t1, t2):
@@ -303,7 +307,7 @@ class TypeConstraints:
         if not isinstance(tvar, TypeVar):
             return tvar
 
-        i = self._find(tvar)
+        i, _ = self._find(tvar)
         the_set = self._sets[i]
 
         rep = None

--- a/tests/test_type_inference/test_annassign.py
+++ b/tests/test_type_inference/test_annassign.py
@@ -19,10 +19,7 @@ def test_annassign_concrete():
               f''
     module, inferer = cs._parse_text(program)
     for node in module.nodes_of_class(astroid.AnnAssign):
-        # variable_type = self._find_type(node, node.target.name)
-        variable_type = inferer.type_constraints.lookup_concrete(
-            inferer._closest_frame(node, node.target.name).type_environment.lookup_in_env(node.target.name))
-        # TODO: we don't want to evaluate.. Just hard code and test builtins?
+        variable_type = inferer.lookup_type(node, node.target.name)
         annotated_type = _node_to_type(node.annotation.name)
         assert variable_type == annotated_type
 
@@ -38,8 +35,7 @@ def test_annassign(variables_annotations_dict):
                f'        pass\n'
     module, inferer = cs._parse_text(program)
     for node in module.nodes_of_class(astroid.AnnAssign):
-        variable_type = inferer.type_constraints.lookup_concrete(
-            inferer._closest_frame(node, node.target.name).type_environment.lookup_in_env(node.target.name))
+        variable_type = inferer.lookup_type(node, node.target.name)
         annotated_type = variables_annotations_dict[node.target.name]
         assert variable_type == annotated_type
 

--- a/tests/test_type_inference/test_assignments.py
+++ b/tests/test_type_inference/test_assignments.py
@@ -54,12 +54,8 @@ def test_set_single_assign(variables_dict):
     program = cs._parse_dictionary_to_program(variables_dict)
     module, inferer = cs._parse_text(program)
     for node in module.nodes_of_class(astroid.AssignName):
-        target_name = node.name
         target_value = node.parent.value
-        # lookup name in the frame's environment
-        target_type_var = node.frame().type_environment.lookup_in_env(target_name)
-        # do a concrete look up of the corresponding TypeVar
-        target_type = inferer.type_constraints.lookup_concrete(target_type_var)
+        target_type = inferer.lookup_type(node, node.name)
         # compare it to the type of the assigned value
         assert target_value.type_constraints.type == target_type
 


### PR DESCRIPTION
- Change structure of TypeConstraints; sets are now composed of tuples of TypeVar and the corresponding Astroid Node that was being visited during unification of the TypeVar.
- Reimplement the relevant operations on the sets of the TypeConstraints; _find, fresh_tvar, create_in_env, unify, can_unify
- Update all calls to changed functions.

--------------------------------------------------

- Decided to refactor the code for AnnAssign nodes in this branch as well as there was a lot of refactoring work to be done of the same nature.
