### PR TITLE
typecheck: Excepting imported objects from being added to type environment

### DIFF
--- a/python_ta/typecheck/README.md
+++ b/python_ta/typecheck/README.md
@@ -92,6 +92,11 @@ Done.
 
 Done.
 
+### Module
+
+**TODOs:**
+- Add support for import statements
+
 ### Name
 
 **TODOs:**


### PR DESCRIPTION
Excepting imported objects from being added to type environment
Prompted by issues caused by code such as the following:
```
from typing import Dict

var: Dict[str, int]
```
In previous implementation, `Dict` would be assigned a type variable, causing incorrect behaviour when `lookup_inf_type` was called while visiting the `Name.Dict` node in the annotation expression