### PR TITLE
typecheck: Removing redundant function type annotation

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -74,8 +74,8 @@ Done.
 Done.
 
 ### FunctionDef
-**TODOs:**
-- It seems function type annotations are unified in both `visit_functiondef` and `visit_arguments`. If so, remove the logic in `visit_functiondef`.
+
+Done.
 
 ### GeneratorExp
 


### PR DESCRIPTION
Removing unification of function type with function type annotations in `visit_functiondef`, as that is now taken care of in `visit_arguments`
Some changes made to `visit_arguments` and `visit_return` to solve for cases that had previously been handled in `visit_functiondef`. `visit_arguments` now unifies parameters without annotations with `Any` and `visit_return` now checks for a return type annotation. Both of these were previously indirectly handled by the `parse_annotations` call in `visit_functiondef`
These changes also reveal an unrelated error in `test_classdef.test_classdef_method_call`, caused by an incorrect `TypeFailLookup` in the return statement of `get_name`. This error should be resolved by fixes in @simeonkr's #477 