### PR TITLE
Typecheck: Unify annotations

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -469,7 +469,10 @@ class TypeInferer:
         node.inf_type = TypeInfo(NoType)
         for i in range(len(node.annotations)):
             if node.annotations[i] is not None:
-                self.type_constraints.unify(_node_to_type(node.annotations[i]), node.args[i])
+                # TODO Create helper function for modifying type_environment and _tvar_to_tnode?
+                tvar = node.parent.type_environment.locals[node.args[i].name]
+                self.type_constraints._tvar_to_tnode[tvar] = node.annotations[i]
+                node.parent.type_environment.locals[node.args[i].name] = _node_to_type(node.annotations[i])
 
     def visit_return(self, node: astroid.Return) -> None:
         t = node.value.inf_type.getValue()

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -332,9 +332,12 @@ class TypeInferer:
         if node.ctx == astroid.Load:
             node.inf_type = self._handle_call(node, '__getitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())
-        else:
-            node.inf_type = TypeInfo(NoType)
-
+        elif node.ctx == astroid.Store:
+            node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
+                                                      node.slice.inf_type.getValue())
+        elif node.ctx == astroid.Del:
+            node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
+                                                      node.slice.inf_type.getValue())
     ##############################################################################
     # Loops
     ##############################################################################

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -469,10 +469,8 @@ class TypeInferer:
         node.inf_type = TypeInfo(NoType)
         for i in range(len(node.annotations)):
             if node.annotations[i] is not None:
-                # TODO Create helper function for modifying type_environment and _tvar_to_tnode?
-                tvar = node.parent.type_environment.locals[node.args[i].name]
-                self.type_constraints._tvar_to_tnode[tvar] = node.annotations[i]
-                node.parent.type_environment.locals[node.args[i].name] = _node_to_type(node.annotations[i])
+                arg_tvar = self.lookup_type(node, node.args[i].name)
+                self.type_constraints.unify(arg_tvar, _node_to_type(node.annotations[i]))
 
     def visit_return(self, node: astroid.Return) -> None:
         t = node.value.inf_type.getValue()

--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -106,7 +106,6 @@ TODOs:
 
 TODOs:
     - Handle ExtSlice
-    - Handle subscripting in assignment ("Store") context
 
 ### Tuple
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -411,8 +411,8 @@ class TypeConstraints:
         new_tvars = {tvar: self.fresh_tvar(node) for tvar in getattr(func_type, 'polymorphic_tvars', [])}
         new_func_type = literal_substitute(func_type, new_tvars)
         for arg_type, param_type in zip(arg_types, new_func_type.__args__[:-1]):
-            if isinstance(self.unify(arg_type, param_type), str):
-                raise TypeInferenceError(f'Incompatible argument types {arg_type} and {param_type}')
+            if isinstance(self.unify(arg_type, param_type), TypeFail):
+                return self.unify(arg_type, param_type)
         return TypeInfo(self._type_eval(new_func_type.__args__[-1]))
 
     def _type_eval(self, t) -> type:

--- a/tests/test_type_inference/test_function_annotation.py
+++ b/tests/test_type_inference/test_function_annotation.py
@@ -3,6 +3,7 @@ from typing import Any
 from nose.tools import eq_
 from python_ta.transforms.type_inference_visitor import TypeInferer
 from python_ta.typecheck.base import TypeFail
+import tests.custom_hypothesis_support as cs
 
 
 def test_single_annotation_int():
@@ -10,10 +11,7 @@ def test_single_annotation_int():
     def foo(x: int):
         return x
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -24,10 +22,7 @@ def test_single_annotation_str():
     def foo(x: str):
         return x
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), str)
@@ -38,10 +33,7 @@ def test_multiple_annotations():
     def foo(x: int, y: int):
         return x + y
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -54,10 +46,7 @@ def test_multiple_annotations_diff_type():
         print(y)
         return x
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -71,10 +60,7 @@ def test_call_wrong_type():
         
     foo("Hello")
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -90,10 +76,7 @@ def test_call_wrong_type_str():
 
     foo(5)
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), str)
@@ -109,10 +92,7 @@ def test_call_multiple_annotation_wrong_type():
 
     foo("Hello", "Goodbye")
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -128,10 +108,7 @@ def test_mixed_annotation():
 
     foo(5, "Hello")
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
@@ -148,11 +125,8 @@ def test_mixed_annotation_wrong():
 
     foo("Hello", 5)
     '''
-    ti = TypeInferer()
-    ast_mod = astroid.parse(src)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
-
+    ast_mod, ti = cs._parse_text(src)
+    
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
     eq_(ti.lookup_type(func_node, "x"), int)
     eq_(ti.lookup_type(func_node, "y"), Any)

--- a/tests/test_type_inference/test_function_annotation.py
+++ b/tests/test_type_inference/test_function_annotation.py
@@ -1,0 +1,163 @@
+import astroid
+from typing import Any
+from nose.tools import eq_
+from python_ta.transforms.type_inference_visitor import TypeInferer
+from python_ta.typecheck.base import TypeFail
+
+
+def test_single_annotation_int():
+    src = '''
+    def foo(x: int):
+        return x
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+
+
+def test_single_annotation_str():
+    src = '''
+    def foo(x: str):
+        return x
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), str)
+
+
+def test_multiple_annotations():
+    src = '''
+    def foo(x: int, y: int):
+        return x + y
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, "y"), int)
+
+
+def test_multiple_annotations_diff_type():
+    src = '''
+    def foo(x: int, y: str):
+        print(y)
+        return x
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, "y"), str)
+
+
+def test_call_wrong_type():
+    src = '''
+    def foo(x: int):
+        return x
+        
+    foo("Hello")
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+
+    call_node = next(ast_mod.nodes_of_class(astroid.Call))
+    assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_call_wrong_type_str():
+    src = '''
+    def foo(x: str):
+        return x
+
+    foo(5)
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), str)
+
+    call_node = next(ast_mod.nodes_of_class(astroid.Call))
+    assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_call_multiple_annotation_wrong_type():
+    src = '''
+    def foo(x: int, y: str):
+        return x
+
+    foo("Hello", "Goodbye")
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+
+    call_node = next(ast_mod.nodes_of_class(astroid.Call))
+    assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_mixed_annotation():
+    src = '''
+    def foo(x: int, y):
+        return y
+
+    foo(5, "Hello")
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, "y"), Any)
+
+    call_node = next(ast_mod.nodes_of_class(astroid.Call))
+    eq_(call_node.inf_type.getValue(), Any)
+
+
+def test_mixed_annotation_wrong():
+    src = '''
+    def foo(x: int, y):
+        return y
+
+    foo("Hello", 5)
+    '''
+    ti = TypeInferer()
+    ast_mod = astroid.parse(src)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+
+    func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
+    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, "y"), Any)
+
+    call_node = next(ast_mod.nodes_of_class(astroid.Call))
+    assert isinstance(call_node.inf_type, TypeFail)
+
+

--- a/tests/test_type_inference/test_function_annotation.py
+++ b/tests/test_type_inference/test_function_annotation.py
@@ -1,137 +1,134 @@
 import astroid
 from typing import Any
 from nose.tools import eq_
-from python_ta.transforms.type_inference_visitor import TypeInferer
 from python_ta.typecheck.base import TypeFail
 import tests.custom_hypothesis_support as cs
 
 
 def test_single_annotation_int():
-    src = '''
+    src = """
     def foo(x: int):
         return x
-    '''
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, 'x'), int)
 
 
 def test_single_annotation_str():
-    src = '''
+    src = """
     def foo(x: str):
         return x
-    '''
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), str)
+    eq_(ti.lookup_type(func_node, 'x'), str)
 
 
 def test_multiple_annotations():
-    src = '''
+    src = """
     def foo(x: int, y: int):
         return x + y
-    '''
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
-    eq_(ti.lookup_type(func_node, "y"), int)
+    eq_(ti.lookup_type(func_node, 'x'), int)
+    eq_(ti.lookup_type(func_node, 'y'), int)
 
 
 def test_multiple_annotations_diff_type():
-    src = '''
+    src = """
     def foo(x: int, y: str):
         print(y)
         return x
-    '''
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
-    eq_(ti.lookup_type(func_node, "y"), str)
+    eq_(ti.lookup_type(func_node, 'x'), int)
+    eq_(ti.lookup_type(func_node, 'y'), str)
 
 
 def test_call_wrong_type():
-    src = '''
+    src = """
     def foo(x: int):
         return x
         
-    foo("Hello")
-    '''
+    foo('Hello')
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, 'x'), int)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
     assert isinstance(call_node.inf_type, TypeFail)
 
 
 def test_call_wrong_type_str():
-    src = '''
+    src = """
     def foo(x: str):
         return x
 
     foo(5)
-    '''
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), str)
+    eq_(ti.lookup_type(func_node, 'x'), str)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
     assert isinstance(call_node.inf_type, TypeFail)
 
 
 def test_call_multiple_annotation_wrong_type():
-    src = '''
+    src = """
     def foo(x: int, y: str):
         return x
 
-    foo("Hello", "Goodbye")
-    '''
+    foo('Hello', 'Goodbye')
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
+    eq_(ti.lookup_type(func_node, 'x'), int)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
     assert isinstance(call_node.inf_type, TypeFail)
 
 
 def test_mixed_annotation():
-    src = '''
+    src = """
     def foo(x: int, y):
         return y
 
-    foo(5, "Hello")
-    '''
+    foo(5, 'Hello')
+    """
     ast_mod, ti = cs._parse_text(src)
 
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
-    eq_(ti.lookup_type(func_node, "y"), Any)
+    eq_(ti.lookup_type(func_node, 'x'), int)
+    eq_(ti.lookup_type(func_node, 'y'), Any)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
     eq_(call_node.inf_type.getValue(), Any)
 
 
 def test_mixed_annotation_wrong():
-    src = '''
+    src = """
     def foo(x: int, y):
         return y
 
-    foo("Hello", 5)
-    '''
+    foo('Hello', 5)
+    """
     ast_mod, ti = cs._parse_text(src)
-    
+
     func_node = next(ast_mod.nodes_of_class(astroid.FunctionDef))
-    eq_(ti.lookup_type(func_node, "x"), int)
-    eq_(ti.lookup_type(func_node, "y"), Any)
+    eq_(ti.lookup_type(func_node, 'x'), int)
+    eq_(ti.lookup_type(func_node, 'y'), Any)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
     assert isinstance(call_node.inf_type, TypeFail)
-
-

--- a/tests/test_type_inference/test_function_def_inference.py
+++ b/tests/test_type_inference/test_function_def_inference.py
@@ -85,6 +85,9 @@ def test_nested_annotated_function_conflicting_body():
     """
     program = f'def random_func(int1: int) -> None:\n' \
               f'    int1 + "bob"\n'
+
+    raise SkipTest("Outdated annotation test. Previously raised SkipTest during cs._parse_text")
+
     try:
         module, inferer = cs._parse_text(program)
     except:


### PR DESCRIPTION
Added a visit_arguments function that goes through any annotated arguments and edits the type_environment to account for those constraints
Slight edit to unify_call to return TypeFail instead of raising exception
Added test file for annotated functions