### PR TITLE
typecheck: Unifying TypeVar with itself

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -390,8 +390,11 @@ class TypeConstraints:
 
         # New implementation of unify
         else:
-            self.create_edges(tnode1, tnode2, ast_node)
-            return TypeInfo(None)
+            if t1 == t2:
+                return TypeInfo(t1)
+            else:
+                self.create_edges(tnode1, tnode2, ast_node)
+                return TypeInfo(None)
 
     def _unify_generic(self, tnode1: _TNode, tnode2: _TNode,
                        ast_node: Optional[NodeNG] = None) -> TypeResult:


### PR DESCRIPTION
Adding proper behavior for attempting to unify two of the same variable where both variables are not concrete