### PR TITLE
typecheck: Fix unify returning unresolved types on higher-order calls

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -291,7 +291,7 @@ class TypeConstraints:
             rep1 = self._find(t1)
             if rep1.type == t1:
                 # Simply make t2 the set representative for t1.
-                rep1.parent = self._make_set(t2)
+                rep1.parent = self._make_set(self.resolve(t2).getValue())
                 return self.resolve(t1)
             else:
                 return self.unify(rep1.type, t2)

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -1,6 +1,6 @@
 from typing import *
 from typing import TupleMeta, CallableMeta, _ForwardRef
-from python_ta.typecheck.base import TypeResult, TypeInfo, TypeFail, TypeConstraints
+from python_ta.typecheck.base import TypeResult, TypeInfo, TypeFail, TypeConstraints, create_Callable
 from nose import SkipTest
 from nose.tools import eq_
 
@@ -197,8 +197,8 @@ def test_simple_polymorphic_call():
     tc.reset()
     tv1 = tc.fresh_tvar()
     tv2 = tc.fresh_tvar()
-    fn1 = Callable[[tv1, tv2], bool]
-    fn2 = Callable[[int, int], bool]
+    fn1 = create_Callable([tv1, tv2], bool, [tv1, tv2])
+    fn2 = create_Callable([int, int], bool)
 
     unify_helper(fn1, fn2, Callable[[int, int], bool])
 
@@ -207,12 +207,16 @@ def test_higher_order_polymorphic_call():
     tc.reset()
     tv1 = tc.fresh_tvar()
     tv2 = tc.fresh_tvar()
-    fn1 = Callable[[Callable[[tv1, int], int]], bool]
-    fn2 = Callable[[Callable[[int, int], int]], bool]
-    fn3 = Callable[[tv2], bool]
 
-    unify_helper(fn1, fn2, Callable[[Callable[[int, int], int]], bool])
-    unify_helper(fn1, fn3, Callable[[Callable[[int, int], int]], bool])
+    fn0 = create_Callable([tv1, int], int, [tv1])
+    fn1 = create_Callable([int, int], int)
+
+    fn2 = create_Callable([fn0, int], bool)
+    fn3 = create_Callable([fn1, int], bool)
+    fn4 = create_Callable([tv2, int], bool, [tv2])
+
+    unify_helper(fn2, fn3, Callable[[Callable[[int, int], int], int], bool])
+    unify_helper(fn2, fn4, Callable[[Callable[[int, int], int], int], bool])
 
     resolve_helper(tv1, int)
     resolve_helper(tv2, Callable[[int, int], int])

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -216,4 +216,3 @@ def test_higher_order_polymorphic_call():
 
     resolve_helper(tv1, int)
     resolve_helper(tv2, Callable[[int, int], int])
-

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -190,3 +190,30 @@ def test_diff_callable():
 
     unify_helper(c1, c2, TypeFail(
         f'Incompatible Types {c1} and {c2}'))
+
+
+# Polymorphic types
+def test_simple_polymorphic_call():
+    tc.reset()
+    tv1 = tc.fresh_tvar()
+    tv2 = tc.fresh_tvar()
+    fn1 = Callable[[tv1, tv2], bool]
+    fn2 = Callable[[int, int], bool]
+
+    unify_helper(fn1, fn2, Callable[[int, int], bool])
+
+
+def test_higher_order_polymorphic_call():
+    tc.reset()
+    tv1 = tc.fresh_tvar()
+    tv2 = tc.fresh_tvar()
+    fn1 = Callable[[Callable[[tv1, int], int]], bool]
+    fn2 = Callable[[Callable[[int, int], int]], bool]
+    fn3 = Callable[[tv2], bool]
+
+    unify_helper(fn1, fn2, Callable[[Callable[[int, int], int]], bool])
+    unify_helper(fn1, fn3, Callable[[Callable[[int, int], int]], bool])
+
+    resolve_helper(tv1, int)
+    resolve_helper(tv2, Callable[[int, int], int])
+

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -9,7 +9,7 @@ tc = TypeConstraints()
 
 
 # Helper functions
-def unify_helper(arg1: type, arg2: type, exp_result: type):
+def unify_helper(arg1: type, arg2: type, exp_result: Union[type, TypeFail]):
     unify_result = TypeInfo(arg1) >> (
         lambda t1: TypeInfo(arg2) >> (
             lambda t2: tc.unify(t1, t2)))

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -9,7 +9,7 @@ tc = TypeConstraints()
 
 
 # Helper functions
-def unify_helper(arg1: type, arg2: type, exp_result: Union[type, TypeFail]):
+def unify_helper(arg1: type, arg2: type, exp_result: type):
     unify_result = TypeInfo(arg1) >> (
         lambda t1: TypeInfo(arg2) >> (
             lambda t2: tc.unify(t1, t2)))


### PR DESCRIPTION
Also added two tests for polymorphic function calls.