### PR TITLE
Typecheck: Overloaded functions

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -267,7 +267,7 @@ class TypeInferer:
     ##############################################################################
     def visit_call(self, node: astroid.Call) -> None:
         callable_t = node.func.inf_type.getValue()
-        if not isinstance(callable_t, (CallableMeta, list)):
+        if not isinstance(callable_t, (CallableMeta, list)) and callable_t.__origin__ is not Union:
             if isinstance(callable_t, _ForwardRef):
                 func_name = callable_t.__forward_arg__
             else:
@@ -463,6 +463,12 @@ class TypeInferer:
         # Update the environment storing the function's type.
         polymorphic_tvars = [arg for arg in combined_args if isinstance(arg, TypeVar)]
         func_type = create_Callable(combined_args, combined_return, polymorphic_tvars)
+        num_defaults = len(node.args.defaults)
+        if num_defaults > 0:
+            for i in range(num_defaults):
+                opt_args = inferred_args[:-1-i]
+                opt_func_type = create_Callable(opt_args, combined_return, polymorphic_tvars)
+                func_type = Union[func_type, opt_func_type]
         self.type_constraints.unify(self.lookup_type(node.parent, node.name), func_type)
 
     def visit_return(self, node: astroid.Return) -> None:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -404,7 +404,17 @@ class TypeConstraints:
         Return a result type.
         """
         # Check that the number of parameters matches the number of arguments.
-        if len(func_type.__args__) - 1 != len(arg_types):
+        if func_type.__origin__ is Union:
+            new_func_type = None
+            for c in func_type.__args__:
+                if len(c.__args__) - 1 == len(arg_types):
+                    new_func_type = c
+            if new_func_type is None:
+                # TODO: Should this return a unique error message?
+                return TypeFail('Wrong number of arguments')
+            else:
+                func_type = new_func_type
+        elif len(func_type.__args__) - 1 != len(arg_types):
             return TypeFail('Wrong number of arguments')
 
         # Substitute polymorphic type variables

--- a/tests/test_type_inference/test_function_overload.py
+++ b/tests/test_type_inference/test_function_overload.py
@@ -1,0 +1,108 @@
+import astroid
+from python_ta.typecheck.base import TypeInfo, TypeFail
+import tests.custom_hypothesis_support as cs
+from nose.tools import eq_
+
+
+def test_overload_function():
+    program = """
+    def foo(x, y=None):
+        return x + 5
+
+    foo(5)
+    foo(5, 6)
+    """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type.getValue(), int)
+
+
+def test_overload_function_2():
+    program = """
+    def foo(x, y=None, z=None):
+        return x + 5
+    foo(5)
+    foo(5, 6)
+    foo(5, 6, 7)
+    foo(5, None, 7)
+    """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type.getValue(), int)
+
+
+def test_too_few_args():
+    program = """
+       def foo(x, y):
+           return x + 5
+       foo(5)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_few_args_2():
+    program = """
+       def foo(x, y, z):
+           return x + 5
+       foo(5, 6)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_many_args():
+    program = """
+       def foo(x):
+           return x + 5
+       foo(5, 6)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+def test_too_many_args_2():
+    program = """
+       def foo(x, y):
+           return x + 5
+       foo(5, 6, 7)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_few_args_with_overload():
+    program = """
+       def foo(x, y, z=None):
+           return x + 5
+       foo(5)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_too_many_args_with_overload():
+    program = """
+       def foo(x, y=None):
+           return x + 5
+       foo(5, 6, y)
+       """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type, TypeFail("Wrong number of arguments"))
+
+
+def test_overload_function_with_annotations():
+    program = """
+    def foo(x: int, y: int=None):
+        return x + 5
+    foo(5)
+    foo(5, 6)
+    """
+    ast_mod, ti = cs._parse_text(program)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        eq_(call_node.inf_type.getValue(), int)


### PR DESCRIPTION
Editing `visit_functiondef` to check for optional arguments, and assign a `Union` of different possible type signatures as the inferred type of that `FunctionDef node`
Editing `unify_call` to handle being passed a `Union` of `Callable`s
Adding test cases for overloaded functions
Planning to make additional changes to `type_store` to handle this representation of this representation of type signatures, will include in separate pull request 