### PR TITLE
Add a checker for bad loop indexing

### DIFF
--- a/examples/bad_loop_indexing_example.py
+++ b/examples/bad_loop_indexing_example.py
@@ -1,0 +1,52 @@
+"""Examples of bad-loop-indexing"""
+
+
+def sum_items(lst):
+    """This is the simplest example. i is only used to index lst."""
+    s = 0
+    for i in range(len(lst)):
+        s += lst[i]
+
+    return s
+
+
+def sum_two_items(lst1, lst2):
+    """Two for-loops with bad index usage."""
+    s = 0
+    for i in range(len(lst1)):
+        s += lst1[i]
+    for j in range(len(lst2)):
+        s += lst2[j]
+
+    return s
+
+
+def nested(lst):
+    """Nested for-loops with bad index usage."""
+    s = 0
+    for i in range(len(lst)):
+        s += lst[i]
+        for j in range(len(lst)):
+            s += lst[j]
+
+    return s
+
+
+def multiple_assign(lst):
+    """For-loops containing multiple and simultaneous assignements."""
+    for i in range(len(lst)):
+        x = y = lst[i]
+    for i in range(len(lst)):
+        x, y = lst[i], lst[i] + 1
+
+
+def index_in_if(lst):
+    """For-loop containing an if statement with bad use of index"""
+    s = 0
+    for i in range(len(lst)):
+        if lst[i] % 2 == 0:
+            s += 1
+
+    return s
+
+# TODO: keep looking for more examples

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -171,7 +171,8 @@ def reset_linter(config=None, file_linted=None):
         'python_ta/checkers/assigning_to_self_checker',
         'python_ta/checkers/always_returning_checker',
         'python_ta/checkers/constant_test_checker',
-        'python_ta/checkers/structure_test_checker'
+        'python_ta/checkers/structure_test_checker',
+        'python_ta/checkers/bad_loop_indexing_checker'
         #'python_ta/checkers/simplified_if_checker'
         # TODO: Eventually enable this checker
         # 'python_ta/checkers/type_inference_checker'

--- a/python_ta/checkers/bad_loop_indexing_checker.py
+++ b/python_ta/checkers/bad_loop_indexing_checker.py
@@ -5,6 +5,7 @@ import astroid
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
+from typing import List
 
 
 class BadLoopIndexingChecker(BaseChecker):
@@ -25,73 +26,82 @@ class BadLoopIndexingChecker(BaseChecker):
         """Return whether the usage of the indexing variable in the for-loop is ONLY to index the iterable.
         True if bad, False if not bad.
         """
-        # store the iteration variable
+        # Store the iteration variable
         index = node.target.name
 
-        # check if the iterable of the for-loop is of the form "range(len(lst))"
-        if isinstance(node.iter, astroid.Call):
-            _iter = node.iter
-            if isinstance(_iter.func, astroid.Name):
-                if _iter.func.name == 'range' and isinstance(_iter.args[0], astroid.Call):
-                    _iter2 = _iter.args[0]
-                    if isinstance(_iter2.func, astroid.Name) and _iter2.func.name == 'len':
-                        iterable = _iter2.args[0].name
-                    else:
-                        return False
-                else:
-                    return False
-            # _iter.func is Attribute node
-            else:
-                return False
+        # Check if the iterable of the for-loop is of the form "range(len(lst))"
+        iterable_lst = _check_iterable_is_range(node)
+        if iterable_lst:
+            iterable = iterable_lst[0]
         else:
             return False
 
-        # use nodes_of_class to find Name nodes
-        for node in node.nodes_of_class(astroid.Name):
-            if node.name == index:
-                if isinstance(node.parent, astroid.Index):
-                    if isinstance(node.parent.parent, astroid.Subscript):
-                        subscript_node = node.parent.parent
-                        if subscript_node.value.name == iterable:
-                            # iterable[index] (eg. lst[i]) used in the left side of an assignment
-                            # Assign node of form "a = b = 1"
-                            if isinstance(subscript_node.parent, astroid.Assign):
-                                if any(target == subscript_node for target in subscript_node.parent.targets):
-                                    return False
-                                else:
-                                    return True
-                            # Assign node of form "a, b = 1, 2"
-                            elif isinstance(subscript_node.parent, astroid.Tuple):
-                                if isinstance(subscript_node.parent.parent, astroid.Assign):
-                                    if any(target == subscript_node for target in
-                                           subscript_node.parent.parent.targets[0].elts):
-                                        return False
-                                    else:
-                                        return True
-                            # AugAssign node
-                            elif isinstance(subscript_node.parent, astroid.AugAssign):
-                                if subscript_node == subscript_node.parent.target:
-                                    return False
-                                else:
-                                    return True
-                            # iterable[index] not used in the left side of an assignment ie. bad usage
-                            else:
-                                return True
-                # It will pass through to here if node.name == index but not subscript_node.slice.name == iterable
-                # ie. if Name node with <index> is found but not used in the form of <iterable[index]>
-                return False
-            # else:
-            # go to the next Name node
-        # If all Name nodes are searched but none of them are <index> which means the indexing variable was not used.
-        # There already is an unused variable checker to catch this error.
-        # TODO: is it sufficient to only search for the indexing variable in the Name nodes???
-        return False
+        # Use node_of_class to find all Name nodes.
+        if any(_check_correct_usage(name_node, index, iterable) for name_node in node.nodes_of_class(astroid.Name)):
+            return False
+        # There is at least one 'index' Name node and they are all used badly.
+        elif any(name_node.name == index for name_node in node.nodes_of_class(astroid.Name)):
+            return True
+        # There are no 'index' Name nodes.
+        # Bad-loop-indexing checker should not catch an error since this is a case for
+        # checker W0612(unused-variable) to prevent duplicating error detection.
+        else:
+            return False
 
     # pass in message symbol as a parameter of check_messages
     @check_messages("bad-loop-indexing")
     def visit_for(self, node):
         if self._check_bad_loop_indexing(node):
             self.add_message('bad-loop-indexing', node=node)
+
+
+# Helper functions
+def _check_iterable_is_range(node: astroid.For) -> List[str]:
+    """Return a list containing the iterable of this For node if it is of the form: range(len(iterable)).
+    Return an empty list if it is not of this form.
+    """
+    _iter = node.iter
+    # Order of operations is important
+    if isinstance(_iter, astroid.Call) and isinstance(_iter.func, astroid.Name) \
+            and _iter.func.name == 'range' and isinstance(_iter.args[0], astroid.Call) \
+            and isinstance(_iter.args[0].func, astroid.Name) and _iter.args[0].func.name == 'len':
+        return [_iter.args[0].args[0].name]
+    else:
+        return []
+
+
+def _check_correct_usage(node: astroid.Name, index: str, iterable: str) -> bool:
+    """Return whether or not this Name node 'index' was used correctly in the for loop.
+    Return True if correctly used, False if badly used or node is not 'index'.
+    """
+    # If Name node is 'index'
+    if node.name == index:
+        # If Name node is inside Subscript node iterable[index]
+        if isinstance(node.parent, astroid.Index) and isinstance(node.parent.parent, astroid.Subscript) \
+                and node.parent.parent.value.name == iterable:
+            subscript_node = node.parent.parent
+            # iterable[index] (eg. lst[i]) used in the left side of an assignment
+            # Assign node of form "a = b = 1"
+            if isinstance(subscript_node.parent, astroid.Assign):
+                if any(target == subscript_node for target in subscript_node.parent.targets):
+                    return True
+            # Assign node of form "a, b = 1, 2"
+            elif isinstance(subscript_node.parent, astroid.Tuple) and \
+                    isinstance(subscript_node.parent.parent, astroid.Assign):
+                if any(target == subscript_node for target in subscript_node.parent.parent.targets[0].elts):
+                    return True
+            # AugAssign node
+            elif isinstance(subscript_node.parent, astroid.AugAssign):
+                if subscript_node == subscript_node.parent.target:
+                    return True
+            # 1)iterable[index] not used on the left side of Assign/AugAssign statement (eg. s += iterable[index])
+            # 2)iterable[index] not used as part of Assign/AugAssign statement (eg. if iterable[index] % 2 == 0:)
+            return False
+        # Name node is not inside Subscript node iterable[index]
+        else:
+            return True
+    else:
+        return False
 
 
 def register(linter):

--- a/python_ta/checkers/bad_loop_indexing_checker.py
+++ b/python_ta/checkers/bad_loop_indexing_checker.py
@@ -1,0 +1,98 @@
+"""checker for bad indexing in a loop.
+"""
+
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages
+
+
+class BadLoopIndexingChecker(BaseChecker):
+    __implements__ = IAstroidChecker
+    # name is the same as file name but without _checker part
+    name = 'bad_loop_indexing'
+    # use dashes for connecting words in message symbol
+    msgs = {'E9994': ('Bad loop indexing used in this for-loop',
+                      'bad-loop-indexing',
+                      'Used when you have an iteration variable in a for-loop '
+                      'where its only usage is to index the iterable it is iterating over'),
+            }
+
+    # this is important so that your checker is executed before others
+    priority = -1
+
+    def _check_bad_loop_indexing(self, node):
+        """Return whether the usage of the indexing variable in the for-loop is ONLY to index the iterable.
+        True if bad, False if not bad.
+        """
+        # store the iteration variable
+        index = node.target.name
+
+        # check if the iterable of the for-loop is of the form "range(len(lst))"
+        if isinstance(node.iter, astroid.Call):
+            _iter = node.iter
+            if isinstance(_iter.func, astroid.Name):
+                if _iter.func.name == 'range' and isinstance(_iter.args[0], astroid.Call):
+                    _iter2 = _iter.args[0]
+                    if isinstance(_iter2.func, astroid.Name) and _iter2.func.name == 'len':
+                        iterable = _iter2.args[0].name
+                    else:
+                        return False
+                else:
+                    return False
+            # _iter.func is Attribute node
+            else:
+                return False
+        else:
+            return False
+
+        # use nodes_of_class to find Name nodes
+        for node in node.nodes_of_class(astroid.Name):
+            if node.name == index:
+                if isinstance(node.parent, astroid.Index):
+                    if isinstance(node.parent.parent, astroid.Subscript):
+                        subscript_node = node.parent.parent
+                        if subscript_node.value.name == iterable:
+                            # iterable[index] (eg. lst[i]) used in the left side of an assignment
+                            # Assign node of form "a = b = 1"
+                            if isinstance(subscript_node.parent, astroid.Assign):
+                                if any(target == subscript_node for target in subscript_node.parent.targets):
+                                    return False
+                                else:
+                                    return True
+                            # Assign node of form "a, b = 1, 2"
+                            elif isinstance(subscript_node.parent, astroid.Tuple):
+                                if isinstance(subscript_node.parent.parent, astroid.Assign):
+                                    if any(target == subscript_node for target in
+                                           subscript_node.parent.parent.targets[0].elts):
+                                        return False
+                                    else:
+                                        return True
+                            # AugAssign node
+                            elif isinstance(subscript_node.parent, astroid.AugAssign):
+                                if subscript_node == subscript_node.parent.target:
+                                    return False
+                                else:
+                                    return True
+                            # iterable[index] not used in the left side of an assignment ie. bad usage
+                            else:
+                                return True
+                # It will pass through to here if node.name == index but not subscript_node.slice.name == iterable
+                # ie. if Name node with <index> is found but not used in the form of <iterable[index]>
+                return False
+            # else:
+            # go to the next Name node
+        # If all Name nodes are searched but none of them are <index> which means the indexing variable was not used.
+        # There already is an unused variable checker to catch this error.
+        # TODO: is it sufficient to only search for the indexing variable in the Name nodes???
+        return False
+
+    # pass in message symbol as a parameter of check_messages
+    @check_messages("bad-loop-indexing")
+    def visit_for(self, node):
+        if self._check_bad_loop_indexing(node):
+            self.add_message('bad-loop-indexing', node=node)
+
+
+def register(linter):
+    linter.register_checker(BadLoopIndexingChecker(linter))


### PR DESCRIPTION
I made a new PyTA checker that looks at the usage of the iteration variable in a for-loop and checks if its only use is to index the iterable it is iterating over. Here are some examples.

Example 1 (bad usage):
![image](https://user-images.githubusercontent.com/37294635/41309076-af0be4ee-6e4b-11e8-9c8c-044102304627.png)
![screen shot 2018-06-12 at 2 24 43 pm](https://user-images.githubusercontent.com/37294635/41309608-36714842-6e4d-11e8-82a4-6973c3d35e12.png)


Example 2 (bad usage):
![screen shot 2018-06-12 at 2 25 21 pm](https://user-images.githubusercontent.com/37294635/41309617-3ca31132-6e4d-11e8-88ac-3327d9b586b4.png)
![screen shot 2018-06-12 at 2 25 04 pm](https://user-images.githubusercontent.com/37294635/41309853-cad07094-6e4d-11e8-8013-9e21de63fb6b.png)


Example 3 (correct usage):
![screen shot 2018-06-12 at 2 03 41 pm](https://user-images.githubusercontent.com/37294635/41309518-f9637d58-6e4c-11e8-9c3b-cfa7b37ad67d.png)
![screen shot 2018-06-12 at 2 24 15 pm](https://user-images.githubusercontent.com/37294635/41309490-e8b276bc-6e4c-11e8-9467-babc4026578b.png)

