### PR TITLE
Correct documentation for Name.py

### DIFF
--- a/nodes/Name.py
+++ b/nodes/Name.py
@@ -5,11 +5,11 @@ This node is used to represent variables in Python, in the context of Loading
 the variable's contents. For Storing and Deleting, see AssignName and DelName.
 
 Attributes:
-    - id   (str)
+    - name   (str)
         - The name of the variable.
 
 Example:
-    - id   -> "my_var"
+    - name   -> "my_var"
 
 Type-checking:
     - The type of a name is determined by looking it up in the *type environment* of its


### PR DESCRIPTION
Changed Name node attribute from "id" to "name". 
astroid.Name.id (wrong) -> astroid.Name.name (correct) 