### PR TITLE
typecheck: Moving unification of class type to environment transformer

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -49,7 +49,10 @@ class TypeInferer:
         node.type_environment = Environment()
         for name in node.globals:
             if not any(isinstance(elt, (astroid.ImportFrom, astroid.Import)) for elt in node.globals[name]):
-                node.type_environment.globals[name] = self.type_constraints.fresh_tvar(node.globals[name][0])
+                new_tvar = self.type_constraints.fresh_tvar(node.globals[name][0])
+                if any(isinstance(elt, astroid.ClassDef) for elt in node.globals[name]):
+                    self.type_constraints.unify(new_tvar, Type[_ForwardRef(name)], node)
+                node.type_environment.globals[name] = new_tvar
         self._populate_local_env(node)
 
     def _set_classdef_environment(self, node: astroid.ClassDef) -> None:
@@ -675,8 +678,6 @@ class TypeInferer:
 
     def visit_classdef(self, node: astroid.ClassDef) -> None:
         node.inf_type = NoType()
-        self.type_constraints.unify(self.lookup_inf_type(node.parent, node.name),
-                                    Type[_ForwardRef(node.name)], node)
 
         # Update type_store for this class.
         # TODO: include node.instance_attrs as well?

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -45,3 +45,17 @@ def test_wrong_number_init():
     ast_mod, ti = cs._parse_text(program, True)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_class_defined_later():
+    program = """
+    class A:
+        def __init__(self):
+            self.attr = B()
+
+    class B:
+        pass
+    """
+    ast_mod, ti = cs._parse_text(program, True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert not isinstance(call_node.inf_type, TypeFail)


### PR DESCRIPTION
Moved unification of class name with class type into environment transformer, so that instantiations of classes that are defined later in the code are considered valid