### PR TITLE
typecheck: Adding support for attribute type annotation

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -196,7 +196,10 @@ class TypeInferer:
                 break
 
     def visit_annassign(self, node: astroid.AnnAssign) -> None:
-        var_inf_type = self.lookup_typevar(node.target, node.target.name)
+        if isinstance(node.target, astroid.AssignAttr):
+            var_inf_type = self.lookup_typevar(node.target, node.target.attrname)
+        else:
+            var_inf_type = self.lookup_typevar(node.target, node.target.name)
         ann_type = self._ann_node_to_type(node.annotation)
         self.type_constraints.unify(var_inf_type, ann_type, node)
         if node.value:


### PR DESCRIPTION
Prompted by `AttributeError` raised when attempting to look up type variable for target when target does not have `name` attribute, ie.
```
def __init__(self):
    self.attr: int
```