### PR TITLE
Typecheck: Checking inferred values of variables during re-assignment

### DIFF
--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -19,22 +19,34 @@ def generate_tuple(length: int, t: type=None):
     return program
 
 
-def generate_tuple_assign(length: int, same_length: bool, more_args: bool = None):
+def generate_tuple_assign(length: int, t: type, same_length: bool, more_args: bool = None):
     program = ''
-    type_list = [int, bool, str]
-    for t in type_list:
-        for i in range(1, length):
-            for j in range(1, length):
-                if same_length and i == j:
+    for i in range(1, length):
+        for j in range(1, length):
+            if same_length and i == j:
+                program += generate_tuple(i) + '= ' + generate_tuple(j, t) + '\n'
+            elif not same_length:
+                if (more_args and i > j) or (not more_args and i < j):
                     program += generate_tuple(i) + '= ' + generate_tuple(j, t) + '\n'
-                elif not same_length:
-                    if (more_args and i > j) or (not more_args and i < j):
-                        program += generate_tuple(i) + '= ' + generate_tuple(j, t) + '\n'
     return program
 
 
-def test_tuple_same_length():
-    program = generate_tuple_assign(10, True)
+def test_tuple_same_length_int():
+    program = generate_tuple_assign(10, int, True)
+    module, _ = cs._parse_text(program)
+    for assign_node in module.nodes_of_class(astroid.Assign):
+        eq_ (assign_node.inf_type, TypeInfo(NoType))
+
+
+def test_tuple_same_length_bool():
+    program = generate_tuple_assign(10, bool, True)
+    module, _ = cs._parse_text(program)
+    for assign_node in module.nodes_of_class(astroid.Assign):
+        eq_ (assign_node.inf_type, TypeInfo(NoType))
+
+
+def test_tuple_same_length_str():
+    program = generate_tuple_assign(10, str, True)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
         eq_ (assign_node.inf_type, TypeInfo(NoType))
@@ -65,7 +77,7 @@ def test_tuple_single_val():
 
 
 def test_tuple_extra_vars():
-    program = generate_tuple_assign(10, False, True)
+    program = generate_tuple_assign(10, int, False, True)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert isinstance(assign_node.inf_type, TypeFail)
@@ -73,7 +85,7 @@ def test_tuple_extra_vars():
 
 
 def test_tuple_extra_value():
-    program = generate_tuple_assign(10, False, False)
+    program = generate_tuple_assign(10, int, False, False)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert isinstance(assign_node.inf_type, TypeFail)


### PR DESCRIPTION
Added lines to `visit_assign` to properly set `inf_type` in the case of a type failure
Change return type of `_assign_type` to return a TypeResult
Separated tests in `test_assign_tuple` for tuples of different types