### PR TITLE
typecheck: Changing type signature of initializers for classes not yet defined

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -417,7 +417,7 @@ class TypeInferer:
                 init_func = Callable[init_args[1:-1], init_args[0]]
             else:
                 # Classes declared without initializer
-                init_func = Callable[[], class_type]
+                init_func = Callable[..., class_type]
             return TypeInfo(init_func)
         # Class instances; e.g., '_ForwardRef('A')'
         elif isinstance(c, _ForwardRef):

--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -704,6 +704,9 @@ class TypeConstraints:
             parent_tnode = self.find_parent(func_var_tnode)
             func_type = parent_tnode.type
 
+        if any(arg is Ellipsis for arg in func_type.__args__):
+            return self._type_eval(func_type.__args__[-1])
+
         # Check that the number of parameters matches the number of arguments.
         if func_type.__origin__ is Union:
             new_func_type = None

--- a/tests/test_type_inference/test_initializer.py
+++ b/tests/test_type_inference/test_initializer.py
@@ -2,6 +2,7 @@ import astroid
 from typing import _ForwardRef
 import tests.custom_hypothesis_support as cs
 from nose.tools import eq_
+from nose import SkipTest
 from python_ta.transforms.type_inference_visitor import TypeFail
 
 
@@ -59,3 +60,30 @@ def test_class_defined_later():
     ast_mod, ti = cs._parse_text(program, True)
     for call_node in ast_mod.nodes_of_class(astroid.Call):
         assert not isinstance(call_node.inf_type, TypeFail)
+
+
+def test_init_defined_later():
+    program = """
+    a = A('Hello')
+    
+    class A:
+        def __init__(self, x):
+            self.attr = x
+    """
+    ast_mod, ti = cs._parse_text(program, True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert not isinstance(call_node.inf_type, TypeFail)
+
+
+def test_wrong_number_init_defined_later():
+    program = """
+    a = A()
+    
+    class A:
+        def __init__(self, x):
+            self.attr = x
+    """
+    raise SkipTest("Initializers for classes that have not yet been defined will accept any number of arguments")
+    ast_mod, ti = cs._parse_text(program, True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        assert isinstance(call_node.inf_type, TypeFail)


### PR DESCRIPTION
This behaviour may be too permissive, as it leads to initializers (for classes that have not yet been defined) accepting any number of arguments, as noted in a skipped test case.
Alternative solution may be to move some of the functionality of `visit_functiondef` into `_set_functiondef_environment`?