### PR TITLE
typecheck: Decorator for functions to take Failables as arguments

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -101,6 +101,21 @@ def _wrap_generic_meta(t, args):
         return TypeInfo(t[tuple(args)])
 
 
+def accept_failable(f):
+    def _f(*args, **kwargs):
+        new_args = []
+        for a in args + tuple(kwargs.values()):
+            if isinstance(a, Failable):
+                result = a >> new_args.append
+                if isinstance(result, TypeFail):
+                    return result
+            else:
+                new_args.append(a)
+        return f(*new_args)
+
+    return _f
+
+
 Num = TypeVar('number', int, float)
 a = TypeVar('a')
 MulNum = TypeVar('mul_n', int, float, str, List[a])
@@ -344,6 +359,7 @@ class TypeConstraints:
     ###########################################################################
     # Type unification ("union")
     ###########################################################################
+    @accept_failable
     def unify(self, t1: type, t2: type,
               ast_node: Optional[NodeNG] = None,
               mod_tnodes = True) -> TypeResult:


### PR DESCRIPTION
Adding decorator to allow functions to optionally take Failables as arguments, returning the Failable if it is a TypeFail
Updating several visit functions in type_inference_visitor to pass TypeResults directly to unify, rather than using .getValue()
Creating helper functions for common functionality between these visit functions