### PR TITLE
type_inference_visitor attribute name change

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -115,70 +115,70 @@ class TypeInferer:
     # Literals
     ##############################################################################
     def visit_const(self, node: astroid.Const) -> None:
-        node.type_constraints = TypeInfo(type(node.value))
+        node.inf_type = TypeInfo(type(node.value))
 
     def visit_list(self, node: astroid.List) -> None:
         if node.ctx == astroid.Store:
             # List is the target of an assignment; do not give it a type.
-            node.type_constraints = TypeInfo(NoType)
+            node.inf_type = TypeInfo(NoType)
         elif node.elts == []:
-            node.type_constraints = TypeInfo(List[Any])
+            node.inf_type = TypeInfo(List[Any])
         else:
-            node_type = node.elts[0].type_constraints.type
+            node_type = node.elts[0].inf_type.type
             for elt in node.elts:
                 if isinstance(node_type, type):
-                    node_type = self.type_constraints.unify(elt.type_constraints.type, node_type)
+                    node_type = self.type_constraints.unify(elt.inf_type.type, node_type)
             if isinstance(node_type, str):
                 node_type = Any
-            node.type_constraints = TypeInfo(List[node_type])
+            node.inf_type = TypeInfo(List[node_type])
 
     def visit_set(self, node: astroid.Set) -> None:
         if node.elts == []:
-            node.type_constraints = TypeInfo(Set[Any])
+            node.inf_type = TypeInfo(Set[Any])
         else:
-            node_type = node.elts[0].type_constraints.type
+            node_type = node.elts[0].inf_type.type
             for elt in node.elts:
                 if isinstance(node_type, type):
-                    node_type = self.type_constraints.unify(elt.type_constraints.type, node_type)
+                    node_type = self.type_constraints.unify(elt.inf_type.type, node_type)
             if isinstance(node_type, str):
                 node_type = Any
-            node.type_constraints = TypeInfo(Set[node_type])
+            node.inf_type = TypeInfo(Set[node_type])
 
     def visit_dict(self, node: astroid.Dict) -> None:
         if node.items == []:
-            node.type_constraints = TypeInfo(Dict[Any, Any])
+            node.inf_type = TypeInfo(Dict[Any, Any])
         else:
-            key_type, val_type = node.items[0][0].type_constraints.type, node.items[0][1].type_constraints.type
+            key_type, val_type = node.items[0][0].inf_type.type, node.items[0][1].inf_type.type
             for key_node, val_node in node.items:
                 if isinstance(key_type, type):
-                    key_type = self.type_constraints.unify(key_node.type_constraints.type, key_type)
+                    key_type = self.type_constraints.unify(key_node.inf_type.type, key_type)
                 if isinstance(val_type, type):
-                    val_type = self.type_constraints.unify(val_node.type_constraints.type, val_type)
+                    val_type = self.type_constraints.unify(val_node.inf_type.type, val_type)
             if isinstance(key_type, str):
                 key_type = Any
             if isinstance(val_type, str):
                 val_type = Any
-            node.type_constraints = TypeInfo(Dict[key_type, val_type])
+            node.inf_type = TypeInfo(Dict[key_type, val_type])
 
     def visit_tuple(self, node):
         if node.ctx == astroid.Store:
             # Tuple is the target of an assignment; do not give it a type.
-            node.type_constraints = TypeInfo(NoType)
+            node.inf_type = TypeInfo(NoType)
         else:
-            node.type_constraints = TypeInfo(
-                Tuple[tuple(x.type_constraints.type for x in node.elts)])
+            node.inf_type = TypeInfo(
+                Tuple[tuple(x.inf_type.type for x in node.elts)])
 
     ##############################################################################
     # Expression types
     ##############################################################################
     def visit_ifexp(self, node: astroid.IfExp) -> None:
-        t = self.type_constraints.unify(node.body.type_constraints.type, node.orelse.type_constraints.type)
-        node.type_constraints = TypeInfo(t)
+        t = self.type_constraints.unify(node.body.inf_type.type, node.orelse.inf_type.type)
+        node.inf_type = TypeInfo(t)
 
     def visit_expr(self, node):
         """Expr nodes take the type of their child
         """
-        node.type_constraints = node.value.type_constraints
+        node.inf_type = node.value.inf_type
 
     def _closest_frame(self, node, name):
         """Helper method to find the closest ancestor node containing name relative to the given node."""
@@ -205,25 +205,25 @@ class TypeInferer:
     ##############################################################################
     def visit_name(self, node: astroid.Name) -> None:
         try:
-            node.type_constraints = TypeInfo(self.lookup_type(node, node.name))
+            node.inf_type = TypeInfo(self.lookup_type(node, node.name))
         except KeyError:
             if node.name in self.type_store.classes:
-                node.type_constraints = TypeInfo(Type[__builtins__[node.name]])
+                node.inf_type = TypeInfo(Type[__builtins__[node.name]])
             elif node.name in self.type_store.functions:
-                node.type_constraints = TypeInfo(self.type_store.functions[node.name][0])
+                node.inf_type = TypeInfo(self.type_store.functions[node.name][0])
             else:
                 # This is an unbound identifier. Ignore it.
-                node.type_constraints = TypeInfo(Any)
+                node.inf_type = TypeInfo(Any)
 
     def visit_assign(self, node: astroid.Assign) -> None:
         """Update the enclosing scope's type environment for the assignment's binding(s)."""
         # the type of the expression being assigned
-        expr_type = node.value.type_constraints.type
+        expr_type = node.value.inf_type.type
 
         for target in node.targets:
             self._assign_type(target, expr_type)
 
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
     def _assign_type(self, target: NodeNG, expr_type: type) -> None:
         """Update the type environment so that the target is bound to the given type."""
@@ -267,7 +267,7 @@ class TypeInferer:
     # Operation nodes
     ##############################################################################
     def visit_call(self, node: astroid.Call) -> None:
-        callable_t = node.func.type_constraints.type
+        callable_t = node.func.inf_type.type
         if not isinstance(callable_t, (CallableMeta, list)):
             if isinstance(callable_t, _ForwardRef):
                 func_name = callable_t.__forward_arg__
@@ -275,40 +275,40 @@ class TypeInferer:
                 func_name = callable_t.__args__[0].__name__
             init_types = self.type_store.classes[func_name]['__init__']
             init_type = init_types[0]  # TODO: handle method overloading (through optional parameters)
-            arg_types = [callable_t] + [arg.type_constraints.type for arg in node.args]
+            arg_types = [callable_t] + [arg.inf_type.type for arg in node.args]
             self.type_constraints.unify_call(init_type, *arg_types)
-            node.type_constraints = TypeInfo(callable_t)
+            node.inf_type = TypeInfo(callable_t)
         else:
             # TODO: resolve this case (from method lookup) more gracefully
             if isinstance(callable_t, list):
                 callable_t = callable_t[0]
-                arg_types = [node.func.expr.type_constraints.type]
+                arg_types = [node.func.expr.inf_type.type]
             else:
                 arg_types = []
-            arg_types += [arg.type_constraints.type for arg in node.args]
+            arg_types += [arg.inf_type.type for arg in node.args]
             print(callable_t, arg_types)
             ret_type = self.type_constraints.unify_call(callable_t, *arg_types, node=node)
-            node.type_constraints = TypeInfo(ret_type)
+            node.inf_type = TypeInfo(ret_type)
 
     def visit_binop(self, node: astroid.BinOp) -> None:
         method_name = BINOP_TO_METHOD[node.op]
-        arg_types = [node.left.type_constraints.type, node.right.type_constraints.type]
-        node.type_constraints = self._handle_call(node, method_name, *arg_types, error_func=binop_error_message)
+        arg_types = [node.left.inf_type.type, node.right.inf_type.type]
+        node.inf_type = self._handle_call(node, method_name, *arg_types, error_func=binop_error_message)
 
     def visit_unaryop(self, node: astroid.UnaryOp) -> None:
         # 'not' is not a function, so this handled as a separate case.
         if node.op == 'not':
-            node.type_constraints = TypeInfo(bool)
+            node.inf_type = TypeInfo(bool)
         else:
             method_name = UNARY_TO_METHOD[node.op]
-            node.type_constraints = self._handle_call(node, method_name, node.operand.type_constraints.type, error_func=unaryop_error_message)
+            node.inf_type = self._handle_call(node, method_name, node.operand.inf_type.type, error_func=unaryop_error_message)
 
     def visit_boolop(self, node: astroid.BoolOp) -> None:
-        node_type_constraints = {operand_node.type_constraints.type for operand_node in node.values}
+        node_type_constraints = {operand_node.inf_type.type for operand_node in node.values}
         if len(node_type_constraints) == 1:
-            node.type_constraints = TypeInfo(node_type_constraints.pop())
+            node.inf_type = TypeInfo(node_type_constraints.pop())
         else:
-            node.type_constraints = TypeInfo(Any)
+            node.inf_type = TypeInfo(Any)
 
     def visit_compare(self, node: astroid.Compare) -> None:
         # TODO: 'in' comparator
@@ -321,37 +321,37 @@ class TypeInferer:
                 resolved_type = self._handle_call(
                     node,
                     BINOP_TO_METHOD[comparator],
-                    left.type_constraints.type,
-                    right.type_constraints.type
+                    left.inf_type.type,
+                    right.inf_type.type
                 )
                 return_types.add(resolved_type.type)
         if len(return_types) == 1:
-            node.type_constraints = TypeInfo(return_types.pop())
+            node.inf_type = TypeInfo(return_types.pop())
         else:
-            node.type_constraints = TypeInfo(Any)
+            node.inf_type = TypeInfo(Any)
 
     ##############################################################################
     # Subscripting
     ##############################################################################
     def visit_index(self, node: astroid.Index) -> None:
-        node.type_constraints = node.value.type_constraints
+        node.inf_type = node.value.inf_type
 
     def visit_slice(self, node: astroid.Slice) -> None:
         # TODO: check input types by doing a typecheck for the slice constructor
-        node.type_constraints = TypeInfo(slice)
+        node.inf_type = TypeInfo(slice)
 
     def visit_subscript(self, node: astroid.Subscript) -> None:
         if node.ctx == astroid.Load:
-            node.type_constraints = self._handle_call(node, '__getitem__', node.value.type_constraints.type,
-                                                      node.slice.type_constraints.type)
+            node.inf_type = self._handle_call(node, '__getitem__', node.value.inf_type.type,
+                                                      node.slice.inf_type.type)
         else:
-            node.type_constraints = TypeInfo(NoType)
+            node.inf_type = TypeInfo(NoType)
 
     ##############################################################################
     # Loops
     ##############################################################################
     def visit_for(self, node):
-        iter_type = self._handle_call(node, '__iter__', node.iter.type_constraints.type).type
+        iter_type = self._handle_call(node, '__iter__', node.iter.inf_type.type).type
         contained_type = iter_type.__args__[0]
         if isinstance(node.target, astroid.AssignName):
             target_type = self.lookup_type(node.target, node.target.name)
@@ -361,14 +361,14 @@ class TypeInferer:
             target_type = Tuple[tuple(self.lookup_type(subtarget, subtarget.name) for subtarget in node.target.elts)]
 
         self.type_constraints.unify(contained_type, target_type)
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
     ##############################################################################
     # Comprehensions
     ##############################################################################
     def visit_comprehension(self, node: astroid.Comprehension) -> None:
         # TODO: refactor code duplication between this and visit_for.
-        iter_type = self._handle_call(node, '__iter__', node.iter.type_constraints.type).type
+        iter_type = self._handle_call(node, '__iter__', node.iter.inf_type.type).type
         contained_type = iter_type.__args__[0]
         if isinstance(node.target, astroid.AssignName):
             target_type = self.lookup_type(node.target, node.target.name)
@@ -378,24 +378,24 @@ class TypeInferer:
             target_type = Tuple[tuple(self.lookup_type(subtarget, subtarget.name) for subtarget in node.target.elts)]
 
         self.type_constraints.unify(contained_type, target_type)
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
     def visit_dictcomp(self, node: astroid.DictComp) -> None:
-        key_type = self.type_constraints.resolve(node.key.type_constraints.type)
-        val_type = self.type_constraints.resolve(node.value.type_constraints.type)
-        node.type_constraints = TypeInfo(Dict[key_type, val_type])
+        key_type = self.type_constraints.resolve(node.key.inf_type.type)
+        val_type = self.type_constraints.resolve(node.value.inf_type.type)
+        node.inf_type = TypeInfo(Dict[key_type, val_type])
 
     def visit_generatorexp(self, node: astroid.GeneratorExp) -> None:
-        elt_type = self.type_constraints.resolve(node.elt.type_constraints.type)
-        node.type_constraints = TypeInfo(Generator[elt_type, None, None])
+        elt_type = self.type_constraints.resolve(node.elt.inf_type.type)
+        node.inf_type = TypeInfo(Generator[elt_type, None, None])
 
     def visit_listcomp(self, node: astroid.ListComp) -> None:
-        val_type = self.type_constraints.resolve(node.elt.type_constraints.type)
-        node.type_constraints = TypeInfo(List[val_type])
+        val_type = self.type_constraints.resolve(node.elt.inf_type.type)
+        node.inf_type = TypeInfo(List[val_type])
 
     def visit_setcomp(self, node: astroid.SetComp) -> None:
-        elt_type = self.type_constraints.resolve(node.elt.type_constraints.type)
-        node.type_constraints = TypeInfo(Set[elt_type])
+        elt_type = self.type_constraints.resolve(node.elt.inf_type.type)
+        node.inf_type = TypeInfo(Set[elt_type])
 
     def _handle_call(self, node: NodeNG, function_name: str, *arg_types: List[type],
                      error_func: Optional[Callable[[NodeNG], str]] = None) -> TypeInfo:
@@ -424,7 +424,7 @@ class TypeInferer:
     # Definitions
     ##############################################################################
     def visit_functiondef(self, node: astroid.FunctionDef) -> None:
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
         # Get the inferred type of the function.
         inferred_args = [self.lookup_type(node, arg) for arg in node.argnames()]
@@ -467,12 +467,12 @@ class TypeInferer:
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), func_type)
 
     def visit_return(self, node: astroid.Return) -> None:
-        t = node.value.type_constraints.type
+        t = node.value.inf_type.type
         self.type_constraints.unify(self.lookup_type(node, 'return'), t)
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
     def visit_classdef(self, node: astroid.ClassDef) -> None:
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), _ForwardRef(node.name))
 
         # Update type_store for this class.
@@ -487,7 +487,7 @@ class TypeInferer:
     # Statements
     ##############################################################################
     def visit_attribute(self, node: astroid.Attribute) -> None:
-        expr_type = node.expr.type_constraints.type
+        expr_type = node.expr.inf_type.type
         if isinstance(expr_type, _ForwardRef):
             type_name =  expr_type.__forward_arg__
         else:
@@ -504,16 +504,16 @@ class TypeInferer:
                 # TODO: handle classmethod calls differently.
                 if isinstance(attribute_type, CallableMeta):
                     attribute_type = Callable[list(attribute_type.__args__[1:-1]), attribute_type.__args__[-1]]
-                node.type_constraints = TypeInfo(attribute_type)
+                node.inf_type = TypeInfo(attribute_type)
 
     def visit_annassign(self, node):
         variable_type = self.type_constraints.resolve(
             self._closest_frame(node, node.target.name).type_environment.lookup_in_env(node.target.name))
         self.type_constraints.unify(variable_type, _node_to_type(node.annotation.name))
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
 
     def visit_module(self, node):
-        node.type_constraints = TypeInfo(NoType)
+        node.inf_type = TypeInfo(NoType)
         # print('All sets:', self.type_constraints._nodes)
         # print('Global bindings:', {k: self.type_constraints.resolve(t) for k, t in node.type_environment.locals.items()})
 

--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -78,8 +78,8 @@ def binary_op_hints(op, args):
 
 def binop_error_message(node: astroid.BinOp) -> str:
     op_name = BINOP_TO_ENGLISH[node.op]
-    left_type = node.left.type_constraints.type.__name__
-    right_type = node.right.type_constraints.type.__name__
+    left_type = node.left.inf_type.type.__name__
+    right_type = node.right.inf_type.type.__name__
     hint = binary_op_hints(node.op, [left_type, right_type]) or ''
 
     return (
@@ -91,7 +91,7 @@ def binop_error_message(node: astroid.BinOp) -> str:
 
 def unaryop_error_message(node: astroid.UnaryOp) -> str:
     op_name = UNARY_TO_ENGLISH[node.op]
-    operand = node.operand.type_constraints.type.__name__
+    operand = node.operand.inf_type.type.__name__
 
     return (
         f'You cannot {op_name} {_correct_article(operand)}, {node.operand.as_string()}.'

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -369,5 +369,5 @@ def _parse_text(source: Union[str, NodeNG]) -> Tuple[astroid.Module, TypeInferer
 
 def _verify_type_setting(module, ast_class, expected_type):
     """Helper to verify nodes visited by type inference visitor of astroid class has been properly transformed."""
-    result = [n.type_constraints.type for n in module.nodes_of_class(ast_class)]
+    result = [n.inf_type.type for n in module.nodes_of_class(ast_class)]
     assert [expected_type] == result, f'{expected_type}, {result}'

--- a/tests/test_type_inference/test_assign.py
+++ b/tests/test_type_inference/test_assign.py
@@ -32,7 +32,7 @@ def test_set_name_unassigned(identifier):
     program = identifier
     module, _ = cs._parse_text(program)
     for name_node in module.nodes_of_class(astroid.Name):
-        assert name_node.type_constraints.type == Any
+        assert name_node.inf_type.type == Any
 
 
 @given(cs.random_dict_variable_homogeneous_value(min_size=1))
@@ -45,7 +45,7 @@ def test_set_name_assigned(variables_dict):
     module, inferer = cs._parse_text(program)
     for name_node in module.nodes_of_class(astroid.Name):
         name_type = inferer.lookup_type(name_node, name_node.name)
-        assert name_node.type_constraints.type == name_type
+        assert name_node.inf_type.type == name_type
 
 
 @given(cs.random_dict_variable_homogeneous_value(min_size=1))
@@ -58,7 +58,7 @@ def test_set_single_assign(variables_dict):
         target_value = node.parent.value
         target_type = inferer.lookup_type(node, node.name)
         # compare it to the type of the assigned value
-        assert target_value.type_constraints.type == target_type
+        assert target_value.inf_type.type == target_type
 
 
 @given(cs.random_dict_variable_homogeneous_value(min_size=2))
@@ -76,7 +76,7 @@ def test_multi_target_assign(variables_dict):
         target_type_tuple = zip(node.targets[0].elts, node.value.elts)
         for target, value in target_type_tuple:
             target_type_var = target.frame().type_environment.lookup_in_env(target.name)
-            assert inferer.type_constraints.resolve(target_type_var) == value.type_constraints.type
+            assert inferer.type_constraints.resolve(target_type_var) == value.inf_type.type
 
 
 @given(hs.lists(hs.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1), min_size=1), cs.primitive_values)
@@ -89,7 +89,7 @@ def test_set_multi_assign(variables_list, value):
     program = (" = ").join(variables_list)
     module, inferer = cs._parse_text(program)
     for target_node in module.nodes_of_class(astroid.AssignName):
-        value_type = target_node.parent.value.type_constraints.type
+        value_type = target_node.parent.value.inf_type.type
         target_type_var = target_node.frame().type_environment.lookup_in_env(target_node.name)
         assert inferer.type_constraints.resolve(target_type_var) == value_type
 
@@ -111,7 +111,7 @@ def test_assign_complex_homogeneous(variables_dict):
     ass_node = list(module.nodes_of_class(astroid.Assign))[0]
     for variable_name in variables_dict:
         var_tvar = module.type_environment.lookup_in_env(variable_name)
-        assert typeinferrer.type_constraints.resolve(var_tvar) == ass_node.value.elts[0].type_constraints.type
+        assert typeinferrer.type_constraints.resolve(var_tvar) == ass_node.value.elts[0].inf_type.type
 
 
 @nottest

--- a/tests/test_type_inference/test_binops.py
+++ b/tests/test_type_inference/test_binops.py
@@ -12,14 +12,14 @@ def test_binop_non_bool_concrete(node):
     """Test type setting of BinOp node(s) with non-boolean operands."""
     module, inferer = cs._parse_text(node)
     binop_node = list(module.nodes_of_class(astroid.BinOp))[0]
-    left_type, right_type = binop_node.left.type_constraints.type, binop_node.right.type_constraints.type
+    left_type, right_type = binop_node.left.inf_type.type, binop_node.right.inf_type.type
     try:
         exp_func_type = inferer.type_store.lookup_method(BINOP_TO_METHOD[node.op], left_type, right_type)
         exp_return_type = exp_func_type.__args__[-1]
     except KeyError:
         exp_return_type = None
     assume(exp_return_type is not None)
-    assert binop_node.type_constraints.type == exp_return_type
+    assert binop_node.inf_type.type == exp_return_type
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_boolops.py
+++ b/tests/test_type_inference/test_boolops.py
@@ -13,7 +13,7 @@ def test_homogeneous_binary_boolop(node):
     """Test type setting of binary BoolOp node(s) representing expression with homogeneous operands."""
     module, _ = cs._parse_text(node)
     boolop_node = list(module.nodes_of_class(astroid.BoolOp))[0]
-    assert boolop_node.type_constraints.type == boolop_node.values[0].type_constraints.type
+    assert boolop_node.inf_type.type == boolop_node.values[0].inf_type.type
 
 
 @given(cs.boolop_node())
@@ -23,7 +23,7 @@ def test_heterogeneous_binary_boolop(node):
     assume(type(node.values[0].value) != type(node.values[1].value))
     module, _ = cs._parse_text(node)
     boolop_node = list(module.nodes_of_class(astroid.BoolOp))[0]
-    assert boolop_node.type_constraints.type == Any
+    assert boolop_node.inf_type.type == Any
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -25,7 +25,7 @@ def test_classdef_attribute_assign():
         for instance in attribute_lst:
             attribute_type = inferer.type_constraints\
                 .resolve(classdef_node.type_environment.lookup_in_env(instance.attrname))
-            value_type = inferer.type_constraints.resolve(instance.parent.value.type_constraints.type)
+            value_type = inferer.type_constraints.resolve(instance.parent.value.inf_type.type)
             assert attribute_type == value_type
 
 
@@ -43,8 +43,8 @@ def test_classdef_method_call():
               f'\n'
     module, inferer = cs._parse_text(program)
     attribute_node = list(module.nodes_of_class(astroid.Attribute))[1]
-    expected_rtype = attribute_node.parent.type_constraints.type
-    actual_rtype = inferer.type_constraints.resolve(attribute_node.type_constraints.type.__args__[-1])
+    expected_rtype = attribute_node.parent.inf_type.type
+    actual_rtype = inferer.type_constraints.resolve(attribute_node.inf_type.type.__args__[-1])
     assert actual_rtype == expected_rtype
 
 
@@ -86,7 +86,7 @@ def test_bad_attribute_access():
     expected_msg = f'Attribute access error!\n' \
                    f'In the Attribute node in line 2:\n' \
                    f'the object "x" does not have the attribute "wrong_name".'
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 def test_builtin_method_call_bad_self():
@@ -102,7 +102,7 @@ def test_builtin_method_call_bad_self():
     expected_msg = f'In the Call node in line 2, when calling the method "append":\n' \
                    f'this function expects to be called on an object of the class List, but was called on an object of ' \
                    f'inferred type int.'
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 def test_builtin_method_call_bad_argument():
@@ -118,7 +118,7 @@ def test_builtin_method_call_bad_argument():
     expected_msg = f'In the Call node in line 2, when calling the method "extend":\n' \
                    f'in parameter (1), the function was expecting an object of type iterable ' \
                    f'but was given an object of type int.'
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_compare.py
+++ b/tests/test_type_inference/test_compare.py
@@ -20,7 +20,7 @@ def test_compare_equality(left_value, operator_value_tuples):
         program += ' '.join([operator, repr(value)])
     module, _ = cs._parse_text(program)
     compare_node = list(module.nodes_of_class(astroid.Compare))[0]
-    assert compare_node.type_constraints.type == bool
+    assert compare_node.inf_type.type == bool
 
 
 @nottest
@@ -42,7 +42,7 @@ def test_compare_equality(operators, values):
     program = f'{str(values[0])} ' + ' '.join(pre)
     module, _ = cs._parse_text(program)
     compare_node = list(module.nodes_of_class(astroid.Compare))[0]
-    assert compare_node.type_constraints.type == bool
+    assert compare_node.inf_type.type == bool
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_dict.py
+++ b/tests/test_type_inference/test_dict.py
@@ -13,7 +13,7 @@ def test_homogeneous_dict(dictionary):
     module, _ = cs._parse_text(dictionary)
     dict_node = list(module.nodes_of_class(astroid.Dict))[0]
     if len(dict_node.items) == 0:
-        assert dict_node.type_constraints.type == Dict[Any, Any]
+        assert dict_node.inf_type.type == Dict[Any, Any]
     else:
         first_key, first_value = next(((k, v) for k, v in dictionary.items))
         cs._verify_type_setting(module, astroid.Dict, Dict[type(first_key.value), type(first_value.value)])

--- a/tests/test_type_inference/test_dictcomp.py
+++ b/tests/test_type_inference/test_dictcomp.py
@@ -15,7 +15,7 @@ def test_dict_comprehension_reproduce_homogeneous(node):
     module, _ = cs._parse_text(program)
     dictcomp_node = list(module.nodes_of_class(astroid.DictComp))[0]
     # reproducing the dict with dict. comprehension; the type of the expression will be same as original iterable
-    assert dictcomp_node.type_constraints.type == dictcomp_node.generators[0].iter.type_constraints.type
+    assert dictcomp_node.inf_type.type == dictcomp_node.generators[0].iter.inf_type.type
 
 
 @given(cs.dict_node(min_size=1))
@@ -27,7 +27,7 @@ def test_dict_comprehension_reproduce_heterogeneous(node):
     program = f"{{key: {dictionary}[key] for key in {dictionary}}}"
     module, _ = cs._parse_text(program)
     dictcomp_node = list(module.nodes_of_class(astroid.DictComp))[0]
-    assert dictcomp_node.type_constraints.type == dictcomp_node.generators[0].iter.type_constraints.type
+    assert dictcomp_node.inf_type.type == dictcomp_node.generators[0].iter.inf_type.type
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_for.py
+++ b/tests/test_type_inference/test_for.py
@@ -18,7 +18,7 @@ def test_for_homogeneous_list(iterable):
     for_node = list(module.nodes_of_class(astroid.For))[0]
     local_type_var = module.type_environment.lookup_in_env('x')
     inferred_type = TypeInferrer.type_constraints.resolve(local_type_var)
-    assert inferred_type == for_node.iter.type_constraints.type.__args__[0]
+    assert inferred_type == for_node.iter.inf_type.type.__args__[0]
 
 
 @given(cs.random_list(min_size=2))

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -46,7 +46,7 @@ def test_function_def_call_no_args(function_name, return_value):
     return_tvar = function_def_node.type_environment.lookup_in_env('return')
     return_type = inferer.type_constraints.resolve(return_tvar)
     expr_node = next(module.nodes_of_class(astroid.Expr))
-    assert expr_node.type_constraints.type == return_type
+    assert expr_node.inf_type.type == return_type
 
 
 @given(cs.valid_identifier(), hs.lists(cs.valid_identifier(), min_size=0), cs.primitive_values)
@@ -97,8 +97,8 @@ def test_function_def_args_simple_function_call(function_name, variables_dict):
         module, inferer = cs._parse_text(program)
         # get the Call node - there is only one in this test case.
         call_node = next(module.nodes_of_class(astroid.Call))
-        function_call_type = call_node.type_constraints.type
-        assert inferer.type_constraints.resolve(function_call_type) == call_node.args[i].type_constraints.type
+        function_call_type = call_node.inf_type.type
+        assert inferer.type_constraints.resolve(function_call_type) == call_node.args[i].inf_type.type
 
 
 def test_incompatible_binop_call():
@@ -134,7 +134,7 @@ def test_non_annotated_function_call_bad_arguments():
                    f'in parameter (2), the function was expecting an object of inferred type ' \
                    f'int but was given an object of type float.\n'
                    # TODO: should we use the term inferred?
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 def test_user_defined_annotated_call_wrong_arguments_type():
@@ -152,7 +152,7 @@ def test_user_defined_annotated_call_wrong_arguments_type():
     expected_msg = f'In the Call node in line 4, there was an error in calling the annotated function "add_3":\n' \
                    f'in parameter (2), the annotated type is int but was given an object of type str.\n' \
                    f'in parameter (3), the annotated type is int but was given an object of type float.\n'
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 def test_user_defined_annotated_call_wrong_arguments_number():
@@ -169,7 +169,7 @@ def test_user_defined_annotated_call_wrong_arguments_number():
     call_node = list(module.nodes_of_class(astroid.Call))[0]
     expected_msg = f'In the Call node in line 4, there was an error in calling the function "add_3":\n' \
                    f'the function was expecting 3 arguments, but was given 0.'
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 def test_conflicting_inferred_type_variable():
@@ -194,7 +194,7 @@ def test_conflicting_inferred_type_variable():
     expected_msg = f'In the Call node in line 8, there was an error in calling the annotated function "return_str":\n' \
                    f'in parameter (1), the annotated type is str but was given an object of inferred type int.'
                    # TODO: test case redundant because recursive..?
-    assert call_node.type_constraints.type.msg == expected_msg
+    assert call_node.inf_type.type.msg == expected_msg
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_ifexpr.py
+++ b/tests/test_type_inference/test_ifexpr.py
@@ -12,7 +12,7 @@ def test_ifexp(node):
     """Test the type setting of an IfExp node representing an if statement."""
     module, type_inferer = cs._parse_text(node)
     for ifexp_node in module.nodes_of_class(astroid.IfExp):
-        assert ifexp_node.type_constraints.type == ifexp_node.body.type_constraints.type
+        assert ifexp_node.inf_type.type == ifexp_node.body.inf_type.type
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_list.py
+++ b/tests/test_type_inference/test_list.py
@@ -13,7 +13,7 @@ def test_homogeneous_lists(lst):
     module, _ = cs._parse_text(lst)
     list_node = list(module.nodes_of_class(astroid.List))[0]
     if len(list_node.elts) == 0:
-        assert list_node.type_constraints.type == List[Any]
+        assert list_node.inf_type.type == List[Any]
     else:
         cs._verify_type_setting(module, astroid.List, List[type(lst.elts[0].value)])
 

--- a/tests/test_type_inference/test_listcomp.py
+++ b/tests/test_type_inference/test_listcomp.py
@@ -14,8 +14,8 @@ def test_list_comprehension_single_target_name_homogeneous_iterable(iterable):
     program = f'[num for num in {repr(iterable)}]'
     module, typeinferrer = cs._parse_text(program)
     listcomp_node = list(module.nodes_of_class(astroid.ListComp))[0]
-    expected_type = List[listcomp_node.generators[0].iter.type_constraints.type.__args__[0]]
-    assert listcomp_node.type_constraints.type == expected_type
+    expected_type = List[listcomp_node.generators[0].iter.inf_type.type.__args__[0]]
+    assert listcomp_node.inf_type.type == expected_type
 
 
 @given(cs.homogeneous_iterable)
@@ -26,8 +26,8 @@ def test_list_comprehension_single_target_name_heterogeneous_iterable(iterable):
     program = f'[num for num in {repr(iterable)}]'
     module, typeinferrer = cs._parse_text(program)
     listcomp_node = list(module.nodes_of_class(astroid.ListComp))[0]
-    expected_type = List[listcomp_node.generators[0].iter.type_constraints.type.__args__[0]]
-    assert listcomp_node.type_constraints.type == expected_type
+    expected_type = List[listcomp_node.generators[0].iter.inf_type.type.__args__[0]]
+    assert listcomp_node.inf_type.type == expected_type
 
 
 @given(cs.valid_identifier(min_size=1))
@@ -38,8 +38,8 @@ def test_list_comprehension_single_target_name_string(iterable):
     program = f'[num for num in {repr(iterable)}]'
     module, typeinferrer = cs._parse_text(program)
     listcomp_node = list(module.nodes_of_class(astroid.ListComp))[0]
-    expected_type = List[listcomp_node.generators[0].iter.type_constraints.type]
-    assert listcomp_node.type_constraints.type == expected_type
+    expected_type = List[listcomp_node.generators[0].iter.inf_type.type]
+    assert listcomp_node.inf_type.type == expected_type
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_literals.py
+++ b/tests/test_type_inference/test_literals.py
@@ -11,7 +11,7 @@ settings.load_profile("pyta")
 def test_index(node):
     module, _ = cs._parse_text(node)
     for index_node in module.nodes_of_class(astroid.Index):
-        assert index_node.type_constraints.type == index_node.value.type_constraints.type
+        assert index_node.inf_type.type == index_node.value.inf_type.type
 
 
 @given(cs.expr_node())
@@ -19,7 +19,7 @@ def test_index(node):
 def test_expr(expr):
     module, _ = cs._parse_text(expr)
     for expr_node in module.nodes_of_class(astroid.Expr):
-        assert expr_node.type_constraints.type == expr_node.value.type_constraints.type
+        assert expr_node.inf_type.type == expr_node.value.inf_type.type
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_name.py
+++ b/tests/test_type_inference/test_name.py
@@ -11,7 +11,7 @@ def test_builtin_function_name():
     """Test looking up the builtin function `bin`."""
     module, _ = cs._parse_text('bin')
     for node in module.nodes_of_class(astroid.Name):
-        assert node.type_constraints.type == Callable[[int], str]
+        assert node.inf_type.type == Callable[[int], str]
 
 
 @settings(suppress_health_check=[HealthCheck.too_slow])
@@ -19,7 +19,7 @@ def test_builtin_class_name():
     """Test looking up the builtin class `int`."""
     module, _ = cs._parse_text('int')
     for node in module.nodes_of_class(astroid.Name):
-        assert node.type_constraints.type == Type[int]
+        assert node.inf_type.type == Type[int]
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_set.py
+++ b/tests/test_type_inference/test_set.py
@@ -13,7 +13,7 @@ def test_homogeneous_set(node):
     module, _ = cs._parse_text(node)
     set_node = list(module.nodes_of_class(astroid.Set))[0]
     if len(set_node.elts) == 0:
-        assert set_node.type_constraints.type == Set[Any]
+        assert set_node.inf_type.type == Set[Any]
     else:
         try:
             cs._verify_type_setting(module, astroid.Set, Set[type(set_node.elts[0].value)])

--- a/tests/test_type_inference/test_setcomp.py
+++ b/tests/test_type_inference/test_setcomp.py
@@ -14,7 +14,7 @@ def test_set_comprehension_reproduce_homogeneous(iterable):
     program = '{elt for elt in ' + repr(iterable) + '}'
     module, _ = cs._parse_text(program)
     setcomp_node = list(module.nodes_of_class(astroid.SetComp))[0]
-    assert setcomp_node.type_constraints.type == Set[setcomp_node.generators[0].iter.type_constraints.type.__args__[0]]
+    assert setcomp_node.inf_type.type == Set[setcomp_node.generators[0].iter.inf_type.type.__args__[0]]
 
 
 @given(cs.heterogeneous_iterable)
@@ -25,7 +25,7 @@ def test_set_comprehension_reproduce_heterogeneous(iterable):
     program = '{elt for elt in ' + repr(iterable) + '}'
     module, _ = cs._parse_text(program)
     setcomp_node = list(module.nodes_of_class(astroid.SetComp))[0]
-    assert setcomp_node.type_constraints.type == Set[setcomp_node.generators[0].iter.type_constraints.type.__args__[0]]
+    assert setcomp_node.inf_type.type == Set[setcomp_node.generators[0].iter.inf_type.type.__args__[0]]
 
 
 @given(cs.valid_identifier(min_size=1))
@@ -36,7 +36,7 @@ def test_set_comprehension_reproduce_string(iterable):
     program = '{elt for elt in ' + repr(iterable) + '}'
     module, _ = cs._parse_text(program)
     setcomp_node = list(module.nodes_of_class(astroid.SetComp))[0]
-    assert setcomp_node.type_constraints.type == Set[setcomp_node.generators[0].iter.type_constraints.type]
+    assert setcomp_node.inf_type.type == Set[setcomp_node.generators[0].iter.inf_type.type]
 
 if __name__ == '__main__':
     nose.main()

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -13,7 +13,7 @@ def test_inference_list_subscript(node):
     module, _ = cs._parse_text(node)
     for subscript_node in module.nodes_of_class(astroid.Subscript):
         list_node = subscript_node.value
-        assert subscript_node.type_constraints.type == list_node.elts[0].type_constraints.type
+        assert subscript_node.inf_type.type == list_node.elts[0].inf_type.type
 
 
 @given(cs.subscript_node(cs.simple_homogeneous_list_node(min_size=1), cs.slice_node()))
@@ -23,7 +23,7 @@ def test_subscript_homogeneous_list_slice(node):
     module, _ = cs._parse_text(node)
     for subscript_node in module.nodes_of_class(astroid.Subscript):
         list_node = subscript_node.value
-        assert subscript_node.type_constraints.type == List[list_node.elts[0].type_constraints.type]
+        assert subscript_node.inf_type.type == List[list_node.elts[0].inf_type.type]
 
 
 # TODO: this test currently fails
@@ -38,7 +38,7 @@ def test_subscript_homogeneous_list_slice(node):
 #         module, _ = cs._parse_text(new_node)
 #         for subscript_node in module.nodes_of_class(astroid.Subscript):
 #             dict_node = subscript_node.value
-#             assert subscript_node.type_constraints.type == list(dict_node.items)[0][1].type_constraints.type
+#             assert subscript_node.inf_type.type == list(dict_node.items)[0][1].inf_type.type
 
 
 # TODO: this test needs to be converted, but will also fail
@@ -50,7 +50,7 @@ def test_subscript_homogeneous_list_slice(node):
 #     program = f'{input_list}[{input_slice}]'
 #     module, _ = cs._parse_text(program)
 #     subscript_node = list(module.nodes_of_class(astroid.Subscript))[0]
-#     assert subscript_node.type_constraints.type == List[Any]
+#     assert subscript_node.inf_type.type == List[Any]
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_tuple.py
+++ b/tests/test_type_inference/test_tuple.py
@@ -12,8 +12,8 @@ def test_tuple(t_tuple):
     """ Test Tuple nodes representing a tuple of various types."""
     module, _ = cs._parse_text(t_tuple)
     for t_node in module.nodes_of_class(astroid.Tuple):
-        elt_types = tuple(elt.type_constraints.type for elt in t_node.elts)
-        assert t_node.type_constraints.type == Tuple[elt_types]
+        elt_types = tuple(elt.inf_type.type for elt in t_node.elts)
+        assert t_node.inf_type.type == Tuple[elt_types]
 
 
 if __name__ == '__main__':

--- a/tests/test_type_inference/test_unaryops.py
+++ b/tests/test_type_inference/test_unaryops.py
@@ -12,7 +12,7 @@ def test_unaryop_non_bool_concrete(node):
     assume(not (node.op == '~' and isinstance(node.operand.value, float)))
     module, _ = cs._parse_text(node)
     unaryop_node = list(module.nodes_of_class(astroid.UnaryOp))[0]
-    assert unaryop_node.type_constraints.type == unaryop_node.operand.type_constraints.type
+    assert unaryop_node.inf_type.type == unaryop_node.operand.inf_type.type
 
 
 @given(cs.unaryop_node(cs.unary_bool_operator))
@@ -22,7 +22,7 @@ def test_not_bool(node):
     module, _ = cs._parse_text(node)
     for unaryop_node in module.nodes_of_class(astroid.UnaryOp):
         if unaryop_node.op == 'not':
-            assert unaryop_node.type_constraints.type == bool
+            assert unaryop_node.inf_type.type == bool
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Originally, type_inference_visitor would augment ast nodes with an attribute called type_constraints
Changing this attribute name to inf_type, for better clarity, and in anticipation of future changes that use the monad TypeResult