### PR TITLE
typecheck: Slight edits to type_annotation_example

### DIFF
--- a/examples/type_annotation_example.py
+++ b/examples/type_annotation_example.py
@@ -8,15 +8,15 @@ def example_function(x):
 
 class ExampleClass:
     """Class docstring."""
-    inst_attr = 0
+    class_var = 0
 
     def __init__(self):
         """Function docstring."""
-        self.init_attr = "Hello"
+        self.inst_attr = "Hello"
 
     def inst_method(self, x):
         """Function dosctring."""
-        return self.inst_attr + x
+        return self.inst_attr
 
     @staticmethod
     def static_function(x):


### PR DESCRIPTION
Prompted by unnecessary instances of TypeFailLookup when running type inference checker (trying to keep this example to purely annotation errors)