### PR TITLE
Typecheck: TNode lookup in visit functions

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -357,16 +357,16 @@ class TypeConstraints:
         rep2 = self._find(t2)
         if isinstance(rep1.type, TypeVar) and isinstance(rep2.type, TypeVar):
             if rep1.type.__name__ < rep2.type.__name__:
-                rep2.parent = rep1
+                rep2.parent = self._tvar_to_tnode[t1]
                 return TypeInfo(rep1.type)
             else:
                 rep1.parent = rep2
                 return TypeInfo(rep2.type)
         elif isinstance(rep2.type, TypeVar):
-            rep2.parent = rep1
+            rep2.parent = self._tvar_to_tnode[t1]
             return TypeInfo(rep2.type)
         elif isinstance(rep1.type, TypeVar):
-            rep1.parent = rep2
+            rep1.parent = self._tvar_to_tnode[t2]
             return TypeInfo(rep2.type)
         else:
             # In this case both set representatives are concrete types.

--- a/tests/test_type_inference/test_assign.py
+++ b/tests/test_type_inference/test_assign.py
@@ -45,7 +45,7 @@ def test_set_name_assigned(variables_dict):
     module, inferer = cs._parse_text(program)
     for name_node in module.nodes_of_class(astroid.Name):
         name_type = inferer.lookup_type(name_node, name_node.name)
-        assert name_node.inf_type.getValue() == name_type
+        assert inferer.type_constraints.resolve(name_node.inf_type.getValue()).getValue() == name_type
 
 
 @given(cs.random_dict_variable_homogeneous_value(min_size=1))


### PR DESCRIPTION
Modifying various visit functions to assign TypeVar to inf_type instead of resolving to concrete type right away
`visit_name` and `visit_assign` now look up and assign `TypeVar`
`visit_attribute` and `visit_call` now check to see if the `inf_type` of the `func` or `expr` nodes are `TypeVar`, and resolve if they are
`_merge_sets` now sets parent as the `TypeVar` `_TNode`, rather than the concrete type `_TNode`
Editing test case in `test_assign` to account for changes

* Unsure if this is the best approach in the long run. Strongly considering changing TypeConstraints to use proper disjoint sets, so that looking up connections between TNodes can happen in more than one direction