### PR TITLE
typecheck: Updating and implementing type_inference_checker

### DIFF
--- a/examples/type_inference_example.py
+++ b/examples/type_inference_example.py
@@ -1,0 +1,6 @@
+"""Module docstring."""
+
+
+A = 1
+
+A = "Hello"

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -172,10 +172,9 @@ def reset_linter(config=None, file_linted=None):
         'python_ta/checkers/always_returning_checker',
         'python_ta/checkers/constant_test_checker',
         'python_ta/checkers/structure_test_checker',
-        'python_ta/checkers/type_annotation_checker'
+        'python_ta/checkers/type_annotation_checker',
+        'python_ta/checkers/type_inference_checker'
         # 'python_ta/checkers/simplified_if_checker'
-        # TODO: Eventually enable this checker
-        # 'python_ta/checkers/type_inference_checker'
     ]
 
     # Register new options to a checker here to allow references to

--- a/python_ta/checkers/type_inference_checker.py
+++ b/python_ta/checkers/type_inference_checker.py
@@ -2,10 +2,12 @@
 """
 
 import astroid
+from typing import _ForwardRef
 from pylint.interfaces import IAstroidChecker
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
-from python_ta.transforms.type_inference_visitor import TypeErrorInfo
+from python_ta.transforms.type_inference_visitor import TypeInferer
+from python_ta.typecheck.base import TypeFail, TypeFailLookup, TypeFailUnify
 
 
 class TypeInferenceChecker(BaseChecker):
@@ -13,20 +15,45 @@ class TypeInferenceChecker(BaseChecker):
     __implements__ = IAstroidChecker
 
     name = 'TypeInferenceChecker'
-    msgs = {'E9900': ('Type error "%s" inferred',
+    msgs = {'E7700': ('%s',
                       'type-error',
                       'Presented when there is some kind of error with types.'),
-           }
+            'E7701': ('Type Error inferred between %s and %s',
+                      'type-error-unify',
+                      'Presented when there is a unification error between types.'),
+            'E7702': ('Lookup Error inferred',
+                      'type-error-lookup',
+                      'Presented when there is a lookup error.'),
+            }
 
     # this is important so that your checker is executed before others
     priority = -1
 
+    def __init__(self, linter):
+        self.type_fails = []
+        super().__init__(linter)
+
     @check_messages('type-error')
     def visit_default(self, node):
-        if hasattr(node, 'type_constraints'):
-            x = node.type_constraints
-            if isinstance(x.type, TypeErrorInfo):
-                self.add_message('type-error', args=x.type.msg, node=x.type.node)
+        if hasattr(node, 'inf_type') and isinstance(node.inf_type, TypeFail) and node.inf_type not in self.type_fails:
+            self.type_fails.append(node.inf_type)
+
+            if isinstance(node.inf_type, TypeFailUnify):
+                args = []
+                for tn in node.inf_type.tnodes:
+                    if tn.ast_node:
+                        args.append(tn.ast_node.as_string())
+                    elif isinstance(tn.type, _ForwardRef):
+                        args.append(str(tn.type))
+                    elif tn.type is not None:
+                        args.append(tn.type.__name__)
+                    else:
+                        args.append(tn.type)
+                self.add_message('type-error-unify', args=tuple(args), node=node.inf_type.src_node)
+            elif isinstance(node.inf_type, TypeFailLookup):
+                self.add_message('type-error-lookup', node=node.inf_type.src_node)
+            else:
+                self.add_message('type-error', args=node.inf_type, node=node)
 
 
 def register(linter):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -106,7 +106,7 @@ class TypeFailUnify(TypeFail):
         super().__init__(str(self))
 
     def __str__(self):
-        string = 'TypeFail: Unable to Unify '
+        string = 'TypeFail: Unable to unify '
         string += f'{self.tnodes[0].ast_node.as_string()}' if self.tnodes[0].ast_node else f'{self.tnodes[0].type}'
         string += ' <-> '
         string += f'{self.tnodes[1].ast_node.as_string()}' if self.tnodes[1].ast_node else f'{self.tnodes[1].type}'


### PR DESCRIPTION
@david-yz-liu  I'm unsure if the `hasattr` in `visit_default` is the best choice... However, the only alternative I can think of is changing the behaviour of `patch_type_inference_transform` in `python_ta/patches/type.py` so that it removes `type-inference-checker` from the list of custom checkers if `type_transformer.visit(ast)` raises an error. I'm worried that might involve too much changing of the attributes of the linter itself, so I left it with the `hasattr` for now