### PR TITLE
typecheck: Modify TypeStore to allow proper method type differentiation in visit_attribute

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -64,7 +64,7 @@ class TypeInferer:
         node.type_environment = Environment()
         for name in node.instance_attrs:
             node.type_environment.locals[name] = self.type_constraints.fresh_tvar(node.instance_attrs[name][0])
-            self.type_store.classes[node.name][name] = [node.type_environment.locals[name]]
+            self.type_store.classes[node.name][name] = [(node.type_environment.locals[name], 'attribute')]
         for name in node.locals:
             node.type_environment.locals[name] = self.type_constraints.fresh_tvar(node.locals[name][0])
 
@@ -520,7 +520,7 @@ class TypeInferer:
             attr_inf_type = self.type_constraints.resolve(node.type_environment.lookup_in_env(attr))
             attr_inf_type >> self.type_store.classes[node.name][attr].append
             attr_inf_type >> (
-                lambda a: self.type_store.methods[attr].append(a) if isinstance(a, CallableMeta) else None)
+                lambda a: self.type_store.methods[attr].append((a, 'attribute')) if isinstance(a, CallableMeta) else None)
 
     ##############################################################################
     # Statements
@@ -536,7 +536,7 @@ class TypeInferer:
         if type_name not in self.type_store.classes:
             node.inf_type = TypeFail('Invalid attribute type')
         else:
-            attribute_type = self.type_store.classes[type_name].get(node.attrname)
+            attribute_type = self.type_store.classes[type_name].get(node.attrname)[0]
             if attribute_type is None:
                 node.inf_type = TypeFail(f'Attribute {node.attrname} not found for type {type_name}')
             else:

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -199,7 +199,7 @@ class TypeInferer:
             if node.name in self.type_store.classes:
                 node.inf_type = TypeInfo(Type[__builtins__[node.name]])
             elif node.name in self.type_store.functions:
-                node.inf_type = TypeInfo(self.type_store.functions[node.name][0])
+                node.inf_type = TypeInfo(self.type_store.functions[node.name][0][0])
             else:
                 # This is an unbound identifier. Ignore it.
                 node.inf_type = TypeInfo(Any)
@@ -281,7 +281,7 @@ class TypeInferer:
             else:
                 func_name = callable_t.__args__[0].__name__
             if '__init__' in self.type_store.classes[func_name]:
-                init_type = self.type_store.classes[func_name]['__init__'][0]
+                init_type = self.type_store.classes[func_name]['__init__'][0][0]
             else:
                 init_type = Callable[[callable_t], None]
             # TODO: handle method overloading (through optional parameters)
@@ -462,7 +462,7 @@ class TypeInferer:
 
         # Get any function type annotations.
         if any(annotation is not None for annotation in node.args.annotations):
-            annotated_type = parse_annotations(node)
+            annotated_type = parse_annotations(node)[0]
         else:
             annotated_type = None
 
@@ -518,15 +518,24 @@ class TypeInferer:
         # TODO: include node.instance_attrs as well?
         for attr in node.locals:
             attr_inf_type = self.type_constraints.resolve(node.type_environment.lookup_in_env(attr))
-            attr_inf_type >> self.type_store.classes[node.name][attr].append
             attr_inf_type >> (
-                lambda a: self.type_store.methods[attr].append((a, 'attribute')) if isinstance(a, CallableMeta) else None)
+                lambda a: self.type_store.methods[attr].append((a, node.locals[attr][0].type)) if isinstance(a, CallableMeta) else None)
+            attr_inf_type >> (
+                lambda a: self.type_store.classes[node.name][attr].append((a, node.locals[attr][0].type if isinstance(a, CallableMeta) else 'attribute')))
 
     ##############################################################################
     # Statements
     ##############################################################################
     def visit_attribute(self, node: astroid.Attribute) -> None:
         expr_type = node.expr.inf_type.getValue()
+
+        inst_expr = True
+
+        # case when expr_type is the type of a class
+        if hasattr(expr_type, '__name__') and expr_type.__name__ == 'Type':
+            inst_expr = False
+            expr_type = expr_type.__args__[0]
+
         if isinstance(expr_type, _ForwardRef):
             type_name =  expr_type.__forward_arg__
         elif hasattr(expr_type, '__name__'):
@@ -540,12 +549,13 @@ class TypeInferer:
             if attribute_type is None:
                 node.inf_type = TypeFail(f'Attribute {node.attrname} not found for type {type_name}')
             else:
-                attribute_type = attribute_type[0]
+                func_type, method_type = attribute_type
                 # Detect an instance method call, and create a bound method signature (first argument removed).
                 # TODO: handle classmethod calls differently.
-                if isinstance(attribute_type, CallableMeta):
-                    attribute_type = Callable[list(attribute_type.__args__[1:-1]), attribute_type.__args__[-1]]
-                node.inf_type = TypeInfo(attribute_type)
+                if isinstance(func_type, CallableMeta) and inst_expr and \
+                        method_type != 'staticmethod':
+                    func_type = Callable[list(func_type.__args__[1:-1]), func_type.__args__[-1]]
+                node.inf_type = TypeInfo(func_type)
 
     def visit_annassign(self, node):
         var_inf_type = self.type_constraints.resolve(

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -619,9 +619,9 @@ def parse_annotations(node, class_tvars=None):
                 arg_types.append(_node_to_type(annotation))
 
         rtype = _node_to_type(node.returns)
-        return create_Callable(arg_types, rtype, class_tvars)
+        return (create_Callable(arg_types, rtype, class_tvars), node.type)
     elif isinstance(node, astroid.AssignName) and isinstance(node.parent, astroid.AnnAssign):
-        return _node_to_type(node.parent.annotation)
+        return (_node_to_type(node.parent.annotation), 'attribute')
 
 
 def _node_to_type(node, locals=None):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -619,9 +619,9 @@ def parse_annotations(node, class_tvars=None):
                 arg_types.append(_node_to_type(annotation))
 
         rtype = _node_to_type(node.returns)
-        return (create_Callable(arg_types, rtype, class_tvars), node.type)
+        return create_Callable(arg_types, rtype, class_tvars), node.type
     elif isinstance(node, astroid.AssignName) and isinstance(node.parent, astroid.AnnAssign):
-        return (_node_to_type(node.parent.annotation), 'attribute')
+        return _node_to_type(node.parent.annotation), 'attribute'
 
 
 def _node_to_type(node, locals=None):

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -27,7 +27,7 @@ class TypeStore:
         # Add in initializers
         for klass_name, methods in self.classes.items():
             if '__init__' in methods:
-                self.functions[klass_name] = [class_callable(init) for init in methods['__init__']]
+                self.functions[klass_name] = [class_callable(init) for init, _ in methods['__init__']]
 
     def _parse_classes(self, module: astroid.Module) -> None:
         """Parse the class definitions from typeshed."""
@@ -66,7 +66,7 @@ class TypeStore:
         if args:
             unified = False
             func_types_list = self.functions[operator]
-            for func_type in func_types_list:
+            for func_type, _ in func_types_list:
                 # check if args can be unified instead of checking if they are the same!
                 unified = True
                 for t1, t2 in zip(func_type.__args__[:-1], args):
@@ -84,7 +84,7 @@ class TypeStore:
             unified = False
             func_types_list = self.methods[operator]
             self_type = args[0]
-            for func_type in func_types_list:
+            for func_type, _ in func_types_list:
                 if len(args) != len(func_type.__args__) - 1:
                     continue
                 unified = True

--- a/tests/test_type_inference/test_attribute.py
+++ b/tests/test_type_inference/test_attribute.py
@@ -1,0 +1,89 @@
+import nose
+import astroid
+from typing import *
+from typing import _ForwardRef
+import tests.custom_hypothesis_support as cs
+
+
+def test_instance_dot_method():
+    program = \
+        '''
+        class A:
+            def foo(self, x):
+                return x + 1
+                
+        A().foo(0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[int], int]
+
+
+def test_instance_dot_classmethod():
+    program = \
+        '''
+        class A:
+            @classmethod
+            def foo(cls, x):
+                return x + 1
+
+        A().foo(A, 0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[int], int]
+
+def test_instance_dot_staticmethod():
+    program = \
+        '''
+        class A:
+            @staticmethod
+            def foo(x):
+                return x + 1
+
+        A().foo(0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[int], int]
+
+def test_class_dot_method():
+    program = \
+        '''
+        class A:
+            def foo(self, x):
+                return x + 1
+
+        A.foo(A(), 0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[_ForwardRef('A'), int], int]
+
+def test_class_dot_classmethod():
+    program = \
+        '''
+        class A:
+            @classmethod
+            def foo(cls, x):
+                return x + 1
+
+        A.foo(A, 0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[Type[_ForwardRef('A')], int], int]
+
+def test_class_dot_staticmethod():
+    program = \
+        '''
+        class A:
+            @staticmethod
+            def foo(x):
+                return x + 1
+
+        A.foo(0)
+        '''
+    module, _ = cs._parse_text(program, reset=True)
+    for attribute_node in module.nodes_of_class(astroid.Attribute):
+        assert attribute_node.inf_type.getValue() == Callable[[int], int]


### PR DESCRIPTION
The dictionaries in TypeStore now have tuples as their values: the first item is the type signature of the function, as before, and the second item is the the method type ('method', 'classmethod', 'staticmethod') in case of a method or 'attribute' otherwise. This allows `visit_attribute` to not trim off the first argument in static methods.