### PR TITLE
typecheck: Add support for automatic type conversion in arithmetic expressions

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -536,11 +536,15 @@ class TypeConstraints:
             elif ct1 == Any or ct2 == Any:
                 return TypeInfo(ct1)
             # Handle inheritance
-            elif self.type_store and \
-                    self.type_store.is_descendant(ct1, ct2):
-                return TypeInfo(ct1)
-            else:
-                return TypeFailUnify(tnode1, tnode2, src_node=ast_node)
+            elif self.type_store:
+                if ct2 == complex and self.type_store.is_descendant(ct1, SupportsComplex):
+                    return TypeInfo(complex)
+                if ct2 == float and self.type_store.is_descendant(ct1, SupportsFloat):
+                    return TypeInfo(float)
+                if self.type_store.is_descendant(ct1, ct2):
+                    return TypeInfo(ct1)
+
+            return TypeFailUnify(tnode1, tnode2, src_node=ast_node)
 
         # One type can be resolved
         elif conc_tnode1 is not None:

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -471,7 +471,6 @@ def test_builtin_call_simple_mro(draw=False):
 
 
 def test_builtin_binop_inheritance(draw=False):
-    raise SkipTest('Auto-casting must be handled for this test to pass')
     src = """
     x = 1.0 + 3
     """


### PR DESCRIPTION
This approach may be a little too simplistic, because ideally we would have to account for each of the "common type" conversion cases in [https://docs.python.org/3.6/reference/expressions.html?highlight=common%20type%20arithmetic](url). However, I think that it is always the case that unification against a float (or complex) happens in the context of one of these cases (which means that any subsequent unifications that involve the to-be converted SupportsFloat/SupportsComplex types do as well). Would there be any situation where would strictly expect, say, a float type and unification against an int (in that direction) would fail?