### PR TITLE
typecheck: Unskip test in test_tnode_structure

### DIFF
--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -538,10 +538,9 @@ def test_builtin_generic_inheritance_init(draw=False):
 
 
 def test_builtin_generic_inheritance_method_lookup(draw=False):
-    raise SkipTest('Depends on PR #493')
     src = """
     x = set([1,2,3])
-    y = x.difference([2,3])
+    y = x.symmetric_difference([2,3])
     """
     ast_mod, ti = cs._parse_text(src, reset=True)
     x, y = [ti.lookup_typevar(node, node.name) for node


### PR DESCRIPTION
I changed the method used in the test only because the old one had * args.