### PR TITLE
typecheck: Replacing _closest_frame

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -4,7 +4,6 @@
 
 ### TODOs
 - Add type annotations and docstrings
-- Replace `_closest_frame` with astroid's provided `scope_lookup` or equivalent.
 - Move `lookup_type` to a test helper file.
 - Add support for the `__call__` magic method.
 


### PR DESCRIPTION
Removing `_closest_frame` function, instead finding scope directly in `lookup_typevar`.
`lookup_typevar` also directly searches TypeStore if variable is found to be a builtin (behaviour previously handled by `isinstance(TypeFail` checks in `visit_name`)
Other functions have been modified to remove their dependency on `_closest_frame`