### PR TITLE
typecheck: Add a scratch file for planning out error msgs

### DIFF
--- a/scratch/expected_error_msgs.py
+++ b/scratch/expected_error_msgs.py
@@ -1,0 +1,93 @@
+x = 3
+x = 'abc'
+
+'''
+Error: Type inference contradiction in the expression
+    <line#> | x
+Expected type is 'int' due to the expression
+    <line#> | x = 3
+but used as 'str' in
+    <line#> | x = 'abc'
+'''
+
+################################################################################
+
+def f(a, b):
+    return a == b
+
+f('abc', True)
+
+'''
+Error: Type inference contradiction in the parameter 'a' of
+    <line#> | f(a, b)
+Expected type is 'bool' due to the expression
+    <line#> | return a == b
+but passed in a 'str' in the expression
+    <line#> | f('abc', True)
+'''
+
+################################################################################
+
+x = 3
+y = x
+
+def f(a):
+    return a == 0
+
+f(y)
+
+'''
+Error: Type inference contradiction in the parameter 'a' of
+    <line#> | f(a)
+Expected type is 'bool' due to the expression
+    <line#> | return a == 0
+but passed in an 'int' in the expression
+    <line#> | f(y)
+    
+Namely,
+
+* type of
+    <line#> | y
+is 'int' due to the expression
+    <line#> | y = x
+* type of 
+    <line#> | x
+is 'int' due to the expression
+    <line#> | x = 3
+'''
+
+################################################################################
+
+x = 0
+
+def f(a):
+    return a + x
+
+def g(b):
+    return b + 'abc'
+
+g(f(x))
+
+'''
+Error: Type inference contradiction in the parameter 'b' of
+    <line#> | g(b)
+Expected type is 'str' due to the expression
+    <line#> | return b + 'abc'
+but passed in an 'int' in the expression
+    <line#> g(f(x))
+    
+Namely,
+
+* type of
+    <line#> | f(x) 
+is 'int' due to the expression
+    <line#> | return a + x
+* type of
+    <line#> | x
+is 'int' due to the expression
+    <line#> | x = 0
+    
+'''
+
+################################################################################
+

--- a/scratch/expected_error_msgs.py
+++ b/scratch/expected_error_msgs.py
@@ -74,7 +74,7 @@ Error: Type inference contradiction in the parameter 'b' of
 Expected type is 'str' due to the expression
     <line#> | return b + 'abc'
 but passed in an 'int' in the expression
-    <line#> g(f(x))
+    <line#> | g(f(x))
     
 Namely,
 
@@ -86,8 +86,30 @@ is 'int' due to the expression
     <line#> | x
 is 'int' due to the expression
     <line#> | x = 0
-    
 '''
 
 ################################################################################
 
+def f(a, b):
+    if a > 0 and b:
+        a = b
+
+'''
+Error: Type inference contradiction in the parameter 'b' of
+    <line#> | f(a, b)
+Expected type is 'bool' due to the expression
+    <line#> | if a > 0 and b:
+but used as an 'int' in the expression
+    <line#> | a = b
+    
+Namely,
+
+* type of
+    <line#> | b
+is 'int' due to the expression
+    <line#> | a = b
+* type of
+    <line#> | a
+is 'int' due to the expression
+    <line#> a > 0
+'''


### PR DESCRIPTION
I think it could be helpful if we plan out and agree on the expected behaviour of type-checker error handling before starting to implement things (that way we can work backwards to figure out the necessary structural changes). I've added a file consisting of example programs with type errors and for each the sort of message that we expect to be provided to the user. Eventually this could be converted into an actual test file.