### PR TITLE
Changing type annotation of _nodes

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -121,7 +121,6 @@ Done.
 ### New Error Type
 - Edit TypeFail to include new attributes src_node, tnode1, tnode2
 - Edit _TNode to include new attributes ast_node, ctx_node
-- Change type annotation of _nodes to reflect its actual type, list of _TNodes, rather than a list of sets of _TNodes 
 - Edit unify to:
   - Take as an argument the astroid node in which the unification is taking place
   - Return TypeFail with new attributes

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -195,8 +195,8 @@ class TypeConstraints:
     """
     # The number of type variables stored in the data structure. Used to generate fresh type variables.
     _count: int
-    # The disjoint sets.
-    _nodes: List[Set[_TNode]]
+    # List of _TNodes
+    _nodes: List[_TNode]
     # A mapping of type variable names to nodes.
     _tvar_to_tnode: Dict[str, _TNode]
 


### PR DESCRIPTION
Change type annotation of _nodes to reflect its actual type, list of _TNodes, rather than a list of sets of _TNodes