### PR TITLE
typecheck: Adding TypeFailUnify subclass and relevant tests

### DIFF
--- a/tests/test_type_inference/test_tnode_structure.py
+++ b/tests/test_type_inference/test_tnode_structure.py
@@ -26,12 +26,12 @@ def _nodes_to_dict(node_list):
     return node_dict
 
 
-def _find_type_fail(ast_node):
+def find_type_fail(ast_node):
     if isinstance(ast_node.inf_type, TypeFail):
         return ast_node
     else:
         for child in ast_node.get_children():
-            child_res = _find_type_fail(child)
+            child_res = find_type_fail(child)
             if child_res is not None:
                 return child_res
     return None
@@ -49,7 +49,7 @@ def _verify_inference(program, node_list):
 
 
 def _verify_type_fail(program, exp_node_str):
-    fail_node = _find_type_fail(program)
+    fail_node = find_type_fail(program)
     assert_is_not_none(fail_node, "Typecheck did not fail!")
     eq_(fail_node.as_string(), exp_node_str)
     eq_(fail_node.inf_type.src_node.as_string(), exp_node_str)

--- a/tests/test_type_inference/test_typefail_reason.py
+++ b/tests/test_type_inference/test_typefail_reason.py
@@ -1,0 +1,56 @@
+import astroid
+import tests.custom_hypothesis_support as cs
+from python_ta.typecheck.base import TypeFail, TypeFailUnify
+from tests.test_type_inference.test_tnode_structure import find_type_fail
+from nose.tools import eq_
+
+
+def verify_typefail_unify(tf: TypeFailUnify, *exp_tnodes, exp_src_type, num_reasons):
+    assert isinstance(tf, TypeFailUnify)
+    for tn, exp_r in zip(tf.tnodes, exp_tnodes):
+        if tn.ast_node:
+            eq_(tn.ast_node.name, exp_r)
+        else:
+            eq_(tn.type, exp_r)
+    assert isinstance(tf.src_node, exp_src_type)
+
+    reasons = []
+    for tn in tf.tnodes:
+        reasons += tn.find_path_to_parent()
+    eq_(len(reasons), num_reasons)
+
+
+def test_var_assign():
+    src = """
+    A = 1
+    A = 'One'
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'A', str, exp_src_type=astroid.Assign, num_reasons=1)
+
+
+def test_two_var_assign():
+    src = """
+    A = 1
+    B = 'Two'
+    A = B
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'A', 'B', exp_src_type=astroid.Assign, num_reasons=2)
+
+
+def test_var_chain():
+    src = """
+    A = 1
+    Z = 'Zed'
+
+    B = A
+    C = B
+    
+    C = Z
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    tf = find_type_fail(ast_mod).inf_type
+    verify_typefail_unify(tf, 'C', 'Z', exp_src_type=astroid.Assign, num_reasons=4)


### PR DESCRIPTION
Adding TypeFail subclass `TypeFailUnify` with `get_reasons()` function, to be used by checkers and reporters to generate comprehensive error messages
Adding `find_path` function to `_TNode`, to be used by `get_reasons()` to find a chain of type inferences
Modifying `_find_type_fail` in test_tnode_structure.py to be used by other test files
Adding relevant test cases 
