### PR TITLE
Typecheck: assigning tuple to single variable

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -221,8 +221,6 @@ class TypeInferer:
                     node.inf_type = TypeFail("Too many values in assignment node")
                 elif len(expr_type.__args__) < len(target.elts):
                     node.inf_type = TypeFail("Too many variables in assignment node")
-            elif isinstance(expr_type, typing.TupleMeta):
-                node.inf_type = TypeFail("Cannot assign multiple values to single variable")
             elif isinstance(target, astroid.Tuple):
                 node.inf_type = TypeFail("Cannot assign single value to multiple variables")
 

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -1,5 +1,6 @@
 import astroid
 from nose.tools import eq_
+from typing import TupleMeta
 import tests.custom_hypothesis_support as cs
 from python_ta.transforms.type_inference_visitor import NoType
 from python_ta.typecheck.base import TypeInfo, TypeFail
@@ -60,9 +61,7 @@ def test_tuple_single_var():
     """
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        assert isinstance(assign_node.inf_type, TypeFail)
-        eq_(assign_node.inf_type, TypeFail("Cannot assign multiple values to single variable"))
-
+        eq_(assign_node.inf_type, TypeInfo(NoType))
 
 def test_tuple_single_val():
     program = """


### PR DESCRIPTION
Previously treated assigning a tuple to a single variable as an error, however this should be valid python code