### PR TITLE
Creating _TNodes in failed unify call

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -125,7 +125,6 @@ Done.
 - Edit unify to:
   - Take as an argument the astroid node in which the unification is taking place
   - Return TypeFail with new attributes
-  - Create _TNodes for arguments in failed unification, if they do not already exist
 - Edit all functions that use resolve, unify, _merge_sets, _assign_type, _handle_call to be properly monadic
 
 ### Other

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -318,6 +318,17 @@ class TypeConstraints:
         elif t1 == t2:
             return TypeInfo(t1)
         else:
+            has_t1 = False
+            has_t2 = False
+            for i in self._nodes:
+                if i.type == t1:
+                    has_t1 = True
+                if i.type == t2:
+                    has_t2 = True
+            if not has_t1:
+                self._make_set(t1)
+            if not has_t2:
+                self._make_set(t2)
             return TypeFail(f'Incompatible types {t1} and {t2}')
 
     def _unify_generic(self, t1: GenericMeta, t2: GenericMeta) -> TypeResult:


### PR DESCRIPTION
Create _TNodes for arguments in failed unification, if they do not already exist