### PR TITLE
typecheck: Creating TypeFailAnnotationInvalid for annotations that are not types

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -135,9 +135,10 @@ class TypeFailLookup(TypeFail):
         return f'TypeFail: Invalid attribute lookup {self.src_node.as_string()}'
 
 
-class TypeFailAnnotation(TypeFail):
+class TypeFailAnnotationUnify(TypeFail):
     """
-    TypeFailAnnotation occurs when the inferred type contradicts the annotated type.
+    TypeFailAnnotationUnify occurs when a contradiction occurs during the unification of the inferred type
+    and the annotated type.
 
     :param tnode: _TNode of expected type
     :param src_node: astroid node where error occurs
@@ -154,6 +155,20 @@ class TypeFailAnnotation(TypeFail):
         string += f'{self.tnode.parent.type.__name__}' if self.tnode.parent else f'{self.tnode.type.__name__}'
         string += f' at {self.ann_node.as_string()}'
         return string
+
+
+class TypeFailAnnotationInvalid(TypeFail):
+    """
+    TypeFailAnnotationInvalid occurs when a variable is annotated as something other than a type
+
+    :param src_node: astroid node where annotation is set
+    """
+    def __init__(self, src_node: NodeNG) -> None:
+        self.src_node = src_node
+        super().__init__(str(self))
+
+    def __str__(self) -> str:
+        return f'TypeFail: Annotation must be a type'
 
 
 class TypeFailFunction(TypeFail):
@@ -635,7 +650,7 @@ class TypeConstraints:
                 for tn in [tnode1, tnode2]:
                     ann_t = tn.find_annotation()
                     if ann_t is not None:
-                        return TypeFailAnnotation(tn, ast_node, ann_t)
+                        return TypeFailAnnotationUnify(tn, ast_node, ann_t)
                 return TypeFailUnify(tnode1, tnode2, src_node=ast_node)
 
         # One type can be resolved
@@ -736,7 +751,7 @@ class TypeConstraints:
                 if param_annotations and param_annotations[i] is not None:
                     tvar = funcdef_node.type_environment.lookup_in_env(funcdef_node.args.args[i].name)
                     tnode = self.get_tnode(tvar)
-                    return TypeFailAnnotation(tnode, node, funcdef_node)
+                    return TypeFailAnnotationUnify(tnode, node, funcdef_node)
                 else:
                     results.append(i)
         if results:

--- a/tests/test_type_inference/test_function_annotation.py
+++ b/tests/test_type_inference/test_function_annotation.py
@@ -1,7 +1,7 @@
 import astroid
 from typing import Any, List, Tuple
 from nose.tools import eq_
-from python_ta.typecheck.base import TypeFailAnnotation
+from python_ta.typecheck.base import TypeFailAnnotationUnify
 import tests.custom_hypothesis_support as cs
 from tests.custom_hypothesis_support import lookup_type
 from nose import SkipTest
@@ -67,7 +67,7 @@ def test_call_wrong_type():
     eq_(lookup_type(ti, func_node, 'x'), int)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
-    assert isinstance(call_node.inf_type, TypeFailAnnotation)
+    assert isinstance(call_node.inf_type, TypeFailAnnotationUnify)
 
 
 def test_call_wrong_type_str():
@@ -83,7 +83,7 @@ def test_call_wrong_type_str():
     eq_(lookup_type(ti, func_node, 'x'), str)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
-    assert isinstance(call_node.inf_type, TypeFailAnnotation)
+    assert isinstance(call_node.inf_type, TypeFailAnnotationUnify)
 
 
 def test_call_multiple_annotation_wrong_type():
@@ -99,7 +99,7 @@ def test_call_multiple_annotation_wrong_type():
     eq_(lookup_type(ti, func_node, 'x'), int)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
-    assert isinstance(call_node.inf_type, TypeFailAnnotation)
+    assert isinstance(call_node.inf_type, TypeFailAnnotationUnify)
 
 
 def test_mixed_annotation():
@@ -133,7 +133,7 @@ def test_mixed_annotation_wrong():
     eq_(lookup_type(ti, func_node, 'y'), Any)
 
     call_node = next(ast_mod.nodes_of_class(astroid.Call))
-    assert isinstance(call_node.inf_type, TypeFailAnnotation)
+    assert isinstance(call_node.inf_type, TypeFailAnnotationUnify)
 
 
 def test_param_subscript_list():

--- a/tests/test_type_inference/test_typefail_reason.py
+++ b/tests/test_type_inference/test_typefail_reason.py
@@ -1,7 +1,7 @@
 import astroid
 import typing
 import tests.custom_hypothesis_support as cs
-from python_ta.typecheck.base import TypeFail, TypeFailUnify, TypeFailAnnotation, TypeFailFunction
+from python_ta.typecheck.base import TypeFail, TypeFailUnify, TypeFailAnnotationUnify, TypeFailFunction
 from nose.tools import eq_
 from nose import SkipTest
 
@@ -113,7 +113,7 @@ def test_annotation():
     """
     ast_mod, ti = cs._parse_text(src, reset=True)
     tf = find_type_fail(ast_mod).inf_type
-    assert isinstance(tf, TypeFailAnnotation)
+    assert isinstance(tf, TypeFailAnnotationUnify)
 
 
 def test_func_annotation():
@@ -126,7 +126,7 @@ def test_func_annotation():
     raise SkipTest("Requires modifications to unify_call")
     ast_mod, ti = cs._parse_text(src, reset=True)
     tf = find_type_fail(ast_mod).inf_type
-    assert isinstance(tf, TypeFailAnnotation)
+    assert isinstance(tf, TypeFailAnnotationUnify)
 
 
 def test_function():


### PR DESCRIPTION
Creating TypeFailAnnotationInvalid for invalid annotations that are not types.
Renaming TypeFailAnnotation to TypeFailAnnotationUnify to avoid confusion between two annotation type fails.
Modifying `_ann_node_to_type` to check if annotation is type or valid forward reference.
Modifying `visit_annassign` and `visit_arguments` to set `inf_type` as TypeFail if one occurs
Adding tests cases with invalid type annotations.