### PR TITLE
Typecheck: __init__ with multiple arguments

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -33,6 +33,9 @@ class TypeInferer:
     def __init__(self):
         self.type_constraints.reset()
 
+    def reset(self):
+        self.type_store = TypeStore(self.type_constraints)
+
     ###########################################################################
     # Setting up the environment
     ###########################################################################
@@ -289,7 +292,11 @@ class TypeInferer:
             # TODO: handle method overloading (through optional parameters)
             arg_types = [callable_t] + [arg.inf_type.getValue() for arg in node.args]
             # TODO: Check for number of arguments if function is an initializer
-            node.inf_type = self.type_constraints.unify_call(init_type, *arg_types)
+            type_result = self.type_constraints.unify_call(init_type, *arg_types)
+            if isinstance(type_result, TypeFail):
+                node.inf_type = type_result
+            else:
+                node.inf_type = TypeInfo(callable_t)
         else:
             # TODO: resolve this case (from method lookup) more gracefully
             if isinstance(callable_t, list):

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -289,8 +289,7 @@ class TypeInferer:
             # TODO: handle method overloading (through optional parameters)
             arg_types = [callable_t] + [arg.inf_type.getValue() for arg in node.args]
             # TODO: Check for number of arguments if function is an initializer
-            self.type_constraints.unify_call(init_type, *arg_types)
-            node.inf_type = TypeInfo(callable_t)
+            node.inf_type = self.type_constraints.unify_call(init_type, *arg_types)
         else:
             # TODO: resolve this case (from method lookup) more gracefully
             if isinstance(callable_t, list):
@@ -503,8 +502,10 @@ class TypeInferer:
         expr_type = node.expr.inf_type.getValue()
         if isinstance(expr_type, _ForwardRef):
             type_name =  expr_type.__forward_arg__
-        else:
+        elif hasattr(expr_type, '__name__'):
             type_name = expr_type.__name__
+        else:
+            type_name = None
         if type_name not in self.type_store.classes:
             node.inf_type = TypeFail('Invalid attribute type')
         else:

--- a/tests/custom_hypothesis_support.py
+++ b/tests/custom_hypothesis_support.py
@@ -352,7 +352,7 @@ subscriptable_expr = hs.one_of(
 
 
 # Helper functions for testing
-def _parse_text(source: Union[str, NodeNG]) -> Tuple[astroid.Module, TypeInferer]:
+def _parse_text(source: Union[str, NodeNG], reset: bool = False) -> Tuple[astroid.Module, TypeInferer]:
     """Parse source code text and output an AST with type inference performed."""
     # TODO: apparently no literal syntax for empty set in Python3, also cannot do set()
     # TODO: Deal with special case later.
@@ -362,6 +362,8 @@ def _parse_text(source: Union[str, NodeNG]) -> Tuple[astroid.Module, TypeInferer
         source = source.as_string()
     module = astroid.parse(source)
     type_inferer = TypeInferer()
+    if reset:
+        type_inferer.reset()
     type_inferer.environment_transformer().visit(module)
     type_inferer.type_inference_transformer().visit(module)
     return module, type_inferer

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -39,7 +39,7 @@ def test_classdef_method_call():
               f'rogers = Network("Rogers")\n' \
               f'rogers.get_name()' \
               f'\n'
-    module, inferer = cs._parse_text(program)
+    module, inferer = cs._parse_text(program, True)
     attribute_node = list(module.nodes_of_class(astroid.Attribute))[1]
     expected_rtype = attribute_node.parent.inf_type.getValue()
     actual_rtype = inferer.type_constraints.resolve(attribute_node.inf_type.getValue().__args__[-1]).getValue()

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -2,6 +2,7 @@ import astroid
 from typing import _ForwardRef
 import tests.custom_hypothesis_support as cs
 from nose.tools import eq_
+from python_ta.transforms.type_inference_visitor import TypeFail
 
 
 def test_class_with_init():
@@ -31,3 +32,17 @@ def test_class_without_init():
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         assert isinstance(call_node.inf_type.getValue(), _ForwardRef)
         eq_(call_node.inf_type.getValue(), _ForwardRef('Foo'))
+
+
+def test_wrong_number_init():
+    program = """
+    class Foo:
+        def __init__(self, x):
+            self.a = x
+
+    foo = Foo()
+    """
+    ast_mod, ti = cs._parse_text(program, True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type, TypeFail)
+        eq_(call_node.inf_type.getValue(), 'Wrong number of arguments')


### PR DESCRIPTION
Added proper error checking in `visit_call`
Edited `visit_attribute` to account for TypeFail objects, which do not have a `__name__` attribute
Added new test to `test_initializer`
Added `reset` function to `type_inference_visitor` to reset TypeStore, edited `_parse_text` to include a flag for resetting before parsing text
Edited tests in `test_classdef` to make use of `reset` (information from previous tests was being carried over)