### PR TITLE
typecheck: Adding some TypeFail subclasses

### DIFF
--- a/tests/test_type_inference/test_tnode_structure.py
+++ b/tests/test_type_inference/test_tnode_structure.py
@@ -26,12 +26,12 @@ def _nodes_to_dict(node_list):
     return node_dict
 
 
-def _find_type_fail(ast_node):
-    if isinstance(ast_node.inf_type, TypeFail):
+def find_type_fail(ast_node):
+    if hasattr(ast_node, 'inf_type') and isinstance(ast_node.inf_type, TypeFail):
         return ast_node
     else:
         for child in ast_node.get_children():
-            child_res = _find_type_fail(child)
+            child_res = find_type_fail(child)
             if child_res is not None:
                 return child_res
     return None
@@ -49,7 +49,7 @@ def _verify_inference(program, node_list):
 
 
 def _verify_type_fail(program, exp_node_str):
-    fail_node = _find_type_fail(program)
+    fail_node = find_type_fail(program)
     assert_is_not_none(fail_node, "Typecheck did not fail!")
     eq_(fail_node.as_string(), exp_node_str)
     eq_(fail_node.inf_type.src_node.as_string(), exp_node_str)

--- a/tests/test_type_inference/test_typefail_reason.py
+++ b/tests/test_type_inference/test_typefail_reason.py
@@ -1,0 +1,147 @@
+import astroid
+import tests.custom_hypothesis_support as cs
+from typing import *
+from python_ta.typecheck.base import TypeFail, TypeFailUnify, TypeFailFunction
+from tests.test_type_inference.test_tnode_structure import find_type_fail
+from nose.tools import eq_
+
+
+def verify_typefail_unify(tf: TypeFailUnify, exp_tn1, exp_tn2, exp_src_type):
+    assert isinstance(tf, TypeFailUnify)
+    for tn, exp_r in zip([tf.tnode1, tf.tnode2], [exp_tn1, exp_tn2]):
+        if tn.ast_node and hasattr(tn.ast_node, 'name'):
+            eq_(tn.ast_node.name, exp_r)
+        else:
+            eq_(tn.type, exp_r)
+    assert isinstance(tf.src_node, exp_src_type)
+
+
+def verify_typefail_function(tf: TypeFailUnify, exp_func_type):
+    assert isinstance(tf, TypeFailFunction)
+    eq_(tf.func_tnode.type, exp_func_type)
+
+
+def test_var_assign():
+    src = """
+    A = 1
+    A = 'One'
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'A', str, astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert int in reasons
+
+
+def test_two_var_assign():
+    src = """
+    A = 1
+    B = 'Two'
+    A = B
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'A', 'B', astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert int in reasons
+    assert str in reasons
+
+
+def test_one_list():
+    src = """
+    L = [1, 2, 3]
+    L = "Hello"
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'L', str, astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert List[int] in reasons
+
+
+def test_two_lists():
+    src = """
+    L = [1, 2, 3]
+    L = ['One', 'Two', 'Three']
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'L', List[str], astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert List[int] in reasons
+
+
+def test_tuple():
+    src = """
+    T = (1, 2)
+    T = 'Hello'
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'T', str, astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert Tuple[int, int] in reasons
+
+
+def test_two_tuple():
+    src = """
+    T = (1, 2)
+    T = ('One', 'Two')
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'T', Tuple[str, str], astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert Tuple[int, int] in reasons
+
+
+def test_mixed_tuple():
+    src = """
+    T = (1, 2)
+    T = (3, "Four")
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'T', Tuple[int, str], astroid.Assign)
+
+    reasons = tf.get_reasons()
+    assert Tuple[int, int] in reasons
+
+
+def test_function():
+    src = """
+    def f(x):
+        return x + 1
+        
+    f('Hello')
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_function(tf, Callable[[int], int])
+
+
+def test_multiple_functions():
+    src = """
+    def f(x):
+        return x + 1
+    
+    def g(x):
+        return x + 2
+
+    f('Hello')
+    g('Goodbye')
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_function(tf, Callable[[int], int])
+
+    reasons = tf.get_reasons()
+    assert isinstance(reasons[-1], astroid.FunctionDef)
+    eq_(reasons[-1].name, 'f')
+


### PR DESCRIPTION
Adding TypeFail subclasses `TypeFailUnify` and `TypeFailFunction`, with `get_reasons()` function, to be used by checkers and reporters to generate comprehensive error messages
Adding `find_path` function to `_TNode`, to be used by `TypeFailUnify` to find a chain of type inferences
Modifying `unify_generic` to return `TypeFail` objects with `_TNode`s that have not been fully resolved to concrete types, so that error checking has more information available
Also modifying `unify_generic` to create `TypeFailUnify` based on generic, rather than propagating `TypeFail` between individual elements
Modifying `_find_type_fail` in test_tnode_structure.py to be used by other test files
Adding relevant test cases 

*Still a work in progress, planning on adding other subclasses such as TypeFailLookup, which have been implemented, but are not included in this pull request as they have not been fully tested
