### PR TITLE
Error messages unaryop

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -2,6 +2,7 @@
 
 
 ## Nodes
+TODOs: - Think of better ways of representing objects when returning error messages from typechecking.
 
 ### Assign
 

--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -65,7 +65,6 @@ BINOP_TO_METHOD = {
     }
 
 
-# TODO: Think of better ways of representing objects when returning error message.
 ###############################################################################
 # BinOp message
 ###############################################################################

--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -89,6 +89,9 @@ def binop_error_message(node: astroid.BinOp) -> str:
     )
 
 
+###############################################################################
+# UnaryOp message
+###############################################################################
 def unaryop_error_message(node: astroid.UnaryOp) -> str:
     op_name = UNARY_TO_ENGLISH[node.op]
     operand = node.operand.type_constraints.type.__name__

--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -65,6 +65,7 @@ BINOP_TO_METHOD = {
     }
 
 
+# TODO: Think of better ways of representing objects when returning error message.
 ###############################################################################
 # BinOp message
 ###############################################################################

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -113,6 +113,18 @@ def test_incompatible_binop_call():
     expected_msg = f''
 
 
+def test_incompatible_unaryop_call():
+    """User tries to call a builtin unary operation on an argument of the wrong type.
+    """
+    program = f'~["D"]'
+    try:
+        module, inferer = cs._parse_text(program)
+    except:
+        raise SkipTest()
+    unaryop_node = next(module.nodes_of_class(astroid.UnaryOp))
+    expected_msg = f''
+
+
 def test_non_annotated_function_call_bad_arguments():
     """ User tries to call a non-annotated function on arguments of the wrong type.
     """

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -122,7 +122,8 @@ def test_incompatible_unaryop_call():
     except:
         raise SkipTest()
     unaryop_node = next(module.nodes_of_class(astroid.UnaryOp))
-    expected_msg = f''
+    expected_msg = "You cannot take the bitwise inverse of a List, ['D']."
+    assert(unaryop_node.type_constraints.type.msg == expected_msg)
 
 
 def test_non_annotated_function_call_bad_arguments():

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -123,7 +123,7 @@ def test_incompatible_unaryop_call():
         raise SkipTest()
     unaryop_node = next(module.nodes_of_class(astroid.UnaryOp))
     expected_msg = "You cannot take the bitwise inverse of a List, ['D']."
-    assert(unaryop_node.type_constraints.type.msg == expected_msg)
+    assert unaryop_node.type_constraints.type.msg == expected_msg
 
 
 def test_non_annotated_function_call_bad_arguments():


### PR DESCRIPTION
- Add section for unary operation error messages.
- Add test case for a built-in unary operator being called on an argument of the wrong type.