### PR TITLE
typecheck: Implement visit_slice correctly

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -325,8 +325,15 @@ class TypeInferer:
         node.inf_type = node.value.inf_type
 
     def visit_slice(self, node: astroid.Slice) -> None:
-        # TODO: check input types by doing a typecheck for the slice constructor
-        node.inf_type = TypeInfo(slice)
+        if node.lower and node.upper:
+            self.type_constraints.unify(node.lower.inf_type.getValue(), int)
+            node.inf_type = self.type_constraints.unify(node.upper.inf_type.getValue(), int)
+        if node.lower:
+            node.inf_type = self.type_constraints.unify(node.lower.inf_type.getValue(), int)
+        if node.upper:
+            node.inf_type = self.type_constraints.unify(node.upper.inf_type.getValue(), int)
+        else:
+            node.inf_type = TypeInfo(int)
 
     def visit_subscript(self, node: astroid.Subscript) -> None:
         if node.ctx == astroid.Load:

--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -99,8 +99,7 @@ Done.
 
 ### Slice
 
-TODOs:
-    - do proper type-checking of arguments
+Done.
 
 ### Subscript
 


### PR DESCRIPTION
There is a failing testcase, but I think this is due to the signature of \_\_getitem\_\_ in typeshed (\_\_getitem\_\_ returns a list in the case of a slice, so has a different signature in this case).
Also, I'm assuming that slice indices are integers only. I think this is the case because a 'slice' object is like a wrapper around a 'range' object.