### PR TITLE
Htmlreport pygments

### DIFF
--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -1,7 +1,4 @@
 import sys
-from pygments import highlight
-from pygments.lexers import PythonLexer
-from pygments.formatters import HtmlFormatter
 from colorama import Fore, Style, Back, init
 from .plain_reporter import PlainReporter
 
@@ -10,6 +7,7 @@ class ColorReporter(PlainReporter):
     _SPACE = ' '
     _BREAK = '\n'
     _COLOURING = {'black': Fore.BLACK,  # or could be empty
+                  'black-line': Fore.BLACK,
                   'bold': Style.BRIGHT,
                   'code-heading': Fore.RED + Style.BRIGHT,
                   'style-heading': Fore.BLUE + Style.BRIGHT,
@@ -17,7 +15,9 @@ class ColorReporter(PlainReporter):
                   'style-name': Fore.BLUE + Style.BRIGHT,
                   'highlight': Style.BRIGHT + Fore.BLACK + Back.CYAN,
                   'grey': Fore.LIGHTBLACK_EX,
+                  'grey-line': Fore.LIGHTBLACK_EX,
                   'gbold': Style.BRIGHT + Fore.LIGHTBLACK_EX,
+                  'gbold-line': Style.BRIGHT + Fore.LIGHTBLACK_EX,
                   'reset': Style.RESET_ALL}
 
     def __init__(self, source_lines=None, module_name=''):
@@ -47,9 +47,7 @@ class ColorReporter(PlainReporter):
         space_count = len(text) - len(new_text)
         if cls._SPACE != ' ':
             new_text = new_text.replace(' ', cls._SPACE)
-        if '-line' not in colour_class:
-            new_text = highlight(new_text, PythonLexer(), HtmlFormatter(nowrap=True, lineseparator=''))
-        return ((space_count * cls._SPACE) + colour + new_text +
+        return ((space_count * cls._SPACE) + colour + cls._vendor_wrap(colour_class, new_text) +
                 cls._COLOURING['reset'])
 
     _display = None   # because PyCharm is annoying about this

--- a/python_ta/reporters/color_reporter.py
+++ b/python_ta/reporters/color_reporter.py
@@ -1,4 +1,7 @@
 import sys
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
 from colorama import Fore, Style, Back, init
 from .plain_reporter import PlainReporter
 
@@ -44,6 +47,8 @@ class ColorReporter(PlainReporter):
         space_count = len(text) - len(new_text)
         if cls._SPACE != ' ':
             new_text = new_text.replace(' ', cls._SPACE)
+        if '-line' not in colour_class:
+            new_text = highlight(new_text, PythonLexer(), HtmlFormatter(nowrap=True, lineseparator=''))
         return ((space_count * cls._SPACE) + colour + new_text +
                 cls._COLOURING['reset'])
 

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -40,14 +40,13 @@ class HTMLReporter(ColorReporter):
     def _messages_shown(self, sorted_messages):
         """Trim the amount of messages according to the default number.
         Add information about the number of occurrences vs number shown."""
-        max_messages = self.linter.config.pyta_number_of_messages
         MessageSet = namedtuple('MessageSet', 'shown occurrences messages')
         ret_sorted = defaultdict()
         for message_key in sorted_messages:
             message_list = []
             for message_tuple_i in sorted_messages[message_key]:
                 # Limit the number of messages shown
-                if len(message_list) < max_messages:
+                if len(message_list) < self.linter.config.pyta_number_of_messages:
                     message_list.append(message_tuple_i)
             ret_sorted[message_key] = MessageSet(shown=len(message_list),
                                                  occurrences=len(sorted_messages[message_key]),

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -40,38 +40,19 @@ class HTMLReporter(ColorReporter):
     def _messages_shown(self, sorted_messages):
         """Trim the amount of messages according to the default number.
         Add information about the number of occurrences vs number shown."""
-
         max_messages = self.linter.config.pyta_number_of_messages
-
         MessageSet = namedtuple('MessageSet', 'shown occurrences messages')
         ret_sorted = defaultdict()
         for message_key in sorted_messages:
-            message_i_instances = []
+            message_list = []
             for message_tuple_i in sorted_messages[message_key]:
                 # Limit the number of messages shown
-                if len(message_i_instances) < max_messages:
-                    message_i_instances.append(message_tuple_i)
-            ret_sorted[message_key] = MessageSet(shown=len(message_i_instances),
+                if len(message_list) < max_messages:
+                    message_list.append(message_tuple_i)
+            ret_sorted[message_key] = MessageSet(shown=len(message_list),
                                                  occurrences=len(sorted_messages[message_key]),
-                                                 messages=message_i_instances)
+                                                 messages=message_list)
         return dict(ret_sorted)
-
-
-
-        # for msg in self._error_messages:
-        #     if len(self._sorted_error_messages[msg.msg_id]) < max_messages:
-        #         self._sorted_error_messages[msg.msg_id].append(msg)
-        #
-        # for msg in self._style_messages:
-        #     if len(self._sorted_style_messages[msg.msg_id]) < max_messages:
-        #         self._sorted_style_messages[msg.msg_id].append(msg)
-
-
-
-        # MessageSet(shown=max_messages,
-        #            occurances=len(sorted_messages),
-        #            sorted_messages=ret_sorted)
-
 
     # Override this method
     def print_messages(self, level='all'):
@@ -97,10 +78,6 @@ class HTMLReporter(ColorReporter):
         with open(os.path.join(TEMPLATES_DIR, 'pyta_logo_markdown.png'), 'rb+') as image_file:
             # Encode img binary to base64 (+33% size), decode to remove the "b'"
             pyta_logo_base64_encoded = b64encode(image_file.read()).decode()
-
-        # Set the max number of messages
-        # max_messages = self.linter.config.pyta_number_of_messages
-        # trim_dict = {key: val for i, (key, val) in enumerate(self.messages_by_file.items()) if i < max_messages}
 
         # Date/time (24 hour time) format:
         # Generated: ShortDay. ShortMonth. PaddedDay LongYear, Hour:Min:Sec

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -13,17 +13,17 @@ TEMPLATE_FILE = 'template.html'
 OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
-    _COLOURING = {'black': '<span class="black">',
+    _COLOURING = {'black': '<span class="black syntax-python">',
                   'black-line': '<span class="black line-num">',
                   'bold': '<span>',
                   'code-heading': '<span>',
                   'style-heading': '<span>',
                   'code-name': '<span>',
                   'style-name': '<span>',
-                  'highlight': '<span class="highlight">',
-                  'grey': '<span class="grey">',
+                  'highlight': '<span class="highlight syntax-python">',
+                  'grey': '<span class="grey syntax-python">',
                   'grey-line': '<span class="grey line-num">',
-                  'gbold': '<span class="gbold">',
+                  'gbold': '<span class="gbold syntax-python">',
                   'gbold-line': '<span class="gbold line-num">',
                   'reset': '</span>'}
     code_err_title = 'Code Errors or Forbidden Usage (fix: high priority)'

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -6,6 +6,10 @@ from jinja2 import Environment, FileSystemLoader
 from datetime import datetime
 from base64 import b64encode
 
+from pygments import highlight
+from pygments.lexers import PythonLexer
+from pygments.formatters import HtmlFormatter
+
 from .color_reporter import ColorReporter
 
 TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'templates')
@@ -20,7 +24,7 @@ class HTMLReporter(ColorReporter):
                   'style-heading': '<span>',
                   'code-name': '<span>',
                   'style-name': '<span>',
-                  'highlight': '<span class="highlight">',
+                  'highlight': '<span class="highlight-pyta">',
                   'grey': '<span class="grey">',
                   'grey-line': '<span class="grey line-num">',
                   'gbold': '<span class="gbold">',
@@ -69,5 +73,13 @@ class HTMLReporter(ColorReporter):
         print('Opening your report in a browser...')
         output_url = 'file:///{}'.format(output_path)
         webbrowser.open(output_url)
+
+    @classmethod
+    def _vendor_wrap(self, colour_class, text):
+        """Override in reporters that wrap snippet lines in vendor styles, e.g. pygments."""
+        if '-line' not in colour_class:
+            text = highlight(text, PythonLexer(),
+                            HtmlFormatter(nowrap=True, lineseparator='', classprefix='pygments-'))
+        return text
 
     _display = None

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -13,9 +13,8 @@ TEMPLATE_FILE = 'template.html'
 OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
-    _SPACE = '&nbsp;'
-    _BREAK = '<br/>'
     _COLOURING = {'black': '<span class="black">',
+                  'black-line': '<span class="black line-num">',
                   'bold': '<span>',
                   'code-heading': '<span>',
                   'style-heading': '<span>',
@@ -23,7 +22,9 @@ class HTMLReporter(ColorReporter):
                   'style-name': '<span>',
                   'highlight': '<span class="highlight">',
                   'grey': '<span class="grey">',
+                  'grey-line': '<span class="grey line-num">',
                   'gbold': '<span class="gbold">',
+                  'gbold-line': '<span class="gbold line-num">',
                   'reset': '</span>'}
     code_err_title = 'Code Errors or Forbidden Usage (fix: high priority)'
     style_err_title = 'Style or Convention Errors (fix: before submission)'

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -13,17 +13,17 @@ TEMPLATE_FILE = 'template.html'
 OUTPUT_FILE = 'output.html'
 
 class HTMLReporter(ColorReporter):
-    _COLOURING = {'black': '<span class="black syntax-python">',
+    _COLOURING = {'black': '<span class="black">',
                   'black-line': '<span class="black line-num">',
                   'bold': '<span>',
                   'code-heading': '<span>',
                   'style-heading': '<span>',
                   'code-name': '<span>',
                   'style-name': '<span>',
-                  'highlight': '<span class="highlight syntax-python">',
-                  'grey': '<span class="grey syntax-python">',
+                  'highlight': '<span class="highlight">',
+                  'grey': '<span class="grey">',
                   'grey-line': '<span class="grey line-num">',
-                  'gbold': '<span class="gbold syntax-python">',
+                  'gbold': '<span class="gbold">',
                   'gbold-line': '<span class="gbold line-num">',
                   'reset': '</span>'}
     code_err_title = 'Code Errors or Forbidden Usage (fix: high priority)'

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -297,8 +297,6 @@ class PlainReporter(BaseReporter):
         elif linetype == LineType.OTHER:
             return spaces + self._colourify('grey-line', number) + spaces
         elif linetype == LineType.DOCSTRING:
-            # import sys
-            # sys.exit()
             return spaces + self._colourify('black-line', number) + spaces
         else:
             return spaces + number + spaces
@@ -313,3 +311,8 @@ class PlainReporter(BaseReporter):
         """Override in reporters that output collections of messages once at
         the end of linting all files, rather than stream to std.out"""
         pass
+
+    @classmethod
+    def _vendor_wrap(self, colour_class, text):
+        """Override in reporters that wrap snippet lines in vendor styles, e.g. pygments."""
+        return text

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -117,9 +117,15 @@ class PlainReporter(BaseReporter):
 
     def sort_messages(self):
         """Sort the messages by their type (message id)."""
+
+        # max_messages = self.linter.config.pyta_number_of_messages
+
         for msg in self._error_messages:
+            # if len(self._sorted_error_messages[msg.msg_id]) < max_messages:
             self._sorted_error_messages[msg.msg_id].append(msg)
+
         for msg in self._style_messages:
+            # if len(self._sorted_style_messages[msg.msg_id]) < max_messages:
             self._sorted_style_messages[msg.msg_id].append(msg)
 
     def set_output_filepath(self, output_filepath_arg):

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -265,9 +265,11 @@ class PlainReporter(BaseReporter):
         end_col = slice_.stop or len(text)
 
         if linetype == LineType.ERROR:
-            snippet += self._colourify('black', text[:start_col])
+            if text[:start_col]:
+                snippet += self._colourify('black', text[:start_col])
             snippet += self._colourify('highlight', text[slice_])
-            snippet += self._colourify('black', text[end_col:])
+            if text[end_col:]:
+                snippet += self._colourify('black', text[end_col:])
         elif linetype == LineType.CONTEXT:
             snippet += self._colourify('grey', text)
         elif linetype == LineType.OTHER:
@@ -289,13 +291,15 @@ class PlainReporter(BaseReporter):
             number = 3 * self._SPACE
 
         if linetype == LineType.ERROR:
-            return spaces + self._colourify('gbold', number) + spaces
+            return spaces + self._colourify('gbold-line', number) + spaces
         elif linetype == LineType.CONTEXT:
-            return spaces + self._colourify('grey', number) + spaces
+            return spaces + self._colourify('grey-line', number) + spaces
         elif linetype == LineType.OTHER:
-            return spaces + self._colourify('grey', number) + spaces
+            return spaces + self._colourify('grey-line', number) + spaces
         elif linetype == LineType.DOCSTRING:
-            return spaces + self._colourify('black', number) + spaces
+            # import sys
+            # sys.exit()
+            return spaces + self._colourify('black-line', number) + spaces
         else:
             return spaces + number + spaces
 

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -117,15 +117,9 @@ class PlainReporter(BaseReporter):
 
     def sort_messages(self):
         """Sort the messages by their type (message id)."""
-
-        # max_messages = self.linter.config.pyta_number_of_messages
-
         for msg in self._error_messages:
-            # if len(self._sorted_error_messages[msg.msg_id]) < max_messages:
             self._sorted_error_messages[msg.msg_id].append(msg)
-
         for msg in self._style_messages:
-            # if len(self._sorted_style_messages[msg.msg_id]) < max_messages:
             self._sorted_style_messages[msg.msg_id].append(msg)
 
     def set_output_filepath(self, output_filepath_arg):

--- a/python_ta/reporters/templates/script.js
+++ b/python_ta/reporters/templates/script.js
@@ -1,3 +1,3 @@
 $("body").on("click", ".slider", function () {
-    $(this).parent().next().slideToggle(500, function () {});
+    $(this).parent().next().toggleClass("hide-and-maintain-width");
 });

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -1,4 +1,5 @@
 body {
+    margin: 0;
 	font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Helvetica Neue,Helvetica,Ubuntu,Arial,sans-serif;
     background: rgba(71, 118, 230, 0.77);
     background: -webkit-linear-gradient(0deg, rgba(49, 48, 178, 0.62), rgba(71, 128, 230, 0.77));
@@ -12,6 +13,11 @@ header {
     -webkit-font-smoothing: antialiased;
     color: #fff;
     text-align: center;
+}
+
+code {
+    white-space: pre;
+    font-size: 120%;
 }
 
 .title {
@@ -31,6 +37,7 @@ time {
 
 main {
     display: grid;
+    overflow: auto;
 }
 
 section {
@@ -39,44 +46,48 @@ section {
 	display: inline-block;
 	font-size: 12px;
 	min-width: 50%;
-	background: rgb(219, 219, 219);
+	background: rgba(234, 233, 233, 0.25);
     box-shadow: -1px 9px 15px -5px rgba(77,77,77,0.6);
 }
 
 .file-name {
     display: flex;
     padding: 0 15px;
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.9);
+    text-shadow: 0px 1px 2px black;
     background: #141E30;
-    background: linear-gradient(to right, #243B55, #141E30);
-    background: -webkit-linear-gradient(left, #243B55, #141E30);
+    background: linear-gradient(to left, rgba(36, 59, 85, 0.67), rgba(20, 30, 48, 0.77));
+    background: -webkit-linear-gradient(right, rgba(36, 59, 85, 0.67), rgba(20, 30, 48, 0.77));
 }
 
 .error-output {
-    padding: 0 15px 15px 15px;
+    padding: 0 15px;
 }
 
 .code-errors {
 }
 
 .style-errors {
-    border-top: 3px solid rgba(0,0,0,.2);
+    border-top: 3px solid rgba(255, 255, 255, 0.25);
 }
 
 .category-heading {
     display: flex;  /*Narrow width viewports*/
+    -webkit-font-smoothing: antialiased;
+    color: white;
 }
 
 .error-instance {
     display: grid;
     background: #fff;
-    padding: 5px;
+    box-shadow: 0 0 4px rgba(0, 0, 0, 0.1), 0 4px 7px rgba(0, 0, 0, 0.1);
+    padding: 8px 16px;
     margin-bottom: 5px;
     border-radius: 3px;
 }
 
 .error-link {
-    vertical-align: middle;
+    /*vertical-align: middle;*/
 }
 
 .error-link a {
@@ -106,10 +117,6 @@ section {
 .style-error-id a:link {
 }
 
-pre {
-    font-size: 120%;
-}
-
 .line-num {
     font-size: 80%;
     opacity: 0.6;
@@ -126,7 +133,8 @@ pre {
 
 .highlight {
     font-weight: bold;
-    background-color: rgba(228, 255, 0, 0.45);
+    background-color: rgba(228, 255, 0, 0.45) !important;
+    background: rgba(228, 255, 0, 0.45) !important;
 }
 
 .black {
@@ -137,6 +145,15 @@ pre {
     text-align: center;
 	font-size: 75%;
 	padding: 20px;
+}
+#report-bug a {
+    text-decoration: none;
+    color: white;
+    font-weight: bold;
+    letter-spacing: 1px;
+}
+#report-bug a:hover {
+    text-decoration: underline;
 }
 
 #logo {
@@ -181,12 +198,21 @@ pre {
     /*width: 100%;*/
 }
 
+/*display none caused width of parent to shrink when longer text messages are hidden*/
+.collapsible.hide-and-maintain-width {
+    visibility: hidden;
+    height: 0;
+    margin: 0;
+    padding: 0;
+}
+
 .content {
+    margin-bottom: 15px;
 }
 
 .message-container{
-    border-top: 1px solid rgba(0, 0, 0, 0.2);
-    margin-top: 5px;
+    border-top: 1px solid rgba(0, 0, 0, 0.15);
+    margin: 8px 0;
 }
 
 .message-name {
@@ -196,4 +222,11 @@ pre {
 .empty-placeholder {
     font-style: italic;
     padding-left: 20px;
+}
+
+footer {
+    background: #2d3441;
+    color: white;
+    padding: 30px;
+    margin-top: 40px;
 }

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -64,6 +64,7 @@ section {
 }
 
 .category-heading {
+    display: flex;  /*Narrow width viewports*/
 }
 
 .error-instance {
@@ -109,6 +110,11 @@ pre {
     font-size: 120%;
 }
 
+.line-num {
+    font-size: 80%;
+    opacity: 0.6;
+}
+
 .grey {
     color: rgb(119, 119, 120);
 }
@@ -147,10 +153,11 @@ pre {
 
 .info {
     font-size: 110%;
+    display: flex;  /*Narrow width viewports*/
 }
 
 .slider {
-    float: right;
+    margin-left: auto;
 }
 
 .slider button {
@@ -171,7 +178,7 @@ pre {
 }
 
 .collapsible {
-    width: 100%;
+    /*width: 100%;*/
 }
 
 .content {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -133,9 +133,7 @@ section {
 
 .highlight-pyta {
     font-weight: bold;
-    border: 1px solid #FF0000;
-    background-color: rgba(228, 255, 0, 0.45) !important;
-    background: rgba(228, 255, 0, 0.45) !important;
+    background: rgba(228, 255, 0, 0.4) !important;
 }
 
 .black {
@@ -164,7 +162,7 @@ section {
     padding-top: 10px;
 }
 
-.occurrences {
+.occurrences, .shown {
     line-height: 25px;
     padding-left: 20px;
     vertical-align: middle;

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -230,3 +230,85 @@ footer {
     padding: 30px;
     margin-top: 40px;
 }
+
+
+
+.highlight {
+    display: inline;
+}
+
+.highlight pre {
+    display: inline;
+}
+
+
+
+.highlight .hll { background-color: #ffffcc }
+.highlight  { background: #f8f8f8; }
+.highlight .c { color: #408080; font-style: italic } /* Comment */
+.highlight .err { border: 1px solid #FF0000 } /* Error */
+.highlight .k { color: #008000; font-weight: bold } /* Keyword */
+.highlight .o { color: #666666 } /* Operator */
+.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
+.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
+.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
+.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
+.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
+.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
+.highlight .gd { color: #A00000 } /* Generic.Deleted */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gr { color: #FF0000 } /* Generic.Error */
+.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
+.highlight .gi { color: #00A000 } /* Generic.Inserted */
+.highlight .go { color: #888888 } /* Generic.Output */
+.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
+.highlight .gt { color: #0044DD } /* Generic.Traceback */
+.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
+.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
+.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
+.highlight .kp { color: #008000 } /* Keyword.Pseudo */
+.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
+.highlight .kt { color: #B00040 } /* Keyword.Type */
+.highlight .m { color: #666666 } /* Literal.Number */
+.highlight .s { color: #BA2121 } /* Literal.String */
+.highlight .na { color: #7D9029 } /* Name.Attribute */
+.highlight .nb { color: #008000 } /* Name.Builtin */
+.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
+.highlight .no { color: #880000 } /* Name.Constant */
+.highlight .nd { color: #AA22FF } /* Name.Decorator */
+.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
+.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
+.highlight .nf { color: #0000FF } /* Name.Function */
+.highlight .nl { color: #A0A000 } /* Name.Label */
+.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
+.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
+.highlight .nv { color: #19177C } /* Name.Variable */
+.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
+.highlight .w { color: #bbbbbb } /* Text.Whitespace */
+.highlight .mb { color: #666666 } /* Literal.Number.Bin */
+.highlight .mf { color: #666666 } /* Literal.Number.Float */
+.highlight .mh { color: #666666 } /* Literal.Number.Hex */
+.highlight .mi { color: #666666 } /* Literal.Number.Integer */
+.highlight .mo { color: #666666 } /* Literal.Number.Oct */
+.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
+.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
+.highlight .sc { color: #BA2121 } /* Literal.String.Char */
+.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
+.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
+.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
+.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
+.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
+.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
+.highlight .sx { color: #008000 } /* Literal.String.Other */
+.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
+.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
+.highlight .ss { color: #19177C } /* Literal.String.Symbol */
+.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
+.highlight .fm { color: #0000FF } /* Name.Function.Magic */
+.highlight .vc { color: #19177C } /* Name.Variable.Class */
+.highlight .vg { color: #19177C } /* Name.Variable.Global */
+.highlight .vi { color: #19177C } /* Name.Variable.Instance */
+.highlight .vm { color: #19177C } /* Name.Variable.Magic */
+.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -87,7 +87,7 @@ section {
 }
 
 .error-link {
-    /*vertical-align: middle;*/
+    line-height: 25px;
 }
 
 .error-link a {
@@ -123,7 +123,7 @@ section {
 }
 
 .grey {
-    color: rgb(119, 119, 120);
+    color: rgb(87, 87, 87);
 }
 
 .gbold{
@@ -131,8 +131,9 @@ section {
     font-weight: bold;
 }
 
-.highlight {
+.highlight-pyta {
     font-weight: bold;
+    border: 1px solid #FF0000;
     background-color: rgba(228, 255, 0, 0.45) !important;
     background: rgba(228, 255, 0, 0.45) !important;
 }
@@ -164,6 +165,7 @@ section {
 }
 
 .occurrences {
+    line-height: 25px;
     padding-left: 20px;
     vertical-align: middle;
 }
@@ -233,82 +235,293 @@ footer {
 
 
 
-.highlight {
-    display: inline;
-}
+/*  Pygments css. Edited and reformatted from original output.
+    Unfortunately the class names cannot be improved to semantic names.
+*/
+.pygments-hll {
+    background-color: #ffffcc;
+} /* ? */
 
-.highlight pre {
-    display: inline;
-}
+.pygments-c {
+    color: #999;
+} /* Comment */
 
+.pygments-err {
+    /*border: 1px solid #FF0000;*/
+} /* Error */
 
+.pygments-k {
+    color: #AA22FF;
+    font-weight: bold;
+} /* Keyword */
 
-.highlight .hll { background-color: #ffffcc }
-.highlight  { background: #f8f8f8; }
-.highlight .c { color: #408080; font-style: italic } /* Comment */
-.highlight .err { border: 1px solid #FF0000 } /* Error */
-.highlight .k { color: #008000; font-weight: bold } /* Keyword */
-.highlight .o { color: #666666 } /* Operator */
-.highlight .ch { color: #408080; font-style: italic } /* Comment.Hashbang */
-.highlight .cm { color: #408080; font-style: italic } /* Comment.Multiline */
-.highlight .cp { color: #BC7A00 } /* Comment.Preproc */
-.highlight .cpf { color: #408080; font-style: italic } /* Comment.PreprocFile */
-.highlight .c1 { color: #408080; font-style: italic } /* Comment.Single */
-.highlight .cs { color: #408080; font-style: italic } /* Comment.Special */
-.highlight .gd { color: #A00000 } /* Generic.Deleted */
-.highlight .ge { font-style: italic } /* Generic.Emph */
-.highlight .gr { color: #FF0000 } /* Generic.Error */
-.highlight .gh { color: #000080; font-weight: bold } /* Generic.Heading */
-.highlight .gi { color: #00A000 } /* Generic.Inserted */
-.highlight .go { color: #888888 } /* Generic.Output */
-.highlight .gp { color: #000080; font-weight: bold } /* Generic.Prompt */
-.highlight .gs { font-weight: bold } /* Generic.Strong */
-.highlight .gu { color: #800080; font-weight: bold } /* Generic.Subheading */
-.highlight .gt { color: #0044DD } /* Generic.Traceback */
-.highlight .kc { color: #008000; font-weight: bold } /* Keyword.Constant */
-.highlight .kd { color: #008000; font-weight: bold } /* Keyword.Declaration */
-.highlight .kn { color: #008000; font-weight: bold } /* Keyword.Namespace */
-.highlight .kp { color: #008000 } /* Keyword.Pseudo */
-.highlight .kr { color: #008000; font-weight: bold } /* Keyword.Reserved */
-.highlight .kt { color: #B00040 } /* Keyword.Type */
-.highlight .m { color: #666666 } /* Literal.Number */
-.highlight .s { color: #BA2121 } /* Literal.String */
-.highlight .na { color: #7D9029 } /* Name.Attribute */
-.highlight .nb { color: #008000 } /* Name.Builtin */
-.highlight .nc { color: #0000FF; font-weight: bold } /* Name.Class */
-.highlight .no { color: #880000 } /* Name.Constant */
-.highlight .nd { color: #AA22FF } /* Name.Decorator */
-.highlight .ni { color: #999999; font-weight: bold } /* Name.Entity */
-.highlight .ne { color: #D2413A; font-weight: bold } /* Name.Exception */
-.highlight .nf { color: #0000FF } /* Name.Function */
-.highlight .nl { color: #A0A000 } /* Name.Label */
-.highlight .nn { color: #0000FF; font-weight: bold } /* Name.Namespace */
-.highlight .nt { color: #008000; font-weight: bold } /* Name.Tag */
-.highlight .nv { color: #19177C } /* Name.Variable */
-.highlight .ow { color: #AA22FF; font-weight: bold } /* Operator.Word */
-.highlight .w { color: #bbbbbb } /* Text.Whitespace */
-.highlight .mb { color: #666666 } /* Literal.Number.Bin */
-.highlight .mf { color: #666666 } /* Literal.Number.Float */
-.highlight .mh { color: #666666 } /* Literal.Number.Hex */
-.highlight .mi { color: #666666 } /* Literal.Number.Integer */
-.highlight .mo { color: #666666 } /* Literal.Number.Oct */
-.highlight .sa { color: #BA2121 } /* Literal.String.Affix */
-.highlight .sb { color: #BA2121 } /* Literal.String.Backtick */
-.highlight .sc { color: #BA2121 } /* Literal.String.Char */
-.highlight .dl { color: #BA2121 } /* Literal.String.Delimiter */
-.highlight .sd { color: #BA2121; font-style: italic } /* Literal.String.Doc */
-.highlight .s2 { color: #BA2121 } /* Literal.String.Double */
-.highlight .se { color: #BB6622; font-weight: bold } /* Literal.String.Escape */
-.highlight .sh { color: #BA2121 } /* Literal.String.Heredoc */
-.highlight .si { color: #BB6688; font-weight: bold } /* Literal.String.Interpol */
-.highlight .sx { color: #008000 } /* Literal.String.Other */
-.highlight .sr { color: #BB6688 } /* Literal.String.Regex */
-.highlight .s1 { color: #BA2121 } /* Literal.String.Single */
-.highlight .ss { color: #19177C } /* Literal.String.Symbol */
-.highlight .bp { color: #008000 } /* Name.Builtin.Pseudo */
-.highlight .fm { color: #0000FF } /* Name.Function.Magic */
-.highlight .vc { color: #19177C } /* Name.Variable.Class */
-.highlight .vg { color: #19177C } /* Name.Variable.Global */
-.highlight .vi { color: #19177C } /* Name.Variable.Instance */
-.highlight .vm { color: #19177C } /* Name.Variable.Magic */
-.highlight .il { color: #666666 } /* Literal.Number.Integer.Long */
+.pygments-o {
+    color: #666666;
+} /* Operator */
+
+.pygments-ch {
+    color: #408080;
+} /* Comment.Hashbang */
+
+.pygments-cm {
+    color: #999;
+} /* Comment.Multiline */
+
+.pygments-cp {
+    color: #BC7A00;
+} /* Comment.Preproc */
+
+.pygments-cpf {
+    color: #408080;
+} /* Comment.PreprocFile */
+
+.pygments-c1 {
+    color: #999;
+} /* Comment.Single */
+
+.pygments-cs {
+    color: #999;
+} /* Comment.Special */
+
+.pygments-gd {
+    color: #A00000;
+} /* Generic.Deleted */
+
+.pygments-ge {
+    font-style: italic;
+} /* Generic.Emph */
+
+.pygments-gr {
+    color: #FF0000;
+} /* Generic.Error */
+
+.pygments-gh {
+    color: #000080;
+    font-weight: bold;
+} /* Generic.Heading */
+
+.pygments-gi {
+    color: #00A000;
+} /* Generic.Inserted */
+
+.pygments-go {
+    color: #888888;
+} /* Generic.Output */
+
+.pygments-gp {
+    color: #000080;
+    font-weight: bold;
+} /* Generic.Prompt */
+
+.pygments-gs {
+    font-weight: bold;
+} /* Generic.Strong */
+
+.pygments-gu {
+    color: #800080;
+    font-weight: bold;
+} /* Generic.Subheading */
+
+.pygments-gt {
+    color: #0044DD;
+} /* Generic.Traceback */
+
+.pygments-kc {
+    color: #008000;
+    font-weight: bold;
+} /* Keyword.Constant */
+
+.pygments-kd {
+    color: #008000;
+    font-weight: bold;
+} /* Keyword.Declaration */
+
+.pygments-kn {
+    color: #008000;
+    font-weight: bold;
+} /* Keyword.Namespace */
+
+.pygments-kp {
+    color: #008000;
+} /* Keyword.Pseudo */
+
+.pygments-kr {
+    color: #008000;
+    font-weight: bold;
+} /* Keyword.Reserved */
+
+.pygments-kt {
+    color: #B00040;
+} /* Keyword.Type */
+
+.pygments-m {
+    color: #666666;
+} /* Literal.Number */
+
+.pygments-s {
+    color: #BA2121;
+} /* Literal.String */
+
+.pygments-na {
+    color: #7D9029;
+} /* Name.Attribute */
+
+.pygments-nb {
+    color: #008000;
+} /* Name.Builtin */
+
+.pygments-nc {
+    color: #0000FF;
+    font-weight: bold;
+} /* Name.Class */
+
+.pygments-no {
+    color: #880000;
+} /* Name.Constant */
+
+.pygments-nd {
+    color: #AA22FF;
+} /* Name.Decorator */
+
+.pygments-ni {
+    color: #999999;
+    font-weight: bold;
+} /* Name.Entity */
+
+.pygments-ne {
+    color: #D2413A;
+    font-weight: bold;
+} /* Name.Exception */
+
+.pygments-nf {
+    color: #0000FF;
+} /* Name.Function */
+
+.pygments-nl {
+    color: #A0A000;
+} /* Name.Label */
+
+.pygments-nn {
+    color: #0000FF;
+    font-weight: bold;
+} /* Name.Namespace */
+
+.pygments-nt {
+    color: #008000;
+    font-weight: bold;
+} /* Name.Tag */
+
+.pygments-nv {
+    color: #19177C;
+} /* Name.Variable */
+
+.pygments-ow {
+    color: #AA22FF;
+    font-weight: bold;
+} /* Operator.Word */
+
+.pygments-w {
+    color: #bbbbbb;
+} /* Text.Whitespace */
+
+.pygments-mb {
+    color: #075cc6;
+} /* Literal.Number.Bin */
+
+.pygments-mf {
+    color: #075cc6;
+} /* Literal.Number.Float */
+
+.pygments-mh {
+    color: #075cc6;
+} /* Literal.Number.Hex */
+
+.pygments-mi {
+    color: #075cc6;
+} /* Literal.Number.Integer */
+
+.pygments-mo {
+    color: #075cc6;
+} /* Literal.Number.Oct */
+
+.pygments-sa {
+    color: #059911;
+} /* Literal.String.Affix */
+
+.pygments-sb {
+    color: #059911;
+} /* Literal.String.Backtick */
+
+.pygments-sc {
+    color: #059911;
+} /* Literal.String.Char */
+
+.pygments-dl {
+    color: #059911;
+} /* Literal.String.Delimiter */
+
+.pygments-sd {
+    color: #059911;
+} /* Literal.String.Doc */
+
+.pygments-s2 {
+    color: #059911;
+} /* Literal.String.Double */
+
+.pygments-se {
+    color: #BB6622;
+    font-weight: bold;
+} /* Literal.String.Escape */
+
+.pygments-sh {
+    color: #059911;
+} /* Literal.String.Heredoc */
+
+.pygments-si {
+    color: #BB6688;
+    font-weight: bold;
+} /* Literal.String.Interpol */
+
+.pygments-sx {
+    color: #008000;
+} /* Literal.String.Other */
+
+.pygments-sr {
+    color: #BB6688;
+} /* Literal.String.Regex */
+
+.pygments-s1 {
+    color: #059911;
+} /* Literal.String.Single */
+
+.pygments-ss {
+    color: #19177C;
+} /* Literal.String.Symbol */
+
+.pygments-bp {
+    color: #008000;
+} /* Name.Builtin.Pseudo */
+
+.pygments-fm {
+    color: #0000FF;
+} /* Name.Function.Magic */
+
+.pygments-vc {
+    color: #19177C;
+} /* Name.Variable.Class */
+
+.pygments-vg {
+    color: #19177C;
+} /* Name.Variable.Global */
+
+.pygments-vi {
+    color: #19177C;
+} /* Name.Variable.Instance */
+
+.pygments-vm {
+    color: #19177C;
+} /* Name.Variable.Magic */
+
+.pygments-il {
+    color: #666666;
+} /* Literal.Number.Integer.Long */

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -33,7 +33,12 @@
                                     <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">&#10064; {{ message }} ({{ file.code[message][0].symbol }})</a>
                                 </span>
                                 <span class="occurrences">
-                                {{ file.code[message]|length }} occurrences.
+                                {{ file.code[message]|length }}
+                                {% if file.code[message]|length == 1 %}
+                                 occurrence.
+                                {% else %}
+                                 occurrences.
+                                {% endif %}
                                 </span>
                                 <span class="slider">
                                     <button> Expand/Collapse </button>
@@ -75,7 +80,12 @@
                                     <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">&#10064; {{ message }} ({{ file.style[message][0].symbol }})</a>
                                 </span>
                                 <span class="occurrences">
-                                {{ file.style[message]|length }} occurrences.
+                                {{ file.style[message]|length }}
+                                {% if file.style[message]|length == 1 %}
+                                 occurrence.
+                                {% else %}
+                                 occurrences.
+                                {% endif %}
                                 </span>
                                 <span class="slider">
                                    <button> Expand/Collapse </button>

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -26,18 +26,23 @@
                         </span>
                     </h3>
                     <div class="content collapsible">
-                        {% for message in file.code %}
+                        {% for message_id in file.code %}
                         <div class="error-instance">
                             <div class="info">
                                 <span class="error-link code-error-id">
-                                    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">&#10064; {{ message }} ({{ file.code[message][0].symbol }})</a>
+                                    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message_id}}" target="_blank">&#10064; {{ message_id }} ({{ file.code[message_id].messages[0].symbol }})</a>
                                 </span>
                                 <span class="occurrences">
-                                {{ file.code[message]|length }}
-                                {% if file.code[message]|length == 1 %}
+                                {{ file.code[message_id].occurrences }}
+                                {% if file.code[message_id].occurrences == 1 %}
                                  occurrence.
                                 {% else %}
                                  occurrences.
+                                {% endif %}
+                                </span>
+                                <span class="shown">
+                                {% if file.code[message_id].shown != file.code[message_id].occurrences %}
+                                 (First {{ file.code[message_id].shown }} shown).
                                 {% endif %}
                                 </span>
                                 <span class="slider">
@@ -45,7 +50,7 @@
                                 </span>
                             </div>
                             <div class="message-container collapsible">
-                                {% for indiv in file.code[message] %}
+                                {% for indiv in file.code[message_id].messages %}
                                 <div class="message">
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
@@ -53,7 +58,7 @@
                                     {% if indiv.snippet != '' %}
                                     <code>{{ indiv.snippet }}</code>
                                     {% else %}
-                                    <span class="empty-placeholder">{{ indiv.snippet }}</span>
+                                    <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}
                                 </div>
                                 {% endfor %}
@@ -72,19 +77,24 @@
                         </span>
                     </h3>
                     <div class="content collapsible">
-                        {% for message in file.style %}
+                        {% for message_id in file.style %}
                         <div class="error-instance">
 
                             <div class="info">
                                 <span class="error-link style-error-id">
-                                    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message}}" target="_blank">&#10064; {{ message }} ({{ file.style[message][0].symbol }})</a>
+                                    <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message_id}}" target="_blank">&#10064; {{ message_id }} ({{ file.style[message_id].messages[0].symbol }})</a>
                                 </span>
                                 <span class="occurrences">
-                                {{ file.style[message]|length }}
-                                {% if file.style[message]|length == 1 %}
+                                {{ file.style[message_id].occurrences }}
+                                {% if file.style[message_id].occurrences == 1 %}
                                  occurrence.
                                 {% else %}
                                  occurrences.
+                                {% endif %}
+                                </span>
+                                <span class="shown">
+                                {% if file.style[message_id].shown != file.style[message_id].occurrences %}
+                                 (First {{ file.style[message_id].shown }} shown).
                                 {% endif %}
                                 </span>
                                 <span class="slider">
@@ -93,7 +103,7 @@
                             </div>
 
                             <div class="message-container collapsible">
-                                {% for indiv in file.style[message] %}
+                                {% for indiv in file.style[message_id].messages %}
                                 <div class="message">
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
@@ -101,7 +111,7 @@
                                     {% if indiv.snippet != '' %}
                                     <code>{{ indiv.snippet }}</code>
                                     {% else %}
-                                    <span class="empty-placeholder">{{ indiv.snippet }}</span>
+                                    <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}
                                 </div>
                                 {% endfor %}

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -53,7 +53,7 @@
                                     {% if indiv.snippet != '' %}
                                     <code>{{ indiv.snippet }}</code>
                                     {% else %}
-                                    <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
+                                    <span class="empty-placeholder">{{ indiv.snippet }}</span>
                                     {% endif %}
                                 </div>
                                 {% endfor %}
@@ -101,7 +101,7 @@
                                     {% if indiv.snippet != '' %}
                                     <code>{{ indiv.snippet }}</code>
                                     {% else %}
-                                    <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
+                                    <span class="empty-placeholder">{{ indiv.snippet }}</span>
                                     {% endif %}
                                 </div>
                                 {% endfor %}

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -19,12 +19,12 @@
                     <h2> {{ file.filename }} </h2>
                 </article>
                 <article class="error-output code-errors">
-                    <h2 class="category-heading">
+                    <h3 class="category-heading">
                         <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
                             <button>Expand/Collapse Section</button>
                         </span>
-                    </h2>
+                    </h3>
                     <div class="content collapsible">
                         {% for message in file.code %}
                         <div class="error-instance">
@@ -51,7 +51,7 @@
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                     </h4>
                                     {% if indiv.snippet != '' %}
-                                    <pre>{{ indiv.snippet }}</pre>
+                                    <code class="language-python">{{ indiv.snippet }}</code>
                                     {% else %}
                                     <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}
@@ -65,12 +65,12 @@
                     </div>
                 </article>
                 <article class="error-output style-errors">
-                    <h2 class="category-heading">
+                    <h3 class="category-heading">
                         <span>{{ reporter.style_err_title }}</span>
                         <span class="slider">
                             <button>Expand/Collapse Section</button>
                         </span>
-                    </h2>
+                    </h3>
                     <div class="content collapsible">
                         {% for message in file.style %}
                         <div class="error-instance">
@@ -99,7 +99,7 @@
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                     </h4>
                                     {% if indiv.snippet != '' %}
-                                    <pre>{{ indiv.snippet }}</pre>
+                                    <code class="language-python">{{ indiv.snippet }}</code>
                                     {% else %}
                                     <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -20,7 +20,7 @@
                 </article>
                 <article class="error-output code-errors">
                     <h2 class="category-heading">
-                        {{ reporter.code_err_title }}
+                        <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
                             <button>Expand/Collapse Section</button>
                         </span>
@@ -61,7 +61,7 @@
                 </article>
                 <article class="error-output style-errors">
                     <h2 class="category-heading">
-                        {{ reporter.style_err_title }}
+                        <span>{{ reporter.style_err_title }}</span>
                         <span class="slider">
                             <button>Expand/Collapse Section</button>
                         </span>

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -51,7 +51,7 @@
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                     </h4>
                                     {% if indiv.snippet != '' %}
-                                    <code class="language-python">{{ indiv.snippet }}</code>
+                                    <code>{{ indiv.snippet }}</code>
                                     {% else %}
                                     <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}
@@ -99,7 +99,7 @@
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                     </h4>
                                     {% if indiv.snippet != '' %}
-                                    <code class="language-python">{{ indiv.snippet }}</code>
+                                    <code>{{ indiv.snippet }}</code>
                                     {% else %}
                                     <span class="empty-placeholder">{{ reporter.no_snippet }}</span>
                                     {% endif %}


### PR DESCRIPTION
Decided to go with the backend syntax formatter (pygments) after trying other frontend solutions (highlightjs, prismjs).

- Changed pluralization of occurances
- remove nbsp and br,
- made more responsive (frontend stuff)
- line numbers more different
- fixed parent container jitter
- syntax highlighting
- configure number_of_messages to work with htmlreporter