### PR TITLE
typecheck: Adding support for generic type annotations with subscripts

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -14,6 +14,11 @@ Done. `lookup_type()` and `types_in_callable()` remain, but should be used purel
 
 ## Nodes
 
+### AnnAssign
+
+**TODOs:**
+- Add proper support for multi-parameter Tuples using ellipsis
+
 ### Assign
 
 Done.

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -492,12 +492,15 @@ class TypeConstraints:
     # Type lookup ("find")
     ###########################################################################
     @accept_failable
-    def resolve(self, t: type) -> TypeInfo:
+    def resolve(self, t: type) -> TypeResult:
         """Return the concrete type or set representative associated with the given type.
         """
         if isinstance(t, GenericMeta):
-            res_args = [self.resolve(arg) for arg in t.__args__]
-            return _wrap_generic_meta(_gorg(t), failable_collect(res_args))
+            if t.__args__ is not None:
+                res_args = [self.resolve(arg) for arg in t.__args__]
+                return _wrap_generic_meta(_gorg(t), failable_collect(res_args))
+            else:
+                return TypeInfo(t)
         elif isinstance(t, TypeVar):
             try:
                 repr = self.find_repr(self.type_to_tnode[str(t)])

--- a/tests/test_type_inference/test_annassign.py
+++ b/tests/test_type_inference/test_annassign.py
@@ -4,7 +4,10 @@ from hypothesis import given, settings, HealthCheck
 import tests.custom_hypothesis_support as cs
 from tests.custom_hypothesis_support import lookup_type
 import hypothesis.strategies as hs
-from python_ta.typecheck.base import _node_to_type
+from python_ta.typecheck.base import _node_to_type, TypeFailUnify
+from typing import List, Set, Dict, Any, Tuple
+from nose import SkipTest
+from nose.tools import eq_
 settings.load_profile("pyta")
 
 
@@ -40,6 +43,145 @@ def test_annassign(variables_annotations_dict):
         variable_type = lookup_type(inferer, node, node.target.name)
         annotated_type = variables_annotations_dict[node.target.name]
         assert variable_type == annotated_type
+
+
+def test_annassign_subscript_list():
+    program = """
+    lst: List
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    assert issubclass(variable_type, List)
+
+
+def test_annassign_subscript_list_int():
+    program = """
+    lst: List[int]
+    
+    lst = [1, 2, 3]
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, List[int])
+
+    assign_node = next(module.nodes_of_class(astroid.Assign))
+    assign_type = lookup_type(inferer, assign_node, assign_node.targets[0].name)
+    eq_(assign_type, List[int])
+
+
+def test_annassign_subscript_list_int_wrong():
+    program = """
+    lst: List[int]
+
+    lst = ['Hello', 'Goodbye']
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, List[int])
+
+    assign_node = next(module.nodes_of_class(astroid.Assign))
+    assert isinstance(assign_node.inf_type, TypeFailUnify)
+
+
+def test_annassign_subscript_set():
+    program = """
+    s: Set
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    assert issubclass(variable_type, Set)
+
+
+def test_annassign_subscript_set_int():
+    program = """
+    s: Set[int]
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, Set[int])
+
+
+def test_annassign_subscript_dict():
+    program = """
+    d: Dict
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    assert issubclass(variable_type, Dict)
+
+
+def test_annassign_subscript_dict_int_str():
+    program = """
+    d: Dict[int, str]
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, Dict[int, str])
+
+
+def test_annassign_subscript_tuple():
+    program = """
+    t: Tuple
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    assert issubclass(variable_type, Tuple)
+
+
+def test_annassign_subscript_tuple_int():
+    program = """
+    t: Tuple[int, int]
+    """
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, Tuple[int, int])
+
+
+def test_annassign_subscript_tuple_multi_param():
+    program = """
+    t: Tuple
+    
+    t = (1, 'Hello')
+    """
+    raise SkipTest("Requires support for multi-parameter Tuple annotations")
+    module, inferer = cs._parse_text(program)
+    ann_node = next(module.nodes_of_class(astroid.AnnAssign))
+    variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+    eq_(variable_type, Tuple[int, int])
+
+
+def test_annassign_subscript_multi_list():
+    program = """
+    l1: List
+    l2: List
+    
+    l1 = [1, 2, 3]
+    l2 = ['Hello', 'Goodbye']
+    """
+    module, inferer = cs._parse_text(program)
+
+    for ann_node in module.nodes_of_class(astroid.AnnAssign):
+        variable_type = lookup_type(inferer, ann_node, ann_node.target.name)
+        assert issubclass(variable_type, List)
+
+    assign_nodes = list(module.nodes_of_class(astroid.Assign))
+
+    assign_node_1 = assign_nodes[0]
+    assign_type_1 = lookup_type(inferer, assign_node_1, assign_node_1.targets[0].name)
+    eq_(assign_type_1, List[Any])
+
+    assign_node_2 = assign_nodes[1]
+    assign_type_2 = lookup_type(inferer, assign_node_2, assign_node_2.targets[0].name)
+    eq_(assign_type_2, List[Any])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prompted by errors raised when running type inference checker on student code for CSC 148, specifically
```
_cars: Dict[str, 'Car']
```

Does not yet support unspecified multi-parameter Tuple annotation, ie. if a variable is annotations as `Tuple`, then it will only unify with single-parameter tuples