### PR TITLE
typecheck: Adding support for assignment to Starred variables

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -179,6 +179,20 @@ class TypeFailReturn(TypeFail):
         return f'TypeFail: Return statement not in valid function'
 
 
+class TypeFailStarred(TypeFail):
+    """
+    TypeFailStarred occurs when there are multiple starred variables in the target of an assignment
+
+    :param src_node: Invalid astroid.Assign node
+    """
+    def __init__(self, src_node):
+        self.src_node = src_node
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        return f'TypeFail: Multiple starred variables not valid'
+
+
 # Make _gorg compatible for Python 3.6.2 and 3.6.3.
 def _gorg(x):
     if sys.version_info < (3, 6, 3):

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -63,6 +63,7 @@ def test_tuple_single_var():
     for assign_node in module.nodes_of_class(astroid.Assign):
         eq_(assign_node.inf_type, NoType())
 
+
 def test_tuple_single_val():
     program = """
     a, b = 1

--- a/tests/test_type_inference/test_starred.py
+++ b/tests/test_type_inference/test_starred.py
@@ -1,0 +1,153 @@
+import astroid
+from nose.tools import eq_
+from nose import SkipTest
+from typing import *
+import tests.custom_hypothesis_support as cs
+from python_ta.typecheck.base import TypeInfo, TypeFail
+
+
+def test_list():
+    src = """
+    *a, b = [1, 2, 3]
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), List[int])
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), int)
+
+
+def test_range():
+    src = """
+    *a, b = range(5)
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), List[int])
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), int)
+
+
+def test_tuple():
+    src = """
+    *a, b = (1, 2, 3)
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), List[int])
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), int)
+
+
+def test_order():
+    src = """
+    a, *b, c = [1, 2, 3, 4]
+    a
+    b
+    c
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), List[int])
+        elif name_node.name == 'c':
+            eq_(name_node.inf_type.getValue(), int)
+
+
+def test_order_2():
+    src = """
+    a, *b = [1, 2, 3]
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), List[int])
+
+
+def test_mixed_tuple():
+    src = """
+    *a, b = (1, "Hello", False)
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), List[Any])
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), bool)
+
+
+def test_mixed_tuple_order():
+    src = """
+    a, *b = (1, "Hello", False)
+    a
+    b
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), List[Any])
+
+
+def test_mixed_tuple_three_var():
+    src = """
+    a, *b, c = (1, "Hello", False, "Goodbye", 4, "What")
+    a
+    b
+    c
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), List[Any])
+        elif name_node.name == 'c':
+            eq_(name_node.inf_type.getValue(), str)
+
+
+def test_mixed_tuple_four_var():
+    src = """
+    a, *b, c, d = (1, "Hello", "Good morning", "Goodbye", 4, "What")
+    a
+    b
+    c
+    d
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for name_node in ast_mod.nodes_of_class(astroid.Name):
+        assert not isinstance(name_node, TypeFail)
+        if name_node.name == 'a':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'b':
+            eq_(name_node.inf_type.getValue(), List[str])
+        elif name_node.name == 'c':
+            eq_(name_node.inf_type.getValue(), int)
+        elif name_node.name == 'd':
+            eq_(name_node.inf_type.getValue(), str)


### PR DESCRIPTION
First noticed while fixing crash in nodes/Starred.py
Adding support for assigning tuples, lists and iterators to a tuple with a starred variable
