### PR TITLE
Typecheck: Call overload function

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -195,7 +195,11 @@ class TypeInferer:
     ##############################################################################
     def visit_name(self, node: astroid.Name) -> None:
         try:
-            node.inf_type = TypeInfo(self.lookup_type(node, node.name))
+            t = self.lookup_type(node, node.name)
+            node.inf_type = TypeInfo(t)
+            if hasattr(t, 'optionals'):
+                node.inf_type.optionals = t.optionals
+                print(node.inf_type.optionals)
         except KeyError:
             if node.name in self.type_store.classes:
                 node.inf_type = TypeInfo(Type[__builtins__[node.name]])
@@ -258,7 +262,8 @@ class TypeInferer:
 
     def lookup_type(self, node, name):
         """Given a variable name, return its concrete type in the closest scope relative to given node."""
-        tvar = self._closest_frame(node, name).type_environment.lookup_in_env(name)
+        cf = self._closest_frame(node, name)
+        tvar = cf.type_environment.lookup_in_env(name)
         return self.type_constraints.resolve(tvar).getValue()
 
 
@@ -276,7 +281,7 @@ class TypeInferer:
             init_type = init_types[0]  # TODO: handle method overloading (through optional parameters)
             arg_types = [callable_t] + [arg.inf_type.getValue() for arg in node.args]
             self.type_constraints.unify_call(init_type, *arg_types)
-            node.inf_type = TypeInfo(callable_t)
+            node.inf_type = self.type_constraints.unify_call(init_type, *arg_types)
         else:
             # TODO: resolve this case (from method lookup) more gracefully
             if isinstance(callable_t, list):
@@ -426,7 +431,17 @@ class TypeInferer:
         node.inf_type = TypeInfo(NoType)
 
         # Get the inferred type of the function.
+
+        # Check for type of function arguments
         inferred_args = [self.lookup_type(node, arg) for arg in node.argnames()]
+
+        # Check for any default values:
+        diff_num_args = []
+        diff_num_args.append(inferred_args)
+        if len(node.args.defaults) > 0:
+            for i in range(len(node.args.defaults)):
+                diff_num_args.append(inferred_args[:-1-i])
+        inferred_args = diff_num_args[-1]
 
         if isinstance(node.parent, astroid.ClassDef) and isinstance(inferred_args[0], TypeVar):
             # TODO: distinguish between instance, class, and static methods.
@@ -462,7 +477,11 @@ class TypeInferer:
 
         # Update the environment storing the function's type.
         polymorphic_tvars = [arg for arg in combined_args if isinstance(arg, TypeVar)]
+        # TODO: Add loop here to check for possible default arguments]
         func_type = create_Callable(combined_args, combined_return, polymorphic_tvars)
+        func_type.optionals = []
+        for args in diff_num_args:
+            func_type.optionals.append(create_Callable(args, combined_return, polymorphic_tvars))
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), func_type)
 
     def visit_return(self, node: astroid.Return) -> None:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -197,8 +197,6 @@ class TypeInferer:
         try:
             t = self.lookup_type(node, node.name)
             node.inf_type = TypeInfo(t)
-            if hasattr(t, 'optional_params'):
-                node.inf_type.optional_params = t.optional_params
         except KeyError:
             if node.name in self.type_store.classes:
                 node.inf_type = TypeInfo(Type[__builtins__[node.name]])
@@ -476,8 +474,11 @@ class TypeInferer:
         # Update the environment storing the function's type.
         polymorphic_tvars = [arg for arg in combined_args if isinstance(arg, TypeVar)]
         func_type = create_Callable(combined_args, combined_return, polymorphic_tvars)
-        if len(diff_num_args) > 1:
+        if hasattr(func_type, "optional_params"):
+            func_type.optional_params.clear()
+        else:
             func_type.optional_params = []
+        if len(diff_num_args) > 1:
             for args in diff_num_args:
                 func_type.optional_params.append(create_Callable(args, combined_return, polymorphic_tvars))
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), func_type)

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -197,9 +197,8 @@ class TypeInferer:
         try:
             t = self.lookup_type(node, node.name)
             node.inf_type = TypeInfo(t)
-            if hasattr(t, 'optionals'):
-                node.inf_type.optionals = t.optionals
-                print(node.inf_type.optionals)
+            if hasattr(t, 'optional_params'):
+                node.inf_type.optional_params = t.optional_params
         except KeyError:
             if node.name in self.type_store.classes:
                 node.inf_type = TypeInfo(Type[__builtins__[node.name]])
@@ -262,8 +261,7 @@ class TypeInferer:
 
     def lookup_type(self, node, name):
         """Given a variable name, return its concrete type in the closest scope relative to given node."""
-        cf = self._closest_frame(node, name)
-        tvar = cf.type_environment.lookup_in_env(name)
+        tvar = self._closest_frame(node, name).type_environment.lookup_in_env(name)
         return self.type_constraints.resolve(tvar).getValue()
 
 
@@ -477,11 +475,11 @@ class TypeInferer:
 
         # Update the environment storing the function's type.
         polymorphic_tvars = [arg for arg in combined_args if isinstance(arg, TypeVar)]
-        # TODO: Add loop here to check for possible default arguments]
         func_type = create_Callable(combined_args, combined_return, polymorphic_tvars)
-        func_type.optionals = []
-        for args in diff_num_args:
-            func_type.optionals.append(create_Callable(args, combined_return, polymorphic_tvars))
+        if len(diff_num_args) > 1:
+            func_type.optional_params = []
+            for args in diff_num_args:
+                func_type.optional_params.append(create_Callable(args, combined_return, polymorphic_tvars))
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), func_type)
 
     def visit_return(self, node: astroid.Return) -> None:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -404,8 +404,6 @@ class TypeConstraints:
         Return a result type.
         """
         # Check that the number of parameters matches the number of arguments.
-        a = len(func_type.__args__) - 1
-        b = len(arg_types)
         if len(func_type.__args__) - 1 != len(arg_types):
             if hasattr(func_type, 'optional_params'):
                 for func in func_type.optional_params:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -405,6 +405,10 @@ class TypeConstraints:
         """
         # Check that the number of parameters matches the number of arguments.
         if len(func_type.__args__) - 1 != len(arg_types):
+            if hasattr(func_type, 'optionals'):
+                for func in func_type.optionals:
+                    if len(func.__args__) - 1 == len(arg_types):
+                        return self.unify_call(func, *arg_types)
             return TypeFail('Wrong number of arguments')
 
         # Substitute polymorphic type variables

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -404,9 +404,11 @@ class TypeConstraints:
         Return a result type.
         """
         # Check that the number of parameters matches the number of arguments.
+        a = len(func_type.__args__) - 1
+        b = len(arg_types)
         if len(func_type.__args__) - 1 != len(arg_types):
-            if hasattr(func_type, 'optionals'):
-                for func in func_type.optionals:
+            if hasattr(func_type, 'optional_params'):
+                for func in func_type.optional_params:
                     if len(func.__args__) - 1 == len(arg_types):
                         return self.unify_call(func, *arg_types)
             return TypeFail('Wrong number of arguments')

--- a/tests/test_type_inference/test_function_overload.py
+++ b/tests/test_type_inference/test_function_overload.py
@@ -1,6 +1,7 @@
 import astroid
 from python_ta.transforms.type_inference_visitor import TypeInferer
 from python_ta.typecheck.base import TypeInfo, TypeFail
+import tests.custom_hypothesis_support as cs
 from nose.tools import eq_
 
 
@@ -12,10 +13,7 @@ def test_overload_function():
     foo(5)
     foo(5, 6)
     """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type.getValue(), int)
 
@@ -30,10 +28,7 @@ def test_overload_function_2():
     foo(5, 6, 7)
     foo(5, None, 7)
     """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type.getValue(), int)
 
@@ -45,10 +40,7 @@ def test_too_few_args():
 
        foo(5)
        """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
@@ -60,10 +52,7 @@ def test_too_few_args_2():
 
        foo(5, 6)
        """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
@@ -75,10 +64,7 @@ def test_too_many_args_2():
 
        foo(5, 6, 7)
        """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
@@ -90,10 +76,7 @@ def test_too_many_args():
 
        foo(5, 6)
        """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
@@ -107,9 +90,6 @@ def test_overload_function_with_annotations():
     foo(5)
     foo(5, 6)
     """
-    ti = TypeInferer()
-    ast_mod = astroid.parse(program)
-    ti.environment_transformer().visit(ast_mod)
-    ti.type_inference_transformer().visit(ast_mod)
+    ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         eq_(call_node.inf_type.getValue(), int)

--- a/tests/test_type_inference/test_function_overload.py
+++ b/tests/test_type_inference/test_function_overload.py
@@ -1,18 +1,7 @@
 import astroid
-import tests.custom_hypothesis_support as cs
 from python_ta.transforms.type_inference_visitor import TypeInferer
 from python_ta.typecheck.base import TypeInfo, TypeFail
 from nose.tools import eq_
-
-src = '''
-def foo(x, y=0, z=1):
-    return (x + y) * z
-    
-a = foo(10)
-b = foo(10, 5)
-c = foo(10, 5, 12)
-d = foo(5, 1, 2, 4)
-'''
 
 
 def test_overload_function():
@@ -28,23 +17,25 @@ def test_overload_function():
     ti.environment_transformer().visit(ast_mod)
     ti.type_inference_transformer().visit(ast_mod)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
-        assert not isinstance(call_node.inf_type, TypeFail)
+        eq_(call_node.inf_type.getValue(), int)
 
 
-def test_overload_function_with_annotations():
+def test_overload_function_2():
     program = """
-    def foo(x: int, y: int=None):
+    def foo(x, y=None, z=None):
         return x + 5
 
     foo(5)
     foo(5, 6)
+    foo(5, 6, 7)
+    foo(5, None, 7)
     """
     ti = TypeInferer()
     ast_mod = astroid.parse(program)
     ti.environment_transformer().visit(ast_mod)
     ti.type_inference_transformer().visit(ast_mod)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
-        assert not isinstance(call_node.inf_type, TypeFail)
+        eq_(call_node.inf_type.getValue(), int)
 
 
 def test_too_few_args():
@@ -62,7 +53,22 @@ def test_too_few_args():
         eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
 
-def test_too_many_args():
+def test_too_few_args_2():
+    program = """
+       def foo(x, y, z):
+           return x + 5
+
+       foo(5, 6)
+       """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_many_args_2():
     program = """
        def foo(x, y):
            return x + 5
@@ -74,5 +80,36 @@ def test_too_many_args():
     ti.environment_transformer().visit(ast_mod)
     ti.type_inference_transformer().visit(ast_mod)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
-        assert isinstance(call_node.inf_type, TypeFail)
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
 
+
+def test_too_many_args():
+    program = """
+       def foo(x):
+           return x + 5
+
+       foo(5, 6)
+       """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+
+def test_overload_function_with_annotations():
+    program = """
+    def foo(x: int, y: int=None):
+        return x + 5
+
+    foo(5)
+    foo(5, 6)
+    """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type.getValue(), int)

--- a/tests/test_type_inference/test_function_overload.py
+++ b/tests/test_type_inference/test_function_overload.py
@@ -1,0 +1,78 @@
+import astroid
+import tests.custom_hypothesis_support as cs
+from python_ta.transforms.type_inference_visitor import TypeInferer
+from python_ta.typecheck.base import TypeInfo, TypeFail
+from nose.tools import eq_
+
+src = '''
+def foo(x, y=0, z=1):
+    return (x + y) * z
+    
+a = foo(10)
+b = foo(10, 5)
+c = foo(10, 5, 12)
+d = foo(5, 1, 2, 4)
+'''
+
+
+def test_overload_function():
+    program = """
+    def foo(x, y=None):
+        return x + 5
+        
+    foo(5)
+    foo(5, 6)
+    """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert not isinstance(call_node.inf_type, TypeFail)
+
+
+def test_overload_function_with_annotations():
+    program = """
+    def foo(x: int, y: int=None):
+        return x + 5
+
+    foo(5)
+    foo(5, 6)
+    """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert not isinstance(call_node.inf_type, TypeFail)
+
+
+def test_too_few_args():
+    program = """
+       def foo(x, y):
+           return x + 5
+
+       foo(5)
+       """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_many_args():
+    program = """
+       def foo(x, y):
+           return x + 5
+
+       foo(5, 6, 7)
+       """
+    ti = TypeInferer()
+    ast_mod = astroid.parse(program)
+    ti.environment_transformer().visit(ast_mod)
+    ti.type_inference_transformer().visit(ast_mod)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type, TypeFail)
+


### PR DESCRIPTION
Adding "optional_params" attribute to created Callables, contains a list of lists of types, where each list of types is a list of argument types that the Callable can take
Adding test cases for functions with optional arguments