### PR TITLE
typecheck: Changing empty Tuples to be polymorphic

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -149,6 +149,8 @@ class TypeInferer:
         if node.ctx == astroid.Store:
             # Tuple is the target of an assignment; do not give it a type.
             node.inf_type = NoType()
+        elif not node.elts:
+            node.inf_type = TypeInfo(Tuple[self.type_constraints.fresh_tvar(node), ...])
         else:
             node.inf_type = wrap_container(Tuple, *(e.inf_type for e in node.elts))
 

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -662,6 +662,10 @@ class TypeConstraints:
         if g1 is not g2 or conc_tnode1.type.__args__ is None or conc_tnode2.type.__args__ is None:
             # TODO: need to store more info here and in the case below
             return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
+        if any(arg is Ellipsis for arg in conc_tnode1.type.__args__):
+            tnode1.parent = conc_tnode2
+            tnode1.parent_path = (conc_tnode1, ast_node)
+            return TypeInfo(conc_tnode2.type)
         if len(conc_tnode1.type.__args__) != len(conc_tnode2.type.__args__):
             return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
 

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -1,9 +1,10 @@
 import astroid
 from nose.tools import eq_
-from typing import TupleMeta
+from typing import Tuple
 import tests.custom_hypothesis_support as cs
 from python_ta.transforms.type_inference_visitor import NoType
 from python_ta.typecheck.base import TypeInfo, TypeFail
+from tests.custom_hypothesis_support import lookup_type
 
 
 def generate_tuple(length: int, t: type=None):
@@ -88,3 +89,15 @@ def test_tuple_extra_value():
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert isinstance(assign_node.inf_type, TypeFail)
 
+
+def test_empty_tuple():
+    program = """
+    t = ()
+    t = (1,)
+    t = (1, 2)
+    """
+    module, ti = cs._parse_text(program)
+    assign_nodes = list(module.nodes_of_class(astroid.Assign))
+    tvar = lookup_type(ti, assign_nodes[1], 't')
+    eq_(tvar, Tuple[int])
+    assert isinstance(assign_nodes[2].inf_type, TypeFail)

--- a/tests/test_type_inference/test_tuple.py
+++ b/tests/test_type_inference/test_tuple.py
@@ -13,7 +13,10 @@ def test_tuple(t_tuple):
     module, _ = cs._parse_text(t_tuple)
     for t_node in module.nodes_of_class(astroid.Tuple):
         elt_types = tuple(elt.inf_type.getValue() for elt in t_node.elts)
-        assert t_node.inf_type.getValue() == Tuple[elt_types]
+        if len(elt_types) > 0:
+            assert t_node.inf_type.getValue() == Tuple[elt_types]
+        else:
+            assert issubclass(t_node.inf_type.getValue(), Tuple)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Representing empty tuples with inferred type `Tuple[TypeVar(T), ...]` to indicate that the tuple is polymorphic, and accepts a variable number of elements