### PR TITLE
typecheck: Ensuring 'target_type' is assigned in visit_augassign

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -227,7 +227,8 @@ class TypeInferer:
         # lookup method for augmented arithmetic assignment
         method_name = BINOP_TO_METHOD[node.op]
         if isinstance(node.target, astroid.Subscript):
-            binop_result = self._handle_call(node.target, '__setitem__', node.target.value.inf_type,
+            target_type = node.target.value.inf_type
+            binop_result = self._handle_call(node.target, '__setitem__', target_type,
                                              node.target.slice.inf_type, node.value.inf_type)
         else:
             if isinstance(node.target, astroid.AssignName):


### PR DESCRIPTION
Errors caused when target_type is referenced before assignment