### PR TITLE
Update GlobalVariablesChecker.

### DIFF
--- a/examples/global_variables_example.py
+++ b/examples/global_variables_example.py
@@ -13,6 +13,13 @@ ex = 1
 print(ex)
 
 
+# The local variable in a comprehension is okay
+print([x for x in [1, 2, 3]])
+print({x + 1 for x in [1, 2, 3]})
+print({x: x * 3 for x in [1, 2, 3]})
+print(list(x + 1 for x in [1, 2, 3]))
+
+
 def function1() -> None:
     """A test for the global variables checker."""
 

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -12,7 +12,7 @@ class GlobalVariablesChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = 'global_variables'
-    msgs = {'E9997': ('Global variables should not be used in CSC108/CSC148 - '
+    msgs = {'E9997': ('Global variables must be constants in CSC108/CSC148: '
                       '%s', 'forbidden-global-variables', '')}
 
     # this is important so that your checker is executed before others
@@ -26,18 +26,14 @@ class GlobalVariablesChecker(BaseChecker):
         args = "the keyword 'global' is used on line {}".format(node.lineno)
         self.add_message('forbidden-global-variables', node=node, args=args)
 
-    def visit_nonlocal(self, node):
-        args = "the keyword 'nonlocal' is used on line {}".format(node.lineno)
-        self.add_message('forbidden-global-variables', node=node, args=args)
-
     def visit_assign(self, node):
-        """Allow global constant variables (uppercase), but issue messages for 
+        """Allow global constant variables (uppercase), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
     def visit_name(self, node):
-        """Allow global constant variables (uppercase), but issue messages for 
+        """Allow global constant variables (uppercase), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
@@ -58,27 +54,29 @@ class GlobalVariablesChecker(BaseChecker):
                 self.import_names.append(name_tuple[0])  # no alias
 
     def _inspect_vars(self, node):
-        """Allows constant, global variables (i.e. uppercase), but issue 
+        """Allows constant, global variables (i.e. uppercase), but issue
         messages for all other global variables.
         """
         if hasattr(node, 'name') and node.name in self.import_names:
             return
-        if (isinstance(node.frame(), astroid.scoped_nodes.Module) and not is_in_main(node)):
+        if isinstance(node.frame(), astroid.scoped_nodes.Module) and not is_in_main(node):
             node_list = _get_child_disallowed_global_var_nodes(node)
             for node in node_list:
-                args = "a global variable '{}' is declared on line {}"\
+                args = "a global variable '{}' is assigned to on line {}"\
                     .format(node.name, node.lineno)
                 self.add_message('forbidden-global-variables', node=node, args=args)
 
 
 def _get_child_disallowed_global_var_nodes(node):
-    """Return a list of all top-level Name or AssignName nodes for a given 
-    global, non-constant variable. 
+    """Return a list of all top-level Name or AssignName nodes for a given
+    global, non-constant variable.
     """
     node_list = []
-    if ((isinstance(node, astroid.AssignName) or (isinstance(node, astroid.Name) and not isinstance(node.parent, astroid.Call))) 
-        and not re.match(CONST_NAME_RGX, node.name)):
+    if ((isinstance(node, (astroid.AssignName, astroid.Name)) and not isinstance(node.parent, astroid.Call)) and
+            not re.match(CONST_NAME_RGX, node.name) and
+            node.scope() is node.root()):
         return [node]
+
     for child_node in node.get_children():
         node_list += _get_child_disallowed_global_var_nodes(child_node)
     return node_list


### PR DESCRIPTION
Stops flagging variables in top-level comprehension expressions.
Changes wording of message (fixes #223).
Supercedes #307.