### PR TITLE
typecheck: Adding support for assigning to tuples of subscripts and attributes

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -294,28 +294,42 @@ class TypeInferer:
                 else:
                     return TypeFailStarred(node)
 
+        target_tvars = []
+        for subtarget in target.elts:
+            if isinstance(subtarget, astroid.AssignAttr):
+                target_tvars.append(self._lookup_attribute_type(subtarget, subtarget.expr.inf_type, subtarget.attrname))
+            elif isinstance(subtarget, astroid.Starred):
+                if isinstance(subtarget.value, astroid.AssignAttr):
+                    target_tvars.append(self.lookup_typevar(subtarget.value, subtarget.value.attrname))
+                else:
+                    target_tvars.append(self.lookup_typevar(subtarget.value, subtarget.value.name))
+            elif isinstance(subtarget, astroid.Subscript):
+                target_tvars.append(self._handle_call(subtarget, '__getitem__', subtarget.value.inf_type,
+                                                      subtarget.slice.inf_type))
+            else:
+                target_tvars.append(self.lookup_typevar(subtarget, subtarget.name))
+
         if starred_index is not None:
             starred_length = len(value.__args__) - len(target.elts) + 1
             starred_subvalues = node.value.elts[starred_index:starred_index+starred_length]
             starred_value = wrap_container(List, self._unify_elements(starred_subvalues, node))
 
-            starred_target = target.elts[starred_index].value
-            starred_target_tvar = self.lookup_typevar(starred_target, starred_target.name)
+            starred_target_tvar = target_tvars[starred_index]
 
             unif_result = self.type_constraints.unify(starred_target_tvar, starred_value, node)
             if isinstance(unif_result, TypeFail):
                 return unif_result
 
             nonstarred_values = Tuple[value.__args__[:starred_index] + value.__args__[starred_index + starred_length:]]
-            nonstarred_targets = target.elts
+            nonstarred_targets = target_tvars
             nonstarred_targets.remove(nonstarred_targets[starred_index])
 
         else:
             nonstarred_values = value
-            nonstarred_targets = target.elts
+            nonstarred_targets = target_tvars
 
         nonstarred_target_tuple = wrap_container(
-            Tuple, *[self.lookup_typevar(subtarget, subtarget.name) for subtarget in nonstarred_targets])
+            Tuple, *nonstarred_targets)
 
         unif_result = self.type_constraints.unify(nonstarred_target_tuple, nonstarred_values, node)
         if isinstance(unif_result, TypeFail):

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -88,3 +88,27 @@ def test_tuple_extra_value():
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert isinstance(assign_node.inf_type, TypeFail)
 
+
+def test_tuple_subscript():
+    program = """
+    lst = ['Hello', 'Goodbye']
+    lst[0], lst[1] = 'Bonjour', 'Au revoir'
+    """
+    module, _ = cs._parse_text(program)
+    for assign_node in module.nodes_of_class(astroid.Assign):
+        assert not isinstance(assign_node.inf_type, TypeFail)
+
+
+def test_tuple_attribute():
+    program = """
+    class A:
+        def __init__(self):
+            self.first_attr = 0
+            self.second_attr = 1
+
+    a = A()
+    a.first_attr, a.second_attr = 10, 11
+    """
+    module, _ = cs._parse_text(program)
+    for assign_node in module.nodes_of_class(astroid.Assign):
+        assert not isinstance(assign_node.inf_type, TypeFail)


### PR DESCRIPTION
Prompted by errors raised when testing on student code that assigned to multiple variables in one line, when those variables were elements or attributes