### PR TITLE
Global variables checker dev

### DIFF
--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -76,7 +76,7 @@ def _get_child_disallowed_global_var_nodes(node):
     global, non-constant variable. 
     """
     node_list = []
-    scoped_comps = (astroid.ListComp, astroid.Comprehension, astroid.DictComp, astroid.SetComp)
+    scoped_comps = (astroid.ListComp, astroid.Comprehension, astroid.DictComp, astroid.SetComp, astroid.GeneratorExp)
     if isinstance(node.parent, scoped_comps):
         return node_list
     if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call)))

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -77,13 +77,14 @@ def _get_child_disallowed_global_var_nodes(node):
     """
     node_list = []
     scoped_comps = (astroid.ListComp, astroid.Comprehension, astroid.DictComp, astroid.SetComp, astroid.GeneratorExp)
-    if isinstance(node.parent, scoped_comps):
+    if isinstance(node.scope(), scoped_comps):
         return node_list
     if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call)))
         and not re.match(CONST_NAME_RGX, node.name)):
         return [node]
     for child_node in node.get_children():
-        node_list += _get_child_disallowed_global_var_nodes(child_node)
+        if isinstance(child_node, astroid.AssignName):
+            node_list += _get_child_disallowed_global_var_nodes(child_node)
     return node_list
 
 

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -76,9 +76,10 @@ def _get_child_disallowed_global_var_nodes(node):
     global, non-constant variable. 
     """
     node_list = []
-    if isinstance(node.parent, astroid.ListComp) or isinstance(node.parent, astroid.Comprehension):
+    scoped_comps = (astroid.ListComp, astroid.Comprehension, astroid.DictComp, astroid.SetComp)
+    if isinstance(node.parent, scoped_comps):
         return node_list
-    if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call))) 
+    if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call)))
         and not re.match(CONST_NAME_RGX, node.name)):
         return [node]
     for child_node in node.get_children():

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -66,7 +66,7 @@ class GlobalVariablesChecker(BaseChecker):
         if (isinstance(node.frame(), astroid.scoped_nodes.Module) and not is_in_main(node)):
             node_list = _get_child_disallowed_global_var_nodes(node)
             for node in node_list:
-                args = "a global variable '{}' is declared on line {}"\
+                args = "a global variable '{}' is on line {}"\
                     .format(node.name, node.lineno)
                 self.add_message('forbidden-global-variables', node=node, args=args)
 
@@ -76,6 +76,8 @@ def _get_child_disallowed_global_var_nodes(node):
     global, non-constant variable. 
     """
     node_list = []
+    if isinstance(node.parent, astroid.ListComp) or isinstance(node.parent, astroid.Comprehension):
+        return node_list
     if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call))) 
         and not re.match(CONST_NAME_RGX, node.name)):
         return [node]


### PR DESCRIPTION
The `global_variables_checker` would think variables inside a list comprehension are always global -- these variables should never be seen as global, purely from being in a list comp.