### PR TITLE
typecheck: Replacing TypeInfo(NoType)

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -48,6 +48,12 @@ class TypeInfo(TypeResult):
         return f'TypeInfo: {self.value}'
 
 
+class NoType(TypeResult):
+    """Class representing no inferred type"""
+    def __init__(self):
+        super().__init__(None)
+
+
 class TypeFail(TypeResult):
     """Represents the result of a failed type check operation
     Contains error message
@@ -456,7 +462,7 @@ class TypeConstraints:
             return TypeInfo(t1)
         else:
             self.create_edges(tnode1, tnode2, ast_node)
-            return TypeInfo(None)
+            return NoType()
 
     def _unify_generic(self, tnode1: _TNode, tnode2: _TNode,
                        ast_node: Optional[NodeNG] = None) -> TypeResult:

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -36,21 +36,21 @@ def test_tuple_same_length_int():
     program = generate_tuple_assign(10, int, True)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        eq_ (assign_node.inf_type, TypeInfo(NoType))
+        eq_ (assign_node.inf_type, NoType())
 
 
 def test_tuple_same_length_bool():
     program = generate_tuple_assign(10, bool, True)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        eq_ (assign_node.inf_type, TypeInfo(NoType))
+        eq_ (assign_node.inf_type, NoType())
 
 
 def test_tuple_same_length_str():
     program = generate_tuple_assign(10, str, True)
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        eq_ (assign_node.inf_type, TypeInfo(NoType))
+        eq_ (assign_node.inf_type, NoType())
 
 
 def test_tuple_single_var():
@@ -61,7 +61,7 @@ def test_tuple_single_var():
     """
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        eq_(assign_node.inf_type, TypeInfo(NoType))
+        eq_(assign_node.inf_type, NoType())
 
 def test_tuple_single_val():
     program = """

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -49,9 +49,9 @@ def test_homogenous_list_store_ctx():
         '''
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
-        assert assign_node.inf_type.getValue() == NoType
+        assert assign_node.inf_type == NoType()
     for subscript_node in module.nodes_of_class(astroid.Subscript):
-        assert subscript_node.inf_type.getValue() == NoType
+        assert subscript_node.inf_type == NoType()
 
 
 def test_homogenous_list_invalid_store_ctx():
@@ -64,7 +64,7 @@ def test_homogenous_list_invalid_store_ctx():
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert isinstance(assign_node.inf_type, TypeFail)
     for subscript_node in module.nodes_of_class(astroid.Subscript):
-        assert subscript_node.inf_type.getValue() == NoType
+        assert subscript_node.inf_type == NoType()
 
 
 @given(cs.subscript_node(cs.list_node(min_size=1), cs.slice_node()))


### PR DESCRIPTION
Replacing TypeInfo(NoType) with NoType, now a subclass of TypeResult, moved to base.py