### PR TITLE
typecheck: Modifying lookup_typevar to be monadic

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -196,22 +196,20 @@ class TypeInferer:
     # Name lookup and assignment
     ##############################################################################
     def visit_name(self, node: astroid.Name) -> None:
-        try:
-            node.inf_type = self.lookup_inf_type(node, node.name)
-        except KeyError:
-            if node.name in self.type_store.classes:
-                node.inf_type = TypeInfo(Type[__builtins__[node.name]])
-            elif node.name in self.type_store.functions:
-                node.inf_type = TypeInfo(self.type_store.functions[node.name][0][0])
-            else:
-                # This is an unbound identifier. Ignore it.
-                node.inf_type = TypeInfo(Any)
+        lookup_result = self.lookup_inf_type(node, node.name)
+
+        if isinstance(lookup_result, TypeFail) and node.name in self.type_store.classes:
+            node.inf_type = TypeInfo(Type[__builtins__[node.name]])
+        elif isinstance(lookup_result, TypeFail) and node.name in self.type_store.functions:
+            node.inf_type = TypeInfo(self.type_store.functions[node.name][0][0])
+        else:
+            node.inf_type = lookup_result
 
     def visit_assign(self, node: astroid.Assign) -> None:
         """Update the enclosing scope's type environment for the assignment's binding(s)."""
         # the type of the expression being assigned
         if isinstance(node.value, astroid.Name):
-            expr_inf_type = TypeInfo(self.lookup_typevar(node, node.value.name))
+            expr_inf_type = self.lookup_typevar(node, node.value.name)
         else:
             expr_inf_type = node.value.inf_type
 
@@ -258,9 +256,12 @@ class TypeInferer:
         class_env = self._closest_frame(node, class_name).locals[class_name][0].type_environment
         return self.type_constraints.resolve(class_env.lookup_in_env(attribute_name))
 
-    def lookup_typevar(self, node: NodeNG, name: str) -> TypeVar:
+    def lookup_typevar(self, node: NodeNG, name: str) -> TypeResult:
         """Given a variable name, return the equivalent TypeVar in the closest scope relative to given node."""
-        return self._closest_frame(node, name).type_environment.lookup_in_env(name)
+        try:
+            return TypeInfo(self._closest_frame(node, name).type_environment.lookup_in_env(name))
+        except:
+            return TypeFail("Unbound identifier")
 
     def lookup_inf_type(self, node: NodeNG, name: str) -> TypeResult:
         """Given a variable name, return a TypeResult object containing the type in the closest scope relative to given node.

--- a/tests/test_type_inference/test_assign.py
+++ b/tests/test_type_inference/test_assign.py
@@ -6,6 +6,7 @@ import tests.custom_hypothesis_support as cs
 import hypothesis.strategies as hs
 from typing import TypeVar, Any
 from keyword import iskeyword
+from python_ta.typecheck.base import TypeFail
 settings.load_profile("pyta")
 
 
@@ -32,7 +33,7 @@ def test_set_name_unassigned(identifier):
     program = identifier
     module, _ = cs._parse_text(program)
     for name_node in module.nodes_of_class(astroid.Name):
-        assert name_node.inf_type.getValue() == Any
+        assert isinstance(name_node.inf_type, TypeFail)
 
 
 @given(cs.random_dict_variable_homogeneous_value(min_size=1))


### PR DESCRIPTION
Changing lookup_typevar to return a TypeInfo or TypeFail, thereby fixing crashes caused by nodes/Call.py and nodes/Assign.py
Updating test case in test_binops to use failable_collect

This replaces pull request #450 and #452