### PR TITLE
typecheck: Fixing functiondef lookup in visit_return

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -625,8 +625,8 @@ class TypeInferer:
         else:
             return_target = return_tvar
 
-        if node.value is not None and node.parent.returns is not None:
-            return_annotation = _node_to_type(node.parent.returns)
+        if node.value is not None and node.scope().returns is not None:
+            return_annotation = _node_to_type(node.scope().returns)
             return_value = self.type_constraints.unify(node.value.inf_type, return_annotation, node)
         elif node.value is not None:
             return_value = node.value.inf_type


### PR DESCRIPTION
Prompted by errors caused when return statement in a function def is within an expression, such as if statements