### PR TITLE
typecheck: Fix inferred type for calls to initializer functions

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -284,7 +284,7 @@ class TypeInferer:
 
         if '__init__' in self.type_store.classes[class_name]:
             init_args = list(self.type_store.classes[class_name]['__init__'][0][0].__args__)
-            init_func = Callable[init_args[1:-1], init_args[-1]]
+            init_func = Callable[init_args[1:-1], init_args[0]]
         else:
             # Classes declared without initializer
             init_func = Callable[[], class_type]


### PR DESCRIPTION
This change makes type inference for calls to builtin class initializers consistent with the behavior for user-defined classes (and the case directly below the change).