### PR TITLE
typecheck: Initiate support for inheritance

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -525,7 +525,7 @@ class TypeInferer:
         self.type_constraints.unify(self.lookup_inf_type(node.parent, node.name),
                                     Type[_ForwardRef(node.name)], node)
 
-        self.type_store.classes[node.name]['__bases'] = [self.type_store.node_to_type(base)
+        self.type_store.classes[node.name]['__bases'] = [_node_to_type(base)
                                                          for base in node.bases]
         self.type_store.classes[node.name]['__mro'] = [cls.name for cls in node.mro()]
 

--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -27,12 +27,15 @@ class TypeInferer:
     """
     type_constraints = TypeConstraints()
     type_store = TypeStore(type_constraints)
+    type_constraints.type_store = type_store
 
     def __init__(self):
         self.type_constraints.reset()
 
     def reset(self):
+        self.type_constraints.reset()
         self.type_store = TypeStore(self.type_constraints)
+        self.type_constraints.type_store = self.type_store
 
     ###########################################################################
     # Setting up the environment
@@ -277,7 +280,10 @@ class TypeInferer:
     def get_call_signature(self, c, node: NodeNG) -> TypeResult:
         if hasattr(c, '__name__') and c.__name__ == 'Type':
             class_type = c.__args__[0]
-            class_name = c.__args__[0].__forward_arg__
+            if isinstance(class_type, _ForwardRef):
+                class_name = c.__args__[0].__forward_arg__
+            else:
+                class_name = class_type.__name__
         elif isinstance(c, _ForwardRef):
             class_type = c
             class_name = c.__forward_arg__
@@ -519,6 +525,10 @@ class TypeInferer:
         self.type_constraints.unify(self.lookup_inf_type(node.parent, node.name),
                                     Type[_ForwardRef(node.name)], node)
 
+        self.type_store.classes[node.name]['__bases'] = [self.type_store.node_to_type(base)
+                                                         for base in node.bases]
+        self.type_store.classes[node.name]['__mro'] = [cls.name for cls in node.mro()]
+
         # Update type_store for this class.
         # TODO: include node.instance_attrs as well?
         for attr in node.locals:
@@ -557,7 +567,11 @@ class TypeInferer:
         class_name, class_type, inst_expr = expr_inf_type >> self.get_attribute_class
 
         if class_name in self.type_store.classes:
-            attribute_type = self.type_store.classes[class_name].get(node.attrname)
+            attribute_type = None
+            for par_class_type in self.type_store.classes[class_name]['__mro']:
+                attribute_type = self.type_store.classes[par_class_type].get(node.attrname)
+                if attribute_type:
+                    break
             if attribute_type is None:
                 class_tnode = self.type_constraints.get_tnode(class_type)
                 node.inf_type = TypeFailLookup(class_tnode, node, node.parent)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -319,6 +319,7 @@ class TypeConstraints:
     type_to_tnode: Dict[str, _TNode]
 
     def __init__(self):
+        self.type_store = None
         self.reset()
 
     def __deepcopy__(self, memodict={}):
@@ -326,8 +327,7 @@ class TypeConstraints:
         tc._count = self._count
         tc._nodes = []
         tc.type_to_tnode = {}
-        if hasattr(self, 'type_store'):
-            tc.type_store = self.type_store
+        tc.type_store = self.type_store
         # copy nodes without copying edges
         for node in self._nodes:
             node_cpy = _TNode(node.type, node.ast_node)
@@ -496,7 +496,7 @@ class TypeConstraints:
             elif ct1 == Any or ct2 == Any:
                 return TypeInfo(ct1)
             # Handle inheritance
-            elif hasattr(self, 'type_store') and \
+            elif self.type_store and \
                     self.type_store.is_descendant(ct1, ct2):
                 return TypeInfo(ct1)
             else:

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -326,6 +326,8 @@ class TypeConstraints:
         tc._count = self._count
         tc._nodes = []
         tc.type_to_tnode = {}
+        if hasattr(self, 'type_store'):
+            tc.type_store = self.type_store
         # copy nodes without copying edges
         for node in self._nodes:
             node_cpy = _TNode(node.type, node.ast_node)
@@ -492,6 +494,10 @@ class TypeConstraints:
                 tnode1.parent = conc_tnode1
                 tnode2.parent = conc_tnode1
                 self.create_edges(tnode1, tnode2, ast_node)
+                return TypeInfo(ct1)
+            # Handle inheritance
+            elif hasattr(self, 'type_store') and \
+                    self.type_store.is_descendant(ct1, ct2):
                 return TypeInfo(ct1)
             else:
                 return TypeFailUnify(tnode1, tnode2, src_node=ast_node)

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -194,10 +194,50 @@ class TupleSubscript(TypeVar, _root=True):
     pass
 
 
-def create_Callable(args: Iterable[type], rtype, poly_vars=None):
-    poly_vars = poly_vars or []
+_TYPESHED_TVARS = {
+    '_T': TypeVar('_T'),
+    '_T_co': TypeVar('_T_co', covariant=True),
+    '_KT': TypeVar('_KT'),
+    '_VT': TypeVar('_VT'),
+    '_S': TypeVar('_S'),
+    '_T1': TypeVar('_T1'),
+    '_T2': TypeVar('_T2'),
+    '_T3': TypeVar('_T3'),
+    '_T4': TypeVar('_T4'),
+    '_T5': TypeVar('_T5'),
+    '_TT': TypeVar('_TT', bound='type'),
+    'function': Callable[[Any], Any]
+}
+
+
+_BUILTIN_TO_TYPING = {
+    'list': 'List',
+    'dict': 'Dict',
+    'tuple': 'Tuple',
+    'set': 'Set',
+    'frozenset': 'FrozenSet',
+    'function': 'Callable'
+}
+
+
+def _get_poly_vars(t: type):
+    if isinstance(t, TypeVar) and t.__name__ in _TYPESHED_TVARS:
+        return set([t.__name__])
+    elif isinstance(t, GenericMeta) and t.__args__:
+        pvars = set()
+        for arg in t.__args__:
+            pvars.update(_get_poly_vars(arg))
+        return pvars
+    return set()
+
+
+def create_Callable(args: Iterable[type], rtype, class_poly_vars=None):
+    poly_vars = class_poly_vars or []
+    poly_vars = set(poly_vars)
     c = Callable[list(args), rtype]
-    c.polymorphic_tvars = poly_vars
+    poly_vars.update(_get_poly_vars(c))
+    c.polymorphic_tvars = set()
+    c.polymorphic_tvars.update(poly_vars)
     return c
 
 
@@ -209,34 +249,34 @@ def create_Callable_TypeResult(args: Iterable[type], rtype, poly_vars=None):
 
 TYPE_SIGNATURES = {
     int: {
-        '__add__': create_Callable([int, Num], Num, [Num]),
-        '__sub__': create_Callable([int, Num], Num, [Num]),
-        '__mul__': create_Callable([int, MulNum], MulNum, [MulNum]),
-        '__idiv__': create_Callable([int, Num], Num, [Num]),
-        '__mod__': create_Callable([int, Num], Num, [Num]),
-        '__pow__': create_Callable([int, Num], Num, [Num]),
-        '__div__': create_Callable([int, Num], float, [Num]),
+        '__add__': create_Callable([int, Num], Num, {Num}),
+        '__sub__': create_Callable([int, Num], Num, {Num}),
+        '__mul__': create_Callable([int, MulNum], MulNum, {MulNum}),
+        '__idiv__': create_Callable([int, Num], Num, {Num}),
+        '__mod__': create_Callable([int, Num], Num, {Num}),
+        '__pow__': create_Callable([int, Num], Num, {Num}),
+        '__div__': create_Callable([int, Num], float, {Num}),
     },
     float: {
-        '__add__': create_Callable([float, Num], float, [Num]),
-        '__sub__': create_Callable([float, Num], float, [Num]),
-        '__mul__': create_Callable([float, Num], float, [Num]),
-        '__idiv__': create_Callable([float, Num], float, [Num]),
-        '__mod__': create_Callable([float, Num], float, [Num]),
-        '__pow__': create_Callable([float, Num], float, [Num]),
-        '__div__': create_Callable([float, Num], float, [Num]),
+        '__add__': create_Callable([float, Num], float, {Num}),
+        '__sub__': create_Callable([float, Num], float, {Num}),
+        '__mul__': create_Callable([float, Num], float, {Num}),
+        '__idiv__': create_Callable([float, Num], float, {Num}),
+        '__mod__': create_Callable([float, Num], float, {Num}),
+        '__pow__': create_Callable([float, Num], float, {Num}),
+        '__div__': create_Callable([float, Num], float, {Num}),
     },
     str: {
         '__add__': Callable[[str, str], str],
         '__mul__': Callable[[str, int], str]
     },
     List: {
-        '__add__': create_Callable([List[a], List[a]], List[a], [a]),
-        '__mul__': create_Callable([List[a], int], List[a], [a]),
-        '__getitem__': create_Callable([List[a], int], a, [a])
+        '__add__': create_Callable([List[a], List[a]], List[a], {a}),
+        '__mul__': create_Callable([List[a], int], List[a], {a}),
+        '__getitem__': create_Callable([List[a], int], a, {a})
     },
     Tuple: {
-        '__add__': create_Callable([tup1, tup2], TuplePlus('tup+', tup1, tup2), [tup1, tup2]),
+        '__add__': create_Callable([tup1, tup2], TuplePlus('tup+', tup1, tup2), {tup1, tup2}),
     }
 }
 
@@ -725,32 +765,6 @@ def _node_to_type(node, locals=None):
         return None
     else:
         return node
-
-
-_TYPESHED_TVARS = {
-    '_T': TypeVar('_T'),
-    '_T_co': TypeVar('_T_co', covariant=True),
-    '_KT': TypeVar('_KT'),
-    '_VT': TypeVar('_VT'),
-    '_S': TypeVar('_S'),
-    '_T1': TypeVar('_T1'),
-    '_T2': TypeVar('_T2'),
-    '_T3': TypeVar('_T3'),
-    '_T4': TypeVar('_T4'),
-    '_T5': TypeVar('_T5'),
-    '_TT': TypeVar('_TT', bound='type'),
-    'function': Callable[[Any], Any]
-}
-
-
-_BUILTIN_TO_TYPING = {
-    'list': 'List',
-    'dict': 'Dict',
-    'tuple': 'Tuple',
-    'set': 'Set',
-    'frozenset': 'FrozenSet',
-    'function': 'Callable'
-}
 
 
 def class_callable(init):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -479,7 +479,12 @@ class TypeConstraints:
             ct1 = conc_tnode1.type
             ct2 = conc_tnode2.type
 
-            if isinstance(ct1, GenericMeta) and isinstance(ct2, GenericMeta):
+            if ct1 == ct2:
+                tnode1.parent = conc_tnode1
+                tnode2.parent = conc_tnode1
+                self.create_edges(tnode1, tnode2, ast_node)
+                return TypeInfo(ct1)
+            elif isinstance(ct1, GenericMeta) and isinstance(ct2, GenericMeta):
                 return self._unify_generic(tnode1, tnode2, ast_node)
             elif ct1.__class__.__name__ == '_Union' or ct2.__class__.__name__ == '_Union':
                 ct1_types = ct1.__args__ if ct1.__class__.__name__ == '_Union' else [ct1]
@@ -489,11 +494,6 @@ class TypeConstraints:
                         return self.unify(u1, u2, ast_node)
                 return TypeFailUnify(tnode1, tnode2, src_node=ast_node)
             elif ct1 == Any or ct2 == Any:
-                return TypeInfo(ct1)
-            elif ct1 == ct2:
-                tnode1.parent = conc_tnode1
-                tnode2.parent = conc_tnode1
-                self.create_edges(tnode1, tnode2, ast_node)
                 return TypeInfo(ct1)
             # Handle inheritance
             elif hasattr(self, 'type_store') and \

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -5,7 +5,6 @@ from python_ta.typecheck.base import parse_annotations, \
     class_callable, accept_failable, _node_to_type
 from typing import Callable
 import os
-from builtins import *
 from typing import *
 from typing import Any
 from typing import _ForwardRef
@@ -88,12 +87,14 @@ class TypeStore:
             for func_type, _ in func_types_list:
                 if len(args) != len(func_type.__args__) - 1:
                     continue
-                if self.type_constraints.can_unify(Callable[list(func_type.__args__[:-1]), Any],
-                                                   Callable[list(args), Any]):
+                if self.type_constraints.can_unify(Callable[list(args), Any],
+                                                   Callable[list(func_type.__args__[:-1]), Any]):
                     return func_type
             raise KeyError
 
-    def is_descendant(self, child: type, ancestor: type):
+    def is_descendant(self, child: type, ancestor: type) -> bool:
+        if ancestor == object:
+            return True
         child_name = child.__forward_arg__ if isinstance(child, _ForwardRef) \
             else child.__name__
         if child_name in self.classes:

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -1,10 +1,14 @@
 import astroid
 from astroid.builder import AstroidBuilder
 from collections import defaultdict
-from python_ta.typecheck.base import parse_annotations, class_callable, accept_failable
+from python_ta.typecheck.base import parse_annotations, \
+    class_callable, accept_failable, _TYPESHED_TVARS
 from typing import Callable
 import os
+from builtins import *
+from typing import *
 from typing import Any
+from typing import _ForwardRef
 
 TYPE_SHED_PATH = os.path.join(os.path.dirname(__file__), 'typeshed', 'builtins.pyi')
 
@@ -40,6 +44,9 @@ class TypeStore:
                     tvars = base.slice.as_string().strip('()').replace(" ", "").split(',')
                     if gen == 'Generic':
                         self.classes[class_def.name]['__pyta_tvars'] = tvars
+            self.classes[class_def.name]['__bases'] = [self.node_to_type(base)
+                                                       for base in class_def.bases]
+            self.classes[class_def.name]['__mro'] = [cls.name for cls in class_def.mro()]
             for node in (nodes[0] for nodes in class_def.locals.values()
                          if isinstance(nodes[0], astroid.AssignName) and
                          isinstance(nodes[0].parent, astroid.AnnAssign)):
@@ -87,6 +94,39 @@ class TypeStore:
                                                    Callable[list(args), Any]):
                     return func_type
             raise KeyError
+
+    def node_to_type(self, node):
+        if isinstance(node, astroid.Name):
+            try:
+                inner_var = globals()[node.name]
+            except KeyError:
+                if node.name in _TYPESHED_TVARS:
+                    inner_var = _TYPESHED_TVARS[node.name]
+                else:
+                    inner_var = _ForwardRef(node.name)
+            return inner_var
+        elif isinstance(node, astroid.Subscript):
+            if hasattr(node.slice.value, 'name') and \
+                    isinstance(node.slice.value, astroid.Tuple):
+                inner_var = tuple([self.node_to_type(elt) for elt in node.slice.value.elts])
+            else:
+                inner_var = self.node_to_type(node.slice.value)
+            try:
+                outer_var = globals()[node.value.name]
+            except KeyError:
+                outer_var = _ForwardRef(node.value.name)
+            return outer_var[inner_var]
+
+    def is_descendant(self, child: type, ancestor: type):
+        child_name = child.__forward_arg__ if isinstance(child, _ForwardRef) \
+            else child.__name__
+        if child_name in self.classes:
+            for base in self.classes[child_name]['__bases']:
+                if self.type_constraints.can_unify(base, ancestor) or \
+                        self.is_descendant(base, ancestor):
+                    self.type_constraints.unify(base, ancestor)
+                    return True
+        return False
 
 
 if __name__ == '__main__':

--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -40,10 +40,8 @@ class TypeStore:
             tvars = []
             for base in class_def.bases:
                 if isinstance(base, astroid.Subscript):
-                    gen = base.value.as_string()
                     tvars = base.slice.as_string().strip('()').replace(" ", "").split(',')
-                    if gen == 'Generic':
-                        self.classes[class_def.name]['__pyta_tvars'] = tvars
+                    self.classes[class_def.name]['__pyta_tvars'] = tvars
             self.classes[class_def.name]['__bases'] = [_node_to_type(base)
                                                        for base in class_def.bases]
             self.classes[class_def.name]['__mro'] = [cls.name for cls in class_def.mro()]
@@ -59,7 +57,7 @@ class TypeStore:
         for function_def in module.nodes_of_class(astroid.FunctionDef):
             in_class = isinstance(function_def.parent, astroid.ClassDef)
             if in_class:
-                tvars = self.classes[function_def.parent.name]['__pyta_tvars']
+                tvars = self.classes[function_def.parent.name]['__pyta_tvars'][:]
             else:
                 tvars = []
             f_type = parse_annotations(function_def, tvars)

--- a/sample_usage/draw_tnodes.py
+++ b/sample_usage/draw_tnodes.py
@@ -3,6 +3,7 @@ import astroid
 from astroid.node_classes import NodeNG
 from graphviz import Graph
 from typing import *
+from typing import _ForwardRef
 from python_ta.typecheck.base import _TNode, TypeFail
 from python_ta.transforms.type_inference_visitor import TypeInferer
 from tests.custom_hypothesis_support import _parse_text
@@ -13,7 +14,8 @@ USAGE = 'Usage: python draw_tnodes.py <your-file.py>'
 
 def _type_str(type):
     if isinstance(type, TypeVar) or isinstance(type, GenericMeta) or \
-            type.__class__.__name__ == '_Any' or type is None:
+            type.__class__.__name__ == '_Any' or \
+            isinstance(type, _ForwardRef) or type is None:
         return str(type).replace('typing.', '')
     elif type.__class__.__name__ == '_Union':
         trimmed_args = []

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -453,4 +453,79 @@ def test_builtin_abst_base_mro(draw=False):
     if draw:
         gen_graph_from_nodes(ti.type_constraints._nodes)
 
-# TODO: more tests for builtin mro
+
+def test_builtin_call_simple_mro(draw=False):
+    src = """
+    class A:
+        pass
+        
+    a = A()
+    x = repr(a)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    a, x = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == str
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_builtin_binop_inheritance(draw=False):
+    raise SkipTest('Auto-casting must be handled for this test to pass')
+    src = """
+    x = 1.0 + 3
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x = [ti.lookup_typevar(node, node.name) for node
+         in ast_mod.nodes_of_class(astroid.AssignName)][0]
+    assert ti.type_constraints.resolve(x).getValue() == float
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_builtin_comp_inheritance(draw=False):
+    src = """
+    x = (3 == 'abc')
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x = [ti.lookup_typevar(node, node.name) for node
+         in ast_mod.nodes_of_class(astroid.AssignName)][0]
+    assert ti.type_constraints.resolve(x).getValue() == bool
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_userdefn_inherits_from_builtin(draw=False):
+    src = """
+    class MyStr(str):
+        pass
+        
+    s = MyStr()
+    x = s.lower()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    s, x = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == str
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_userdefn_overrides_builtin(draw=False):
+    src = """
+    class MyStr(str):
+        def lower(self):
+            return 0
+
+    s = MyStr()
+    x = s.lower()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    _, s, x = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == int
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+# TODO: test builtins with Any in signature

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -449,8 +449,6 @@ def test_builtin_abst_base_mro(draw=False):
     ast_mod, ti = cs._parse_text(src, reset=True)
     x, y = [ti.lookup_typevar(node, node.name) for node
             in ast_mod.nodes_of_class(astroid.AssignName)]
-    from sample_usage.print_ast_from_mod import print_ast
-    print_ast(ast_mod)
     assert ti.type_constraints.resolve(y).getValue() == int
     if draw:
         gen_graph_from_nodes(ti.type_constraints._nodes)

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -1,5 +1,6 @@
 import tests.custom_hypothesis_support as cs
 from nose import SkipTest
+import astroid
 from typing import *
 from typing import _ForwardRef
 from python_ta.typecheck.base import TypeConstraints, _TNode, TypeFail
@@ -271,3 +272,187 @@ def test_can_unify_callable(draw=False):
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
+
+
+# Inheritance
+
+def test_userdefn_inheritance_simple(draw=False):
+    src = """
+    class A:
+        pass
+
+    class B:
+        pass
+
+    class C(A, B):
+        pass
+
+    a = A()
+    b = B()
+    c = C()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tc = ti.type_constraints
+    a, b, c = [ti.lookup_typevar(node, node.name) for node
+               in ast_mod.nodes_of_class(astroid.AssignName)]
+
+    assert isinstance(tc.unify(a, b), TypeFail)
+    assert tc.unify(c, a).getValue() == _ForwardRef('C')
+    assert isinstance(tc.unify(a, c), TypeFail)  # note that order matters!
+    assert tc.unify(c, b).getValue() == _ForwardRef('C')
+    assert isinstance(tc.unify(b, c), TypeFail)
+
+    actual_set = tc_to_disjoint(tc)
+    expected_set = [
+        {'~_T0', Type[_ForwardRef('A')]},
+        {'~_T1', Type[_ForwardRef('B')]},
+        {'~_T2', Type[_ForwardRef('C')]},
+        {'~_T3', _ForwardRef('A')},
+        {'~_T4', _ForwardRef('B')},
+        {'~_T5', _ForwardRef('C')}
+    ]
+
+    # _TNodes should be unchanged after unification
+    compare_list_sets(actual_set, expected_set)
+
+    if draw:
+        gen_graph_from_nodes(tc._nodes)
+
+
+def test_userdefn_inheritance_multilevel(draw=False):
+    src = """
+    class A:
+        pass
+
+    class B(A):
+        pass
+
+    class C(B):
+        pass
+
+    a = A()
+    b = B()
+    c = C()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tc = ti.type_constraints
+    a, b, c = [ti.lookup_typevar(node, node.name) for node
+               in ast_mod.nodes_of_class(astroid.AssignName)]
+
+    assert tc.unify(b, a).getValue() == _ForwardRef('B')
+    assert tc.unify(c, b).getValue() == _ForwardRef('C')
+    assert tc.unify(c, a).getValue() == _ForwardRef('C')
+    assert isinstance(ti.type_constraints.unify(b, c), TypeFail)
+
+    if draw:
+        gen_graph_from_nodes(tc._nodes)
+
+
+def test_builtin_abst_inheritance(draw=False):
+    src = """
+    x = 3
+    # float takes in an argument of type SupportsInt
+    y = float(x)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tc = ti.type_constraints
+    actual_set = tc_to_disjoint(tc)
+    assert {'~_T0', int} in actual_set
+    assert {'~_T1', float} in actual_set
+    if draw:
+        gen_graph_from_nodes(tc._nodes)
+
+
+# TODO: more tests for builtin inheritance
+
+
+# Inheritance-based method lookup
+
+def test_userdefn_mro_simple(draw=False):
+    src = """
+    class A:
+        def foo(self):
+            return 0
+            
+    class B(A):
+        pass
+        
+    b = B()
+    x = b.foo()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    _, b, x = [ti.lookup_typevar(node, node.name) for node
+               in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == int
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_userdefn_mro_multilevel(draw=False):
+    src = """
+    class A:
+        def foo(self):
+            return 0
+            
+    class B:
+        pass
+        
+    class C(A):
+        pass
+        
+    class D(B, C):
+        pass
+        
+    d = D()
+    x = d.foo()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    _, d, x = [ti.lookup_typevar(node, node.name) for node
+               in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == int
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_userdefn_mro_diamond(draw=False):
+    src = """
+    class A:
+        pass
+            
+    class B(A):
+        def foo(self):
+            return 'a'
+        
+    class C(A):
+        def foo(self):
+            return 0
+        
+    class D(B,C):
+        pass
+        
+    d = D()
+    x = d.foo() # this is a call to B.foo()
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    _, _, d, x = [ti.lookup_typevar(node, node.name) for node
+                  in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == str
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_builtin_abst_base_mro(draw=False):
+    src = """
+    x = 3 # x descends from SupportsAbs[int]
+    y = abs(x)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x, y = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    from sample_usage.print_ast_from_mod import print_ast
+    print_ast(ast_mod)
+    assert ti.type_constraints.resolve(y).getValue() == int
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+# TODO: more tests for builtin mro

--- a/tests/test_type_constraints/test_unify.py
+++ b/tests/test_type_constraints/test_unify.py
@@ -197,7 +197,7 @@ def test_simple_polymorphic_call():
     tc.reset()
     tv1 = tc.fresh_tvar()
     tv2 = tc.fresh_tvar()
-    fn1 = create_Callable([tv1, tv2], bool, [tv1, tv2])
+    fn1 = create_Callable([tv1, tv2], bool, {tv1, tv2})
     fn2 = create_Callable([int, int], bool)
 
     unify_helper(fn1, fn2, Callable[[int, int], bool])
@@ -208,12 +208,12 @@ def test_higher_order_polymorphic_call():
     tv1 = tc.fresh_tvar()
     tv2 = tc.fresh_tvar()
 
-    fn0 = create_Callable([tv1, int], int, [tv1])
+    fn0 = create_Callable([tv1, int], int, {tv1})
     fn1 = create_Callable([int, int], int)
 
     fn2 = create_Callable([fn0, int], bool)
     fn3 = create_Callable([fn1, int], bool)
-    fn4 = create_Callable([tv2, int], bool, [tv2])
+    fn4 = create_Callable([tv2, int], bool, {tv2})
 
     unify_helper(fn2, fn3, Callable[[Callable[[int, int], int], int], bool])
     unify_helper(fn2, fn4, Callable[[Callable[[int, int], int], int], bool])


### PR DESCRIPTION
I am currently looking into the astroid source code for mro() which seems to be discarding subscripted classes like `SupportsAbs[int]`. Ideally, we shouldn't have to store both `__bases` and `__mro` in the classes dictionary.