### PR TITLE
typecheck: Modifying unify_generic to return less concrete _TNodes

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -425,7 +425,7 @@ class TypeConstraints:
             ct2 = conc_tnode2.type
 
             if isinstance(ct1, GenericMeta) and isinstance(ct2, GenericMeta):
-                return self._unify_generic(conc_tnode1, conc_tnode2, ast_node)
+                return self._unify_generic(tnode1, tnode2, ast_node)
             elif ct1.__class__.__name__ == '_Union' or ct2.__class__.__name__ == '_Union':
                 ct1_types = ct1.__args__ if ct1.__class__.__name__ == '_Union' else [ct1]
                 ct2_types = ct2.__args__ if ct2.__class__.__name__ == '_Union' else [ct2]
@@ -472,13 +472,21 @@ class TypeConstraints:
         if len(conc_tnode1.type.__args__) != len(conc_tnode2.type.__args__):
             return TypeFail(conc_tnode1, conc_tnode2, ast_node)
 
-        unified_args = failable_collect([self.unify(a1, a2, ast_node)
-                                         for a1, a2 in
-                                         zip(conc_tnode1.type.__args__,
-                                             conc_tnode2.type.__args__)])
+        unified_args = []
+        for a1, a2 in zip(conc_tnode1.type.__args__, conc_tnode2.type.__args__):
+            result = self.unify(a1, a2, ast_node)
+            if isinstance(result, TypeFail):
+                result = TypeFail(tnode1, tnode2, ast_node)
+                unified_args = [result]
+                break
+            else:
+                unified_args.append(result)
 
-        self.create_edges(tnode1, tnode2, ast_node)
-        return _wrap_generic_meta(g1, unified_args)
+        collected_args = failable_collect(unified_args)
+
+        if not isinstance(collected_args, TypeFail):
+            self.create_edges(tnode1, tnode2, ast_node)
+        return _wrap_generic_meta(g1, collected_args)
 
     ###########################################################################
     # Handling generic polymorphism

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -239,8 +239,8 @@ def test_polymorphic_callable4(draw=False):
     assert isinstance(tc.unify(t2, Callable[[int], str]), TypeFail)
     actual_set = tc_to_disjoint(tc)
     expected_set = [{'~_T0', int},
-                    {'~_T1', '~_T2', 'typing.Callable[[~_T0], ~_T0]',
-                     'typing.Callable[[int], str]'}, {str}]
+                    {'~_T1', '~_T2', 'typing.Callable[[~_T0], ~_T0]'},
+                    {'typing.Callable[[int], str]'}, {str}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)


### PR DESCRIPTION
 Modifying unify_generic to return less concrete _TNodes in TypeFail, and not create edges between tnodes in the case of a TypeFail
Updating one test case where a TypeFail originally resulted in an edge created between the two failed tnodes