### PR TITLE
Error messages

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -231,7 +231,7 @@ class TypeInferer:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
             return TypeInfo(
-                TypeErrorInfo(f'Function {func_call} not found with given args:\
+                TypeErrorInfo(f'Function {op_to_name_binary(func_name)} not found with given args:\
                               {arg_types}', node))
 
         try:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,7 +4,7 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import binary_op_hints, op_to_name_binary, op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
+from ..typecheck.base import _correct_article, binary_op_hints, op_to_name_binary, op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
 from ..typecheck.type_store import TypeStore
 
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -237,8 +237,8 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            error = f'You cannot {op_to_name_binary(func_name)} with a(n) {arg_types[0].__name__}' \
-                    f' "{node.left.value}" and a(n) {arg_types[1].__name__} "{node.right.value}".'
+            error = f'You cannot {op_to_name_binary(func_name)} with {_correct_article(arg_types[0].__name__)}' \
+                    f' "{node.left.value}" and {_correct_article(arg_types[1].__name__)} "{node.right.value}".'
             hint = f' {binary_op_hints(func_name, arg_types)}'
             return TypeInfo(TypeErrorInfo(error + hint , node))
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -230,7 +230,7 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            error = f'You cannot {op_to_name_binary(func_name)} with {_correct_article(arg_types[0].__name__)}' \
+            error = f'You cannot {op_to_name_binary(func_name)} {_correct_article(arg_types[0].__name__)}' \
                     f' "{node.left.value}" and {_correct_article(arg_types[1].__name__)} "{node.right.value}".'
             hint = f' {binary_op_hints(func_name, arg_types)}'
             return TypeInfo(TypeErrorInfo(error + hint , node))

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -217,13 +217,6 @@ class TypeInferer:
     ##############################################################################
     # Operation nodes
     ##############################################################################
-    def _correct_article(noun : str):
-        """Helper to return a noun with the correct article."""
-        if noun.lower() == == "a" or "e" or "i" or "o" or "u":
-            return "an" + noun
-        else:
-            return "a" + noun
-
     def _handle_call(self, node, func_name, *args):
         """Helper to lookup a function and unify it with given arguments.
            Returns the return type of unified function call."""

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,7 +4,7 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import op_to_name_binary, op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
+from ..typecheck.base import binary_op_hints, op_to_name_binary, op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
 from ..typecheck.type_store import TypeStore
 
 
@@ -232,7 +232,8 @@ class TypeInferer:
         except KeyError:
             return TypeInfo(
                 TypeErrorInfo(f'You can not do {op_to_name_binary(func_name)}\
-                        with a(n) {arg_types[0]} and a(n) {arg_types[1]}', node))
+                        with a(n) {arg_types[0]} and a(n) {arg_types[1]}.\n\
+                        {binary_op_hints(func_name, arg_types)}', node))
 
         try:
             return_type = self.type_constraints.unify_call(func_type, *arg_types, node=node)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -231,8 +231,8 @@ class TypeInferer:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
             return TypeInfo(
-                TypeErrorInfo(f'Function {op_to_name_binary(func_name)} not found with given args:\
-                              {arg_types}', node))
+                TypeErrorInfo(f'You can not do {op_to_name_binary(func_name)}\
+                        with a(n) {arg_types[0]} and a(n) {arg_types[1]}', node))
 
         try:
             return_type = self.type_constraints.unify_call(func_type, *arg_types, node=node)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -4,7 +4,7 @@ from astroid.node_classes import *
 from typing import *
 from typing import CallableMeta, TupleMeta, Union, _ForwardRef
 from astroid.transforms import TransformVisitor
-from ..typecheck.base import op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
+from ..typecheck.base import op_to_name_binary, op_to_dunder_binary, op_to_dunder_unary, Environment, TypeConstraints, TypeInferenceError, parse_annotations, create_Callable,_node_to_type
 from ..typecheck.type_store import TypeStore
 
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -217,6 +217,13 @@ class TypeInferer:
     ##############################################################################
     # Operation nodes
     ##############################################################################
+    def _correct_article(noun : str):
+        """Helper to return a noun with the correct article."""
+        if noun.lower() == == "a" or "e" or "i" or "o" or "u":
+            return "an" + noun
+        else:
+            return "a" + noun
+
     def _handle_call(self, node, func_name, *args):
         """Helper to lookup a function and unify it with given arguments.
            Returns the return type of unified function call."""

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -230,8 +230,8 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            if func_call in OP_TO_NAME_BINARY:
-                return TypeInfo(f'Function {func_call} not found with given args: {arg_types}', node))
+            if func_call not in OP_TO_NAME_BINARY:
+                return TypeInfo(TypeErrorInfo(f'Function {func_call} not found with given args: {arg_types}', node))
             else:
                 error = f'You cannot {op_to_name_binary(func_name)} {_correct_article(arg_types[0].__name__)}' \
                         f' "{node.left.value}" and {_correct_article(arg_types[1].__name__)} "{node.right.value}".'

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -230,7 +230,7 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            error = f'You can not do {op_to_name_binary(func_name)} with a(n) {arg_types[0].__name__}' \
+            error = f'You cannot {op_to_name_binary(func_name)} with a(n) {arg_types[0].__name__}' \
                     f' "{node.left.value}" and a(n) {arg_types[1].__name__} "{node.right.value}".'
             hint = f' {binary_op_hints(func_name, arg_types)}'
             return TypeInfo(TypeErrorInfo(error + hint , node))

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -230,9 +230,9 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            error = f'You can not do {op_to_name_binary(func_name)} with a(n) {arg_types[0]} {node.left.value} ' \
-                    f'and a(n) {arg_types[1]} {node.right.value}.'
-            hint = f'{binary_op_hints(func_name, arg_types)}'
+            error = f'You can not do {op_to_name_binary(func_name)} with a(n) {arg_types[0].__name__}' \
+                    f' "{node.left.value}" and a(n) {arg_types[1].__name__} "{node.right.value}".'
+            hint = f' {binary_op_hints(func_name, arg_types)}'
             return TypeInfo(TypeErrorInfo(error + hint , node))
 
         try:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -230,10 +230,10 @@ class TypeInferer:
         try:
             func_type = self.type_store.lookup_function(func_call, *arg_types)
         except KeyError:
-            return TypeInfo(
-                TypeErrorInfo(f'You can not do {op_to_name_binary(func_name)}\
-                        with a(n) {arg_types[0]} and a(n) {arg_types[1]}.\n\
-                        {binary_op_hints(func_name, arg_types)}', node))
+            error = f'You can not do {op_to_name_binary(func_name)} with a(n) {arg_types[0]} {node.left.value} ' \
+                    f'and a(n) {arg_types[1]} {node.right.value}.'
+            hint = f'{binary_op_hints(func_name, arg_types)}'
+            return TypeInfo(TypeErrorInfo(error + hint , node))
 
         try:
             return_type = self.type_constraints.unify_call(func_type, *arg_types, node=node)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -86,37 +86,39 @@ def binary_op_hints(op, args):
 def op_to_name_binary(op):
     """Return the name of the method corresponding to binary op."""
     if op == '+':
-        return 'addition'
+        return 'add'
     elif op == '-':
-        return 'subtraction'
+        return 'subtract'
     elif op == '*':
-        return 'multiplication'
+        return 'multiply'
     elif op == '//':
-        return 'integer division'
+        return 'use integer division with'
     elif op == '%':
-        return 'modular operation'
+        # integer divide?
+        return 'use modulus with'
     elif op == '/':
-        return 'division'
+        return 'divide'
     elif op == '**':
-        return 'exponential operation'
+        return 'exponentiate'
     elif op == '&':
-        return 'bitwise AND operation'
+        return 'use bitwise AND with'
     elif op == '^':
-        return 'bitwise XOR operation'
+        return 'use bitwise XOR with'
     elif op == '|':
-        return 'bitwise OR operation'
+        return 'use bitwise OR with'
     elif op == '==':
-        return 'equality operation'
+        return 'compare for equality between'
     elif op == '!=':
-        return 'inequality operation'
+        return 'compare for inequality between'
     elif op == '<':
-        return 'less than operation'
+        # TODO: compare whether {} is _ than {}
+        return 'compare'
     elif op == '<=':
-        return 'less than or equal to operation'
+        return 'compare'
     elif op == '>':
-        return 'greater than operation'
+        return 'compare'
     elif op == '>=':
-        return 'greater than or equal to operation'
+        return 'compare'
     # TODO: 'is' and 'in'
     else:
         return op

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -75,6 +75,14 @@ TYPE_SIGNATURES = {
     }
 }
 
+
+def binary_op_hints(op, args):
+    """Return an appropriate 'hint' or suggestion given the binary operation and operand types."""
+    if op == '+':
+        if int in args and str in args:
+            return "Perhaps you wanted to cast the integer into a string or the converse?"
+
+
 def op_to_name_binary(op):
     """Return the name of the method corresponding to binary op."""
     if op == '+':

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -100,11 +100,11 @@ def op_to_name_binary(op):
     elif op == '**':
         return 'exponential operation'
     elif op == '&':
-        return 'logical AND operation'
+        return 'bitwise AND operation'
     elif op == '^':
-        return 'logical XOR operation'
+        return 'bitwise XOR operation'
     elif op == '|':
-        return 'logical OR operation'
+        return 'bitwise OR operation'
     elif op == '==':
         return 'equality operation'
     elif op == '!=':

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -76,52 +76,33 @@ TYPE_SIGNATURES = {
 }
 
 
+OP_TO_NAME_BINARY = {
+      '+' : 'add'
+    , '-' : 'subtract'
+    , '*' : 'multiply'
+    , '//' : 'use integer division with'
+    , '%' : 'use modulus with'
+    , '/' : 'exponentiate'
+    , '&' : 'use bitwise AND with'
+    , '^' : 'use bitwise XOR with'
+    , '|' : 'use bitwise OR with'
+    , '==' : 'compare for equality between'
+    , '!=' : 'compare for inequality between'
+    # TODO : compare whether {} is _ than {} 'compare'
+    , '<' : 'compare'
+    , '<=' : 'compare'
+    , '>' : 'compare'
+    , '>=' : 'compare'
+    # TODO: 'is' and 'in'
+    }
+
+
+# TODO: Convert this into dictionary
 def binary_op_hints(op, args):
     """Return an appropriate 'hint' or suggestion given the binary operation and operand types."""
     if op == '+':
         if int in args and str in args:
             return "Perhaps you wanted to cast the integer into a string or vice versa?"
-
-
-def op_to_name_binary(op):
-    """Return the name of the method corresponding to binary op."""
-    if op == '+':
-        return 'add'
-    elif op == '-':
-        return 'subtract'
-    elif op == '*':
-        return 'multiply'
-    elif op == '//':
-        return 'use integer division with'
-    elif op == '%':
-        # integer divide?
-        return 'use modulus with'
-    elif op == '/':
-        return 'divide'
-    elif op == '**':
-        return 'exponentiate'
-    elif op == '&':
-        return 'use bitwise AND with'
-    elif op == '^':
-        return 'use bitwise XOR with'
-    elif op == '|':
-        return 'use bitwise OR with'
-    elif op == '==':
-        return 'compare for equality between'
-    elif op == '!=':
-        return 'compare for inequality between'
-    elif op == '<':
-        # TODO: compare whether {} is _ than {}
-        return 'compare'
-    elif op == '<=':
-        return 'compare'
-    elif op == '>':
-        return 'compare'
-    elif op == '>=':
-        return 'compare'
-    # TODO: 'is' and 'in'
-    else:
-        return op
 
 
 def op_to_dunder_binary(op):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -175,6 +175,14 @@ def op_to_dunder_unary(op):
         return op
 
 
+def _correct_article(noun : str):
+    """Helper to return a noun with the correct article."""
+    if noun.lower() == == "a" or "e" or "i" or "o" or "u":
+        return "an" + noun
+    else:
+        return "a" + noun
+
+
 def lookup_method(name, caller_type, *args):
     """Lookup method with the given name for the given type."""
     if isinstance(caller_type, TupleMeta):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -80,7 +80,7 @@ def binary_op_hints(op, args):
     """Return an appropriate 'hint' or suggestion given the binary operation and operand types."""
     if op == '+':
         if int in args and str in args:
-            return "Perhaps you wanted to cast the integer into a string or the converse?"
+            return "Perhaps you wanted to cast the integer into a string or vice versa?"
 
 
 def op_to_name_binary(op):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -156,12 +156,12 @@ def op_to_dunder_unary(op):
         return op
 
 
-def _correct_article(noun : str):
+def _correct_article(noun : str) -> None:
     """Helper to return a noun with the correct article."""
-    if noun.lower()[0] in ["a", "e", "i", "o", "u"]:
-        return "an " + noun
+    if noun.lower()[0] in 'aeiou':
+        return 'an ' + noun
     else:
-        return "a " + noun
+        return 'a ' + noun
 
 
 def lookup_method(name, caller_type, *args):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -156,7 +156,7 @@ def op_to_dunder_unary(op):
         return op
 
 
-def _correct_article(noun : str) -> None:
+def _correct_article(noun : str) -> str:
     """Helper to return a noun with the correct article."""
     if noun.lower()[0] in 'aeiou':
         return 'an ' + noun

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -75,6 +75,44 @@ TYPE_SIGNATURES = {
     }
 }
 
+def op_to_name_binary(op):
+    """Return the name of the method corresponding to binary op."""
+    if op == '+':
+        return 'addition'
+    elif op == '-':
+        return 'subtraction'
+    elif op == '*':
+        return 'multiplication'
+    elif op == '//':
+        return 'integer division'
+    elif op == '%':
+        return 'modular operation'
+    elif op == '/':
+        return 'division'
+    elif op == '**':
+        return 'exponential operation'
+    elif op == '&':
+        return 'logical AND operation'
+    elif op == '^':
+        return 'logical XOR operation'
+    elif op == '|':
+        return 'logical OR operation'
+    elif op == '==':
+        return 'equality operation'
+    elif op == '!=':
+        return 'inequality operation'
+    elif op == '<':
+        return 'less than operation'
+    elif op == '<=':
+        return 'less than or equal to operation'
+    elif op == '>':
+        return 'greater than operation'
+    elif op == '>=':
+        return 'greater than or equal to operation'
+    # TODO: 'is' and 'in'
+    else:
+        return op
+
 
 def op_to_dunder_binary(op):
     """Return the dunder method name corresponding to binary op."""

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -177,7 +177,7 @@ def op_to_dunder_unary(op):
 
 def _correct_article(noun : str):
     """Helper to return a noun with the correct article."""
-    if noun.lower() == == "a" or "e" or "i" or "o" or "u":
+    if noun.lower() == "a" or "e" or "i" or "o" or "u":
         return "an" + noun
     else:
         return "a" + noun

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -177,10 +177,10 @@ def op_to_dunder_unary(op):
 
 def _correct_article(noun : str):
     """Helper to return a noun with the correct article."""
-    if noun.lower() == "a" or "e" or "i" or "o" or "u":
-        return "an" + noun
+    if noun.lower()[0] in ["a", "e", "i", "o", "u"]:
+        return "an " + noun
     else:
-        return "a" + noun
+        return "a " + noun
 
 
 def lookup_method(name, caller_type, *args):

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -324,6 +324,7 @@ def functiondef_node(draw, name=None, annotated=False, returns=False):
         returns_node.postinit(const_node(None))
     body.append(returns_node)
     node = astroid.FunctionDef(name=name)
+    node.parent = astroid.Module('Default', None)
     node.postinit(
         args,
         body,

--- a/tests/test_type_inference/test_compare.py
+++ b/tests/test_type_inference/test_compare.py
@@ -30,6 +30,7 @@ def test_compare_equality(operators, values):
         assume(value)
         if isinstance(value, str):
             assume(len(value) > 2)
+        assume(isinstance(value, int) or isinstance(value, bool) or isinstance(value, float))
     a = list(zip(operators, values))
     pre = []
     for operator, value in a:

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -105,6 +105,8 @@ def test_incompatible_binop_call():
         module, inferer = cs._parse_text(program)
     except:
         raise SkipTest()
+    call_node = next(module.nodes_of_class(astroid.Call))
+    expected_msg = f''
 
 
 
@@ -123,7 +125,7 @@ def test_non_annotated_function_call_bad_arguments():
     expected_msg = f'In the Call node in line 4, there was an error in calling the function "add_num":\n' \
                    f'in parameter (1), the function was expecting an object of inferred type ' \
                    f'int but was given an object of type str.\n' \
-                   f'in parameter (1), the function was expecting an object of inferred type ' \
+                   f'in parameter (2), the function was expecting an object of inferred type ' \
                    f'int but was given an object of type float.\n'
                    # TODO: should we use the term inferred?
     assert call_node.type_constraints.type.msg == expected_msg

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -99,8 +99,7 @@ def test_function_def_args_simple_function_call(function_name, variables_dict):
 def test_incompatible_binop_call():
     """ User tries to call a builtin binary operation on arguments of the wrong type.
     """
-    program = f'a = 5\n' \
-              f'a + "string"\n'
+    program = f'a + "string"\n'
     try:
         module, inferer = cs._parse_text(program)
     except:

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -96,6 +96,18 @@ def test_function_def_args_simple_function_call(function_name, variables_dict):
         assert inferer.type_constraints.lookup_concrete(function_call_type) == call_node.args[i].type_constraints.type
 
 
+def test_incompatible_binop_call():
+    """ User tries to call a builtin binary operation on arguments of the wrong type.
+    """
+    program = f'a = 5\n' \
+              f'a + "string"\n'
+    try:
+        module, inferer = cs._parse_text(program)
+    except:
+        raise SkipTest()
+
+
+
 def test_non_annotated_function_call_bad_arguments():
     """ User tries to call a non-annotated function on arguments of the wrong type.
     """

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -120,7 +120,7 @@ def test_non_annotated_function_call_bad_arguments():
     except:
         raise SkipTest()
     call_node = next(module.nodes_of_class(astroid.Call))
-    # TODO: This error is a flawed because the unification error occurs for both arguments due to our current implementation,
+    # TODO: This error is flawed because the unification error occurs for both arguments due to our current implementation,
     # which "chooses" the first valid function type from TypeStore.
     # Should we fix this implementation first or save it for later and hard-code the correct error message for now?
     expected_msg = f'In the Call node in line 4, there was an error in calling the function "add_num":\n' \

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -99,14 +99,13 @@ def test_function_def_args_simple_function_call(function_name, variables_dict):
 def test_incompatible_binop_call():
     """ User tries to call a builtin binary operation on arguments of the wrong type.
     """
-    program = f'a + "string"\n'
+    program = f'5 + "string"\n'
     try:
         module, inferer = cs._parse_text(program)
     except:
         raise SkipTest()
-    call_node = next(module.nodes_of_class(astroid.Call))
+    binop_node = next(module.nodes_of_class(astroid.BinOp))
     expected_msg = f''
-
 
 
 def test_non_annotated_function_call_bad_arguments():

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -122,6 +122,9 @@ def test_non_annotated_function_call_bad_arguments():
     except:
         raise SkipTest()
     call_node = next(module.nodes_of_class(astroid.Call))
+    # TODO: This error is a flawed because the unification error occurs for both arguments due to our current implementation,
+    # which "chooses" the first valid function type from TypeStore.
+    # Should we fix this implementation first or save it for later and hard-code the correct error message for now?
     expected_msg = f'In the Call node in line 4, there was an error in calling the function "add_num":\n' \
                    f'in parameter (1), the function was expecting an object of inferred type ' \
                    f'int but was given an object of type str.\n' \


### PR DESCRIPTION
- Update op_to_binary dictionary to help return more natural error messages.
- Implement the basic case for a "hints" dictionary, that will supplement error messages in the hopes of guiding students to a possible solution.
- Implement test case for type inference error when calling the binary operator for addition on incompatible types.
- Update the error message returned for aforementioned error to be more informative and natural.

*** Added TODOs for where there could be improvements in making return message more natural.