### PR TITLE
Fixed deprecation warnings.

### DIFF
--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -264,23 +264,26 @@ def unaryop_node(draw, op=hs.one_of(non_bool_unary_op, unary_bool_operator),
 def simple_homogeneous_dict_node(draw, **kwargs):
     k = draw(primitive_types)
     v = draw(primitive_types)
-    return dict_node(
+    return draw(dict_node(
         const_node(k()),
         const_node(v()),
         **kwargs
-    ).example()
+    ))
 
 
 @hs.composite
 def simple_homogeneous_list_node(draw, **kwargs):
     t = draw(primitive_types)
-    return list_node(const_node(t()), **kwargs).example()
+    return draw(list_node(const_node(t()), **kwargs))
 
 
 @hs.composite
 def simple_homogeneous_set_node(draw, **kwargs):
     t = draw(primitive_types)
-    return set_node(const_node(t()), **kwargs).example()
+    homogeneous_set = draw(set_node(const_node(t()), **kwargs))
+    assume(homogeneous_set.elts != set())
+    return homogeneous_set
+
 
 
 @hs.composite


### PR DESCRIPTION
- Use draw function instead of example function to properly generate nodes.
- Deprecation warnings have been resolved.