### PR TITLE
typecheck: Implementing TypeFailFunction for non-callable objects

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -274,7 +274,7 @@ class TypeInferer:
     # Operation nodes
     ##############################################################################
     @accept_failable
-    def get_call_signature(self, c, node: NodeNG) -> TypeResult:
+    def get_call_signature(self, c: type, node: NodeNG) -> TypeResult:
         if hasattr(c, '__name__') and c.__name__ == 'Type':
             class_type = c.__args__[0]
             if isinstance(class_type, _ForwardRef):
@@ -284,8 +284,12 @@ class TypeInferer:
         elif isinstance(c, _ForwardRef):
             class_type = c
             class_name = c.__forward_arg__
-        else:
+        elif isinstance(c, CallableMeta):
             return TypeInfo(c)
+        elif hasattr(c, '__args__') and all(isinstance(elt, CallableMeta) for elt in c.__args__):
+            return TypeInfo(c)
+        else:
+            return TypeFailFunction((c,), None, node)
 
         if '__init__' in self.type_store.classes[class_name]:
             init_args = list(self.type_store.classes[class_name]['__init__'][0][0].__args__)

--- a/tests/test_type_inference/test_functions.py
+++ b/tests/test_type_inference/test_functions.py
@@ -2,7 +2,7 @@ import astroid
 import nose
 from hypothesis import assume, given, settings, HealthCheck
 from unittest import SkipTest
-from python_ta.transforms.type_inference_visitor import TypeFail
+from python_ta.transforms.type_inference_visitor import TypeFail, TypeFailFunction
 import tests.custom_hypothesis_support as cs
 import hypothesis.strategies as hs
 from typing import Callable
@@ -403,6 +403,16 @@ def test_conflicting_inferred_type_variable():
                    f'in parameter (1), the annotated type is str but was given an object of inferred type int.'
                    # TODO: test case redundant because recursive..?
     assert call_node.inf_type.getValue() == expected_msg
+
+
+def test_non_callable():
+    program = '''
+    x = 1
+    x()
+    '''
+    module, inferer = cs._parse_text(program)
+    call_node = next(module.nodes_of_class(astroid.Call))
+    assert isinstance(call_node.inf_type, TypeFailFunction)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add check for non-callable objects in `get_call_signature`, and add relevant test case
Change prompted by `examples/pylint/E1102_not_callable.py`