### PR TITLE
typecheck: Fix call in visit_subscript & add tests

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -253,6 +253,10 @@ class TypeInferer:
                         target_tvar = self.lookup_type(subtarget, subtarget.name)
                         self.type_constraints.unify(target_tvar, contained_type)
                 return iter_type_result
+        elif isinstance(target, astroid.Subscript):
+            # TODO: previous case must recursively handle this one
+            return self._handle_call(target, '__setitem__', target.value.inf_type.getValue(),
+                                     target.slice.inf_type.getValue(), expr_type)
 
     def _lookup_attribute_type(self, node, instance_name, attribute_name):
         """Given the node, class name and attribute name, return the type of the attribute."""
@@ -376,13 +380,12 @@ class TypeInferer:
     def visit_subscript(self, node: astroid.Subscript) -> None:
         if node.ctx == astroid.Load:
             node.inf_type = self._handle_call(node, '__getitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                              node.slice.inf_type.getValue())
         elif node.ctx == astroid.Store:
-            node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue(), Any)
+            node.inf_type = TypeInfo(NoType) # type assigned when parent Assign node is visited
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                              node.slice.inf_type.getValue())
 
     ##############################################################################
     # Loops

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -383,6 +383,7 @@ class TypeInferer:
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())
+
     ##############################################################################
     # Loops
     ##############################################################################

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -379,7 +379,7 @@ class TypeInferer:
                                                       node.slice.inf_type.getValue())
         elif node.ctx == astroid.Store:
             node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                                      node.slice.inf_type.getValue(), Any)
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -48,8 +48,9 @@ def test_subscript_store_ctx(node, val):
     asgn_node = astroid.Assign()
     asgn_node.postinit([node], val)
     module, _ = cs._parse_text(asgn_node)
-    for subscript_node in module.nodes_of_class(astroid.Subscript):
-        assert subscript_node.inf_type.getValue() == type(None)
+    subscript_node = module.body[0].targets[0]
+    val_node = module.body[0].value
+    assert subscript_node.inf_type.getValue() == val_node.inf_type.getValue()
 
 
 @given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()))

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -52,13 +52,14 @@ def test_subscript_store_ctx(node, val):
         assert subscript_node.inf_type.getValue() == type(None)
 
 
-@given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()), cs.const_node())
+@given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()))
 @settings(suppress_health_check=[HealthCheck.too_slow])
-def test_subscript_del_ctx(node, val):
+def test_subscript_del_ctx(node):
     """Test visitor of Subscript node within a del statement."""
-    asgn_node = astroid.Assign(node, val)
-    for subscript_node in asgn_node.nodes_of_class(astroid.Subscript):
-        list_node = subscript_node.value
+    del_node = astroid.Delete()
+    del_node.postinit([node])
+    module, _ = cs._parse_text(del_node)
+    for subscript_node in module.nodes_of_class(astroid.Subscript):
         assert subscript_node.inf_type.getValue() == type(None)
 
 


### PR DESCRIPTION
I have assumed, as before, that inferred type for a Subscript node within an Assign node (ctx=Store) is NoneType (the return type of \_\_setitem\_\_), but I'm not sure if this is the case. It might make more sense if the whole Assign node is handled as a call to \_\_setitem\_\_ so that Assign.value can be passed as the last argument of \_\_setitem\_\_ (and this also fits in with Assign nodes being of type NoneType). But this means treating this case as a special case in visit_assign. The inferred type of the Subscript node itself would be the type of Assign.value (or a list around that type in case of a slice).