### PR TITLE
typecheck: Adding case in _node_to_type for astroid.Const node

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -855,6 +855,8 @@ def _node_to_type(node, locals=None):
         return [_node_to_type(t) for t in node.elts if not isinstance(t, astroid.Ellipsis)]
     elif isinstance(node, astroid.Const) and node.value is None:
         return None
+    elif isinstance(node, astroid.Const) and isinstance(node.value, str):
+        return _node_to_type(node.value)
     else:
         return node
 


### PR DESCRIPTION
Fixing crash in nodes/Arguments.py, when an argument is annotated with a string literal, as opposed to the str type