### PR TITLE
typecheck: Fixing crash caused by empty tuple

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -153,6 +153,8 @@ class TypeInferer:
         if node.ctx == astroid.Store:
             # Tuple is the target of an assignment; do not give it a type.
             node.inf_type = NoType()
+        elif not node.elts:
+            node.inf_type = TypeInfo(Tuple)
         else:
             node.inf_type = wrap_container(Tuple, *(e.inf_type for e in node.elts))
 

--- a/tests/test_type_inference/test_tuple.py
+++ b/tests/test_type_inference/test_tuple.py
@@ -12,8 +12,11 @@ def test_tuple(t_tuple):
     """ Test Tuple nodes representing a tuple of various types."""
     module, _ = cs._parse_text(t_tuple)
     for t_node in module.nodes_of_class(astroid.Tuple):
-        elt_types = tuple(elt.inf_type.getValue() for elt in t_node.elts)
-        assert t_node.inf_type.getValue() == Tuple[elt_types]
+        if t_node.elts:
+            elt_types = tuple(elt.inf_type.getValue() for elt in t_node.elts)
+            assert t_node.inf_type.getValue() == Tuple[elt_types]
+        else:
+            assert t_node.inf_type.getValue() == Tuple
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Changing `visit_tuple` to use `Tuple` on its own to represent an empty tuple, rather than the previous usage of `Tuple[()]`, which would cause crashes when the code attempted to parse the arguments of `Tuple[()]` as types