### PR TITLE
typecheck: Small fix to logic in get_attribute_class

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -547,7 +547,7 @@ class TypeInferer:
         else:
             class_name = None
 
-        if class_name not in self.type_store.classes:
+        if class_name is not None and class_name not in self.type_store.classes:
             class_name = class_name.lower()
 
         return class_name, is_inst_expr


### PR DESCRIPTION
Removing accidental case attempting to call `lower()` on a `None` object