### PR TITLE
typecheck: Editing required astroid and pylint versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ python:
   - "3.6"
 install:
   - sudo apt install graphviz
-  - pip install pylint funcparserlib colorama jinja2 pycodestyle hypothesis pygments graphviz
+  - pip install funcparserlib colorama jinja2 pycodestyle hypothesis pygments graphviz
+  - pip install 'astroid==1.6.5' 'pylint==1.9'
 script:
   - nosetests
 notifications:

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ setup(
               'python_ta.docstring', 'python_ta.patches', 'python_ta.parser',
               'python_ta.transforms', 'python_ta.typecheck'],
     install_requires=[
-        'astroid>=1.6',
+        'astroid>=1.6,<=1.6.5',
         'funcparserlib',
         'hypothesis',
         'pycodestyle',
-        'pylint>=1.8',
+        'pylint>=1.8,<=1.9',
         'nose',
         'colorama',
         'six',


### PR DESCRIPTION
Prompted by releases of astroid 2.0 and pylint 2.0 on July 15, 2018
First noticed during Travis CI build of #454 