### PR TITLE
Typecheck: Fix unify call return type

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -276,7 +276,7 @@ class TypeInferer:
             else:
                 arg_types = []
             arg_types += [arg.inf_type.getValue() for arg in node.args]
-            node.inf_type = TypeInfo(self.type_constraints.unify_call(callable_t, *arg_types, node=node))
+            node.inf_type = self.type_constraints.unify_call(callable_t, *arg_types, node=node)
 
     def visit_binop(self, node: astroid.BinOp) -> None:
         method_name = BINOP_TO_METHOD[node.op]
@@ -405,7 +405,7 @@ class TypeInferer:
                 return TypeFail(error_func(node))
 
         try:
-            return TypeInfo(self.type_constraints.unify_call(func_type, *arg_types, node=node))
+            return self.type_constraints.unify_call(func_type, *arg_types, node=node)
         except TypeInferenceError:
             return TypeFail(f'Bad unify_call of function {function_name} given args: {arg_types}')
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -332,9 +332,12 @@ class TypeInferer:
         if node.ctx == astroid.Load:
             node.inf_type = self._handle_call(node, '__getitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())
-        else:
-            node.inf_type = TypeInfo(NoType)
-
+        elif node.ctx == astroid.Store:
+            node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
+                                                      node.slice.inf_type.getValue())
+        elif node.ctx == astroid.Del:
+            node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
+                                                      node.slice.inf_type.getValue())
     ##############################################################################
     # Loops
     ##############################################################################

--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -106,7 +106,6 @@ TODOs:
 
 TODOs:
     - Handle ExtSlice
-    - Handle subscripting in assignment ("Store") context
 
 ### Tuple
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -398,14 +398,14 @@ class TypeConstraints:
         else:
             return t1 == t2
 
-    def unify_call(self, func_type, *arg_types, node=None) -> type:
+    def unify_call(self, func_type, *arg_types, node=None) -> TypeResult:
         """Unify a function call with the given function type and argument types.
 
         Return a result type.
         """
         # Check that the number of parameters matches the number of arguments.
         if len(func_type.__args__) - 1 != len(arg_types):
-            raise TypeInferenceError('Wrong number of arguments')
+            return TypeFail('Wrong number of arguments')
 
         # Substitute polymorphic type variables
         new_tvars = {tvar: self.fresh_tvar(node) for tvar in getattr(func_type, 'polymorphic_tvars', [])}
@@ -413,7 +413,7 @@ class TypeConstraints:
         for arg_type, param_type in zip(arg_types, new_func_type.__args__[:-1]):
             if isinstance(self.unify(arg_type, param_type), str):
                 raise TypeInferenceError(f'Incompatible argument types {arg_type} and {param_type}')
-        return self._type_eval(new_func_type.__args__[-1])
+        return TypeInfo(self._type_eval(new_func_type.__args__[-1]))
 
     def _type_eval(self, t) -> type:
         """Evaluate a type. Used for tuples."""

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -386,8 +386,7 @@ def test_user_defined_annotated_call_wrong_arguments_number():
     except:
         raise SkipTest()
     call_node = list(module.nodes_of_class(astroid.Call))[0]
-    expected_msg = f'In the Call node in line 4, there was an error in calling the function "add_3":\n' \
-                   f'the function was expecting 3 arguments, but was given 0.'
+    expected_msg = "Wrong number of arguments"
     assert call_node.inf_type.getValue() == expected_msg
 
 


### PR DESCRIPTION
Fixing type signature of unify_call, as well as all relevant functions that use it