### PR TITLE
typecheck: Implement type-checking in visit_slice correctly

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -248,6 +248,14 @@ class TypeInferer:
                     for subtarget in target.elts:
                         target_tvar = self.lookup_type(subtarget, subtarget.name)
                         self.type_constraints.unify(target_tvar, contained_type)
+        elif isinstance(target, astroid.Subscript):
+            # TODO: previous case must recursively handle this one
+            set_call_type = self._handle_call(target, '__setitem__', target.value.inf_type.getValue(),
+                              target.slice.inf_type.getValue(), expr_type)
+            if isinstance(set_call_type, TypeErrorInfo):
+                target.inf_type = set_call_type
+            else:
+                target.inf_type = TypeInfo(expr_type)
 
     def _lookup_attribute_type(self, node, instance_name, attribute_name):
         """Given the node, class name and attribute name, return the type of the attribute."""
@@ -340,13 +348,12 @@ class TypeInferer:
     def visit_subscript(self, node: astroid.Subscript) -> None:
         if node.ctx == astroid.Load:
             node.inf_type = self._handle_call(node, '__getitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                              node.slice.inf_type.getValue())
         elif node.ctx == astroid.Store:
-            node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue(), Any)
+            node.inf_type = TypeInfo(NoType) # type assigned when parent Assign node is visited
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                              node.slice.inf_type.getValue())
 
     ##############################################################################
     # Loops

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -343,7 +343,7 @@ class TypeInferer:
                                                       node.slice.inf_type.getValue())
         elif node.ctx == astroid.Store:
             node.inf_type = self._handle_call(node, '__setitem__', node.value.inf_type.getValue(),
-                                                      node.slice.inf_type.getValue())
+                                                      node.slice.inf_type.getValue(), Any)
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -342,8 +342,13 @@ class TypeInferer:
         node.inf_type = node.value.inf_type
 
     def visit_slice(self, node: astroid.Slice) -> None:
-        # TODO: check input types by doing a typecheck for the slice constructor
-        node.inf_type = TypeInfo(slice)
+        lower_type = node.lower.inf_type.getValue() if node.lower else type(None)
+        upper_type = node.upper.inf_type.getValue() if node.upper else type(None)
+        step_type = node.step.inf_type.getValue() if node.step else type(None)
+        node.inf_type = self._handle_call(node, '__init__', slice, lower_type,
+                                          upper_type, step_type)
+        if node.inf_type.getValue() is None:
+            node.inf_type = TypeInfo(slice)
 
     def visit_subscript(self, node: astroid.Subscript) -> None:
         if node.ctx == astroid.Load:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -252,7 +252,7 @@ class TypeInferer:
             # TODO: previous case must recursively handle this one
             set_call_type = self._handle_call(target, '__setitem__', target.value.inf_type.getValue(),
                               target.slice.inf_type.getValue(), expr_type)
-            if isinstance(set_call_type, TypeErrorInfo):
+            if isinstance(set_call_type, TypeFail):
                 target.inf_type = set_call_type
             else:
                 target.inf_type = TypeInfo(expr_type)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -347,7 +347,7 @@ class TypeInferer:
         step_type = node.step.inf_type.getValue() if node.step else type(None)
         node.inf_type = self._handle_call(node, '__init__', slice, lower_type,
                                           upper_type, step_type)
-        if node.inf_type.getValue() is None:
+        if node.inf_type.getValue() == type(None):
             node.inf_type = TypeInfo(slice)
 
     def visit_subscript(self, node: astroid.Subscript) -> None:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -347,6 +347,7 @@ class TypeInferer:
         elif node.ctx == astroid.Del:
             node.inf_type = self._handle_call(node, '__delitem__', node.value.inf_type.getValue(),
                                                       node.slice.inf_type.getValue())
+
     ##############################################################################
     # Loops
     ##############################################################################

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -45,8 +45,9 @@ def test_subscript_store_ctx(node, val):
     asgn_node = astroid.Assign()
     asgn_node.postinit([node], val)
     module, _ = cs._parse_text(asgn_node)
-    for subscript_node in module.nodes_of_class(astroid.Subscript):
-        assert subscript_node.inf_type.getValue() == type(None)
+    subscript_node = module.body[0].targets[0]
+    val_node = module.body[0].value
+    assert subscript_node.inf_type.getValue() == val_node.inf_type.getValue()
 
 
 @given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()))

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -49,13 +49,14 @@ def test_subscript_store_ctx(node, val):
         assert subscript_node.inf_type.getValue() == type(None)
 
 
-@given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()), cs.const_node())
+@given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()))
 @settings(suppress_health_check=[HealthCheck.too_slow])
-def test_subscript_del_ctx(node, val):
+def test_subscript_del_ctx(node):
     """Test visitor of Subscript node within a del statement."""
-    asgn_node = astroid.Assign(node, val)
-    for subscript_node in asgn_node.nodes_of_class(astroid.Subscript):
-        list_node = subscript_node.value
+    del_node = astroid.Delete()
+    del_node.postinit([node])
+    module, _ = cs._parse_text(del_node)
+    for subscript_node in module.nodes_of_class(astroid.Subscript):
         assert subscript_node.inf_type.getValue() == type(None)
 
 

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -75,6 +75,15 @@ def test_inference_dict_subscript(node):
             assert subscript_node.inf_type.getValue() == list(dict_node.items)[0][1].inf_type. getValue()
 
 
+@given(cs.simple_homogeneous_list_node(min_size=1))
+def test_inference_invalid_slice(node):
+    sub_node = astroid.Subscript()
+    sub_node.postinit(node, slice('a', 1, 1))
+    module, _ = cs._parse_text(sub_node)
+    for subscript_node in module.nodes_of_class(astroid.Subscript):
+        assert isinstance(subscript_node.inf_type.getValue(), TypeFail)
+
+
 # TODO: this test needs to be converted, but will also fail
 # @given(cs.random_list(min_size=2), cs.random_slice_indices())
 # def test_subscript_heterogeneous_list_slice(input_list, slice):

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -26,19 +26,51 @@ def test_subscript_homogeneous_list_slice(node):
         assert subscript_node.inf_type.getValue() == List[list_node.elts[0].inf_type.getValue()]
 
 
-# TODO: this test currently fails
-# @given(cs.simple_homogeneous_dict_node(min_size=1))
-# def test_inference_dict_subscript(node):
-#     """Note that this test only takes in a dictionary because the subscript index
-#     must be the same type as the dictionary's keys in order to type check.
-#     """
-#     for key, _ in node.items:
-#         new_node = astroid.Subscript()
-#         new_node.postinit(node, key)
-#         module, _ = cs._parse_text(new_node)
-#         for subscript_node in module.nodes_of_class(astroid.Subscript):
-#             dict_node = subscript_node.value
-#             assert subscript_node.inf_type.getValue() == list(dict_node.items)[0][1].inf_type. getValue()
+@given(cs.subscript_node(cs.simple_homogeneous_list_node(min_size=1), cs.slice_node()))
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_subscript_load_ctx(node):
+    """Test visitor of Subscript node when loaded in an (if) expression."""
+    load_node = astroid.If()
+    load_node.postinit(astroid.Const(True), [node])
+    module, _ = cs._parse_text(load_node)
+    for subscript_node in module.nodes_of_class(astroid.Subscript):
+        list_node = subscript_node.value
+        assert subscript_node.inf_type.getValue() == List[list_node.elts[0].inf_type.getValue()]
+
+
+@given(cs.subscript_node(cs.list_node(min_size=1), cs.index_node()), cs.const_node())
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_subscript_store_ctx(node, val):
+    """Test visitor of Subscript node within an assignment."""
+    asgn_node = astroid.Assign()
+    asgn_node.postinit([node], val)
+    module, _ = cs._parse_text(asgn_node)
+    for subscript_node in module.nodes_of_class(astroid.Subscript):
+        assert subscript_node.inf_type.getValue() == type(None)
+
+
+@given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()), cs.const_node())
+@settings(suppress_health_check=[HealthCheck.too_slow])
+def test_subscript_del_ctx(node, val):
+    """Test visitor of Subscript node within a del statement."""
+    asgn_node = astroid.Assign(node, val)
+    for subscript_node in asgn_node.nodes_of_class(astroid.Subscript):
+        list_node = subscript_node.value
+        assert subscript_node.inf_type.getValue() == type(None)
+
+
+@given(cs.simple_homogeneous_dict_node(min_size=1))
+def test_inference_dict_subscript(node):
+    """Note that this test only takes in a dictionary because the subscript index
+    must be the same type as the dictionary's keys in order to type check.
+    """
+    for key, _ in node.items:
+        new_node = astroid.Subscript()
+        new_node.postinit(node, key)
+        module, _ = cs._parse_text(new_node)
+        for subscript_node in module.nodes_of_class(astroid.Subscript):
+            dict_node = subscript_node.value
+            assert subscript_node.inf_type.getValue() == list(dict_node.items)[0][1].inf_type. getValue()
 
 
 # TODO: this test needs to be converted, but will also fail


### PR DESCRIPTION
I think this fails because can_unify hasn't been implemented yet, and hence the lookup to the \_\_init\_\_ signature (for slice) in typeshed fails.
Also, since the return value of \_\_init\_\_ is None (as per the reasons in the typing documentation), I manually set the inferred type of the node to slice (the constructed object). I'm not sure if this is the way to handle \_\_init\_\_ calls in general.