### PR TITLE
typecheck: Modifying visit_return to use get_attr

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -684,7 +684,7 @@ class TypeInferer:
         else:
             return_target = return_tvar
 
-        if node.value is not None and node.scope().returns is not None:
+        if node.value is not None and getattr(node.scope(), 'returns', None) is not None:
             return_annotation = _node_to_type(node.scope().returns)
             return_value = self.type_constraints.unify(node.value.inf_type, return_annotation, node)
         elif node.value is not None:


### PR DESCRIPTION
Prompted by crashes when return statement is not in function, thus `node.scope()` returns a node that does not have a `returns` attribute