### PR TITLE
typecheck: Fixing type_annotation_checker

### DIFF
--- a/examples/type_annotation_example.py
+++ b/examples/type_annotation_example.py
@@ -9,12 +9,14 @@ def example_function(x):
 class ExampleClass:
     """Class docstring."""
     class_var = 0
+    inst_attr = "Hello"
 
     def __init__(self):
         """Function docstring."""
-        self.inst_attr = "Hello"
+        self.inst_attr: str
+        self.inst_attr_2 = True
 
-    def inst_method(self, x):
+    def inst_method(self):
         """Function dosctring."""
         return self.inst_attr
 

--- a/python_ta/checkers/type_annotation_checker.py
+++ b/python_ta/checkers/type_annotation_checker.py
@@ -17,10 +17,10 @@ class TypeAnnotationChecker(BaseChecker):
             'E9971': ('Function is missing return type annotation',
                       'type-annotation-return',
                       'Presented when a type annotation is missing.'),
-            'E9972': ('Class variable is missing type annotation',
-                      'type-annotation-class-var',
+            'E9972': ('Variable is missing type annotation',
+                      'type-annotation-var',
                       'Presented when a type annotation is missing.'),
-            'E9973': ('Instance variable is missing type annotation',
+            'E9973': ('Instance variable should be annotated in class body',
                       'type-annotation-inst-var',
                       'Presented when a type annotation is missing.'),
            }
@@ -39,14 +39,18 @@ class TypeAnnotationChecker(BaseChecker):
             self.add_message('type-annotation-return', node=node.args)
 
     def visit_classdef(self, node):
-        for attr_key in node.locals:
-            attr_node = node.locals[attr_key][0]
-            if isinstance(attr_node, astroid.AssignName):
-                self.add_message('type-annotation-class-var', node=attr_node)
         for attr_key in node.instance_attrs:
             attr_node = node.instance_attrs[attr_key][0]
-            if isinstance(attr_node, astroid.AssignAttr) and isinstance(attr_node.parent, astroid.Assign):
-                self.add_message('type-annotation-inst-var', node=attr_node)
+            if isinstance(attr_node, astroid.AssignAttr):
+                if attr_key not in node.locals:
+                    self.add_message('type-annotation-inst-var', node=attr_node)
+                elif isinstance(attr_node.parent, astroid.AnnAssign):
+                    self.add_message('type-annotation-inst-var', node=attr_node)
+
+        for attr_key in node.locals:
+            attr_node = node.locals[attr_key][0]
+            if isinstance(attr_node, astroid.AssignName) and not isinstance(attr_node.parent, astroid.AnnAssign):
+                self.add_message('type-annotation-var', node=attr_node)
 
 
 def register(linter):


### PR DESCRIPTION
Fixing logic in `for attr_node in node.locals`, was previously raising false positives. Previous type annotation example only checked that missing annotations were pointed out, and variables with correct annotations were also classified as missing annotations. For example, `class_var: int = 0` and `class_var: int` would previously be highlighted as missing a type annotation. 
Also now requires instances variables to be annotated in class body. type_annotation_example edited to provide example