### PR TITLE
typecheck: Handle inheritance for generic types properly

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -659,11 +659,12 @@ class TypeConstraints:
         conc_tnode2 = self.find_parent(tnode2)
 
         g1, g2 = _gorg(conc_tnode1.type), _gorg(conc_tnode2.type)
-        if g1 is not g2 or conc_tnode1.type.__args__ is None or conc_tnode2.type.__args__ is None:
-            # TODO: need to store more info here and in the case below
-            return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
-        if len(conc_tnode1.type.__args__) != len(conc_tnode2.type.__args__):
-            return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
+        if not self.type_store or not self.type_store.is_descendant(conc_tnode1.type, conc_tnode2.type):
+            if g1 is not g2 or conc_tnode1.type.__args__ is None or conc_tnode2.type.__args__ is None:
+                # TODO: need to store more info here and in the case below
+                return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
+            if len(conc_tnode1.type.__args__) != len(conc_tnode2.type.__args__):
+                return TypeFailUnify(conc_tnode1, conc_tnode2, src_node=ast_node)
 
         arg_inf_types = []
         for a1, a2 in zip(conc_tnode1.type.__args__, conc_tnode2.type.__args__):

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -527,4 +527,39 @@ def test_userdefn_overrides_builtin(draw=False):
         gen_graph_from_nodes(ti.type_constraints._nodes)
 
 
-# TODO: test builtins with Any in signature
+def test_builtin_generic_inheritance_init(draw=False):
+    src = """
+    x = set([1,2,3])
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x = [ti.lookup_typevar(node, node.name) for node
+         in ast_mod.nodes_of_class(astroid.AssignName)][0]
+    assert ti.type_constraints.resolve(x).getValue() == Set[int]
+
+
+def test_builtin_generic_inheritance_method_lookup(draw=False):
+    raise SkipTest('Depends on PR #493')
+    src = """
+    x = set([1,2,3])
+    y = x.difference([2,3])
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x, y = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(y).getValue() == Set[int]
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)
+
+
+def test_builtin_generic_inheritance_overloaded_init(draw=False):
+    raise SkipTest('Support for overloaded initializers required')
+    src = """
+    x = set([1,2,3])
+    y = list(x)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    x, y = [ti.lookup_typevar(node, node.name) for node
+            in ast_mod.nodes_of_class(astroid.AssignName)]
+    assert ti.type_constraints.resolve(x).getValue() == List[int]
+    if draw:
+        gen_graph_from_nodes(ti.type_constraints._nodes)


### PR DESCRIPTION
This change allows unification of types like `List[int]` and `Sequence[~_T]`.