### PR TITLE
Typecheck: handling classes without initalizer

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -278,6 +278,7 @@ class TypeInferer:
                 init_type = Callable[[callable_t], None]
             # TODO: handle method overloading (through optional parameters)
             arg_types = [callable_t] + [arg.inf_type.getValue() for arg in node.args]
+            # TODO: Check for number of arguments if function is an initializer
             self.type_constraints.unify_call(init_type, *arg_types)
             node.inf_type = TypeInfo(callable_t)
         else:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -272,8 +272,11 @@ class TypeInferer:
                 func_name = callable_t.__forward_arg__
             else:
                 func_name = callable_t.__args__[0].__name__
-            init_types = self.type_store.classes[func_name]['__init__']
-            init_type = init_types[0]  # TODO: handle method overloading (through optional parameters)
+            if '__init__' in self.type_store.classes[func_name]:
+                init_type = self.type_store.classes[func_name]['__init__'][0]
+            else:
+                init_type = Callable[[callable_t], None]
+            # TODO: handle method overloading (through optional parameters)
             arg_types = [callable_t] + [arg.inf_type.getValue() for arg in node.args]
             self.type_constraints.unify_call(init_type, *arg_types)
             node.inf_type = TypeInfo(callable_t)

--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -23,6 +23,7 @@ Done.
 **TODOs:**
 * Handling of "overloaded" functions (with optional arguments)
 * Improve handling of initializers
+  * Check number of arguments when instantiating a class that uses an initializer with multiple arguments
 * Handling inheritance
 
 ### ClassDef

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -1,10 +1,7 @@
 import astroid
 from typing import _ForwardRef
-from python_ta.transforms.type_inference_visitor import TypeInferer
 import tests.custom_hypothesis_support as cs
-from python_ta.typecheck.base import TypeInfo, TypeFail
 from nose.tools import eq_
-from nose import SkipTest
 
 
 def test_class_with_init():
@@ -26,27 +23,10 @@ def test_class_without_init():
     program = """
     class Foo:
         def fee(self):
-            return 4
+            return 1
 
     foo = Foo()
     """
-    ast_mod, ti = cs._parse_text(program)
-    for call_node in ast_mod.nodes_of_class(astroid.Call):
-        assert isinstance(call_node.inf_type.getValue(), _ForwardRef)
-        eq_(call_node.inf_type.getValue(), _ForwardRef('Foo'))
-
-
-def test_class_with_multi_init():
-    program = """
-    class Foo:
-    
-        def __init__(self, x):
-            self.a = x
-
-    foo = Foo(5, 6)
-    """
-
-    # raise SkipTest("Should indicate that Foo() is called with the wrong number of arguments")
     ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         assert isinstance(call_node.inf_type.getValue(), _ForwardRef)

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -1,0 +1,52 @@
+import astroid
+from typing import _ForwardRef
+from python_ta.transforms.type_inference_visitor import TypeInferer
+import tests.custom_hypothesis_support as cs
+from python_ta.typecheck.base import TypeInfo, TypeFail
+from nose.tools import eq_
+from nose import SkipTest
+
+
+def test_class_with_init():
+    program = """
+    class Foo:
+    
+        def __init__(self):
+            self.a = 5
+    
+    foo = Foo()
+    """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type.getValue(), _ForwardRef)
+        eq_(call_node.inf_type.getValue(), _ForwardRef('Foo'))
+
+
+def test_class_without_init():
+    program = """
+    class Foo:
+        def fee(self):
+            return 4
+
+    foo = Foo()
+    """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type.getValue(), _ForwardRef)
+        eq_(call_node.inf_type.getValue(), _ForwardRef('Foo'))
+
+
+def test_class_with_multi_init():
+    program = """
+    class Foo:
+    
+        def __init__(self, x):
+            self.a = x
+
+    foo = Foo(5, 6)
+    """
+    raise SkipTest("Should indicate that Foo() is called with the wrong number of arguments")
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type.getValue(), _ForwardRef)
+        eq_(call_node.inf_type.getValue(), _ForwardRef('Foo'))

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -45,7 +45,8 @@ def test_class_with_multi_init():
 
     foo = Foo(5, 6)
     """
-    raise SkipTest("Should indicate that Foo() is called with the wrong number of arguments")
+
+    # raise SkipTest("Should indicate that Foo() is called with the wrong number of arguments")
     ast_mod, ti = cs._parse_text(program)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         assert isinstance(call_node.inf_type.getValue(), _ForwardRef)


### PR DESCRIPTION
`visit_call` checks for an `__init__` function, and if there is none, creates a callable with the same type signature that an initialization function would have, to be passed to `unify_call`