### PR TITLE
typecheck: Reimplement can_unify to fix incorrect behavior

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -256,6 +256,24 @@ class TypeConstraints:
     def __init__(self):
         self.reset()
 
+    def __deepcopy__(self, memodict={}):
+        tc = TypeConstraints()
+        tc._count = self._count
+        tc._nodes = []
+        tc.type_to_tnode = {}
+        # copy nodes without copying edges
+        for node in self._nodes:
+            node_cpy = _TNode(node.type, node.ast_node)
+            tc._nodes.append(node_cpy)
+            tc.type_to_tnode[node.type] = node_cpy
+        # fill in edges
+        for node in self._nodes:
+            for adj_node, ctx in node.adj_list:
+                tc.type_to_tnode[node.type].adj_list.append((tc.type_to_tnode[adj_node.type], ctx))
+            if node.parent:
+                tc.type_to_tnode[node.type].parent = tc.type_to_tnode[node.parent.type]
+        return tc
+
     def reset(self):
         """Reset the type constraints kept track of in the program."""
         self._count = 0
@@ -361,21 +379,19 @@ class TypeConstraints:
     ###########################################################################
     @accept_failable
     def unify(self, t1: type, t2: type,
-              ast_node: Optional[NodeNG] = None,
-              mod_tnodes = True) -> TypeResult:
+              ast_node: Optional[NodeNG] = None) -> TypeResult:
         """Attempt to unify two types.
 
         :param t1: The first of the two types to be unified.
         :param t2: The second of the two types to be unified.
         :param ast_node: The astroid node responsible for the unification of t1 & t2.
-        :param mod_tnodes: Whether the _TNode graph is to be updated.
         :returns: A TypeResult object (TypeFail or TypeInfo) containing information
             about the success / failure of the type unification.
         """
 
         # Get associated TNodes
-        tnode1 = self.get_tnode(t1, mod_tnodes)
-        tnode2 = self.get_tnode(t2, mod_tnodes)
+        tnode1 = self.get_tnode(t1)
+        tnode2 = self.get_tnode(t2)
 
         # Attempt to resolve to a TNode with concrete type
         conc_tnode1 = self.find_parent(tnode1)
@@ -384,7 +400,7 @@ class TypeConstraints:
         # Both types can be resolved
         if conc_tnode1 is not None and conc_tnode2 is not None:
             if isinstance(conc_tnode1.type, GenericMeta) and isinstance(conc_tnode2.type, GenericMeta):
-                return self._unify_generic(conc_tnode1, conc_tnode2, ast_node, mod_tnodes)
+                return self._unify_generic(conc_tnode1, conc_tnode2, ast_node)
 
             # TODO: Replace with logic based on concrete tnodes
             # Legacy code from previous implementation of unify
@@ -393,27 +409,25 @@ class TypeConstraints:
                 t2_types = t2.__args__ if t2.__class__.__name__ == '_Union' else [t2]
                 for u1, u2 in product(t1_types, t2_types):
                     if self.can_unify(u1, u2):
-                        return self.unify(u1, u2, ast_node, mod_tnodes)
+                        return self.unify(u1, u2, ast_node)
                 return TypeFail(tnode1, tnode2, ast_node)
             elif t1 == Any or t2 == Any:
                 return TypeInfo(t1)
             elif conc_tnode1.type == conc_tnode2.type:
-                if mod_tnodes:
-                    tnode1.parent = conc_tnode1
-                    tnode2.parent = conc_tnode1
-                    self.create_edges(tnode1, tnode2, ast_node)
+                tnode1.parent = conc_tnode1
+                tnode2.parent = conc_tnode1
+                self.create_edges(tnode1, tnode2, ast_node)
                 return TypeInfo(conc_tnode1.type)
             else:
                 return TypeFail(tnode1, tnode2, ast_node)
 
         # One type can be resolved
         elif conc_tnode1 is not None:
-            if mod_tnodes:
-                tnode2.parent = conc_tnode1
-                self.create_edges(tnode1, tnode2, ast_node)
+            tnode2.parent = conc_tnode1
+            self.create_edges(tnode1, tnode2, ast_node)
             return TypeInfo(conc_tnode1.type)
         elif conc_tnode2 is not None:
-            return self.unify(t2, t1, ast_node, mod_tnodes)
+            return self.unify(t2, t1, ast_node)
 
         # TODO: Replace with logic based on concrete tnodes
         # Legacy code from previous implementation of unify
@@ -427,13 +441,11 @@ class TypeConstraints:
         elif t1 == t2:
             return TypeInfo(t1)
         else:
-            if mod_tnodes:
-                self.create_edges(tnode1, tnode2, ast_node)
+            self.create_edges(tnode1, tnode2, ast_node)
             return TypeInfo(None)
 
     def _unify_generic(self, tnode1: _TNode, tnode2: _TNode,
-                       ast_node: Optional[NodeNG] = None,
-                       mod_tnodes = True) -> TypeResult:
+                       ast_node: Optional[NodeNG] = None) -> TypeResult:
         """Unify two generic types (e.g., List, Tuple, Dict, Callable)."""
 
         conc_tnode1 = self.find_parent(tnode1)
@@ -446,23 +458,24 @@ class TypeConstraints:
         if len(conc_tnode1.type.__args__) != len(conc_tnode2.type.__args__):
             return TypeFail(conc_tnode1, conc_tnode2, ast_node)
 
-        unify_result = failable_collect(self.unify(a1, a2, ast_node, mod_tnodes)
+        unify_result = failable_collect([self.unify(a1, a2, ast_node)
                                          for a1, a2 in
                                          zip(conc_tnode1.type.__args__,
-                                             conc_tnode2.type.__args__))
+                                             conc_tnode2.type.__args__)])
         if isinstance(unify_result, TypeFail):
             return unify_result
         unified_args = unify_result.getValue()
 
-        if mod_tnodes:
-            self.create_edges(tnode1, tnode2, ast_node)
+        self.create_edges(tnode1, tnode2, ast_node)
         return _wrap_generic_meta(g1, unified_args)
 
     ###########################################################################
     # Handling generic polymorphism
     ###########################################################################
     def can_unify(self, t1: type, t2: type) -> bool:
-        return isinstance(self.unify(t1, t2, None, False), TypeInfo)
+        """Check if the two types can unify without modifying current TypeConstraints."""
+        tc = self.__deepcopy__()
+        return isinstance(tc.unify(t1, t2, None), TypeInfo)
 
     def unify_call(self, func_type, *arg_types, node=None) -> TypeResult:
         """Unify a function call with the given function type and argument types.

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -1,7 +1,7 @@
 import tests.custom_hypothesis_support as cs
 from nose import SkipTest
 from typing import *
-from python_ta.typecheck.base import TypeConstraints, _TNode
+from python_ta.typecheck.base import TypeConstraints, _TNode, TypeFail
 from sample_usage.draw_tnodes import gen_graph_from_nodes
 
 
@@ -242,6 +242,18 @@ def test_polymorphic_callable5(draw=False):
                     {'typing.Callable[[int, ~_T0], int]', 'typing.Callable[[int, int], int]'},
                     {'typing.Callable[[typing.Callable[[int, ~_T0], int], int], ~_T0]',
                      'typing.Callable[[typing.Callable[[int, int], int], int], ~_T0]'}]
+    compare_list_sets(actual_set, expected_set)
+    if draw:
+        gen_graph_from_nodes(tc._nodes)
+
+
+def test_can_unify_callable(draw=False):
+    tc.reset()
+    t0 = tc.fresh_tvar()
+    assert not tc.can_unify(Callable[[t0, t0], int], Callable[[str, int], int])
+    # make sure tc is unchanged
+    actual_set = tc_to_disjoint(tc)
+    expected_set = [{'~_T0'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)


### PR DESCRIPTION
`can_unify` has been reimplemented so that it makes a copy of the current TypeConstraints object and calls unify on the copy so as to avoid modifying the original TypeConstraints. This is inefficient, but my previous implementation was short-sighted and caused problems throughout. The added test case (which previously failed at the assert line) demonstrates the necessity of this change.

To make things more efficient, I could use a hybrid approach: the previous method always ~~fails~~ passes when it should, so a copy would be necessary only to verify a success (most calls to can_unify result in failures anyway). Alternatively, I could hard-code some common cases that allow us to bypass the general check.