### PR TITLE
typecheck: Modifying name of user-created type variables

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -466,7 +466,7 @@ class TypeConstraints:
     # TODO: Rename to better distinguish between _TNodes and AST Nodes
     def fresh_tvar(self, node: Optional[NodeNG] = None) -> TypeVar:
         """Create and return a fresh type variable, associated with the given node."""
-        tvar = TypeVar(f'_T{self._count}')
+        tvar = TypeVar(f'_TV{self._count}')
         self._count += 1
         self._make_set(tvar, ast_node=node)
         return tvar

--- a/tests/test_type_constraints/test_tnode_structure.py
+++ b/tests/test_type_constraints/test_tnode_structure.py
@@ -56,7 +56,7 @@ def test_one_var():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{int, '~_T0'}]
+    expected_set = [{int, '~_TV0'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -68,7 +68,7 @@ def test_typefail():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{int, '~_T0'}, {str, '~_T1'}]
+    expected_set = [{int, '~_TV0'}, {str, '~_TV1'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -81,7 +81,7 @@ def test_multi_var_int():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{int, '~_T0', '~_T1', '~_T2', '~_T3'}]
+    expected_set = [{int, '~_TV0', '~_TV1', '~_TV2', '~_TV3'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -94,7 +94,7 @@ def test_multi_var():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{int, '~_T0'}, {'~_T1', str}, {'~_T2', bool}, {'~_T3', float}]
+    expected_set = [{int, '~_TV0'}, {'~_TV1', str}, {'~_TV2', bool}, {'~_TV3', float}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -108,7 +108,7 @@ def test_var_chain():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{int, '~_T0', '~_T1', '~_T2', '~_T3', '~_T4'}]
+    expected_set = [{int, '~_TV0', '~_TV1', '~_TV2', '~_TV3', '~_TV4'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -118,7 +118,7 @@ def test_list_int():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{'~_T0', 'typing.List[int]'}, {int}]
+    expected_set = [{'~_TV0', 'typing.List[int]'}, {int}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -128,7 +128,7 @@ def test_any_list():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{'~_T0', 'typing.List[typing.Any]'}, {int}, {str}]
+    expected_set = [{'~_TV0', 'typing.List[typing.Any]'}, {int}, {str}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -138,7 +138,7 @@ def test_tuple_int():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{'~_T0', 'typing.Tuple[int, int]'}]
+    expected_set = [{'~_TV0', 'typing.Tuple[int, int]'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -148,7 +148,7 @@ def test_tuple_int_str():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{'~_T0', 'typing.Tuple[int, str]'}]
+    expected_set = [{'~_TV0', 'typing.Tuple[int, str]'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -159,7 +159,7 @@ def test_elt():
     """
     ast_mod, ti = cs._parse_text(src)
     actual_set = tc_to_disjoint(ti.type_constraints)
-    expected_set = [{'~_T0', 'typing.List[~_T2]', 'typing.List[int]'}, {'~_T1', int, '~_T2'}]
+    expected_set = [{'~_TV0', 'typing.List[~_TV2]', 'typing.List[int]'}, {'~_TV1', int, '~_TV2'}]
     compare_list_sets(actual_set, expected_set)
 
 
@@ -173,7 +173,7 @@ def test_forward_ref(draw=False):
     assert tc.unify(_ForwardRef('A'), _ForwardRef('A')).getValue() == _ForwardRef('A')
     assert tc.unify(t0, _ForwardRef('A')).getValue() == _ForwardRef('A')
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', _ForwardRef('A')}, {_ForwardRef('B')}]
+    expected_set = [{'~_TV0', _ForwardRef('A')}, {_ForwardRef('B')}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -188,9 +188,9 @@ def test_polymorphic_callable(draw=False):
     tc.unify(t2, Callable[[t0], t0])
     tc.unify(t1, t2)
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', int},
-                    {'~_T1', '~_T2', 'typing.Callable[[int], int]',
-                     'typing.Callable[[~_T0], ~_T0]'}]
+    expected_set = [{'~_TV0', int},
+                    {'~_TV1', '~_TV2', 'typing.Callable[[int], int]',
+                     'typing.Callable[[~_TV0], ~_TV0]'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -205,9 +205,9 @@ def test_polymorphic_callable2(draw=False):
     tc.unify(t2, Callable[[int], t0])
     tc.unify(t1, t2)
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', int},
-                    {'~_T1', '~_T2', 'typing.Callable[[~_T0], int]',
-                     'typing.Callable[[int], ~_T0]'}]
+    expected_set = [{'~_TV0', int},
+                    {'~_TV1', '~_TV2', 'typing.Callable[[~_TV0], int]',
+                     'typing.Callable[[int], ~_TV0]'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -222,9 +222,9 @@ def test_polymorphic_callable3(draw=False):
     tc.unify(t2, t1)
     tc.unify(t2, Callable[[int], int])
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', int},
-                    {'~_T1', '~_T2', 'typing.Callable[[int], int]',
-                     'typing.Callable[[~_T0], ~_T0]'}]
+    expected_set = [{'~_TV0', int},
+                    {'~_TV1', '~_TV2', 'typing.Callable[[int], int]',
+                     'typing.Callable[[~_TV0], ~_TV0]'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -239,8 +239,8 @@ def test_polymorphic_callable4(draw=False):
     tc.unify(t2, t1)
     assert isinstance(tc.unify(t2, Callable[[int], str]), TypeFail)
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', int},
-                    {'~_T1', '~_T2', 'typing.Callable[[~_T0], ~_T0]'},
+    expected_set = [{'~_TV0', int},
+                    {'~_TV1', '~_TV2', 'typing.Callable[[~_TV0], ~_TV0]'},
                     {'typing.Callable[[int], str]'}, {str}]
     compare_list_sets(actual_set, expected_set)
     if draw:
@@ -253,10 +253,10 @@ def test_polymorphic_callable5(draw=False):
     tc.unify(Callable[[Callable[[int, t0], int], int], t0],
              Callable[[Callable[[int, int], int], int], t0])
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0', int},
-                    {'typing.Callable[[int, ~_T0], int]', 'typing.Callable[[int, int], int]'},
-                    {'typing.Callable[[typing.Callable[[int, ~_T0], int], int], ~_T0]',
-                     'typing.Callable[[typing.Callable[[int, int], int], int], ~_T0]'}]
+    expected_set = [{'~_TV0', int},
+                    {'typing.Callable[[int, ~_TV0], int]', 'typing.Callable[[int, int], int]'},
+                    {'typing.Callable[[typing.Callable[[int, ~_TV0], int], int], ~_TV0]',
+                     'typing.Callable[[typing.Callable[[int, int], int], int], ~_TV0]'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -268,7 +268,7 @@ def test_can_unify_callable(draw=False):
     assert not tc.can_unify(Callable[[t0, t0], int], Callable[[str, int], int])
     # make sure tc is unchanged
     actual_set = tc_to_disjoint(tc)
-    expected_set = [{'~_T0'}]
+    expected_set = [{'~_TV0'}]
     compare_list_sets(actual_set, expected_set)
     if draw:
         gen_graph_from_nodes(tc._nodes)
@@ -304,12 +304,12 @@ def test_userdefn_inheritance_simple(draw=False):
 
     actual_set = tc_to_disjoint(tc)
     expected_set = [
-        {'~_T0', Type[_ForwardRef('A')]},
-        {'~_T1', Type[_ForwardRef('B')]},
-        {'~_T2', Type[_ForwardRef('C')]},
-        {'~_T3', _ForwardRef('A')},
-        {'~_T4', _ForwardRef('B')},
-        {'~_T5', _ForwardRef('C')}
+        {'~_TV0', Type[_ForwardRef('A')]},
+        {'~_TV1', Type[_ForwardRef('B')]},
+        {'~_TV2', Type[_ForwardRef('C')]},
+        {'~_TV3', _ForwardRef('A')},
+        {'~_TV4', _ForwardRef('B')},
+        {'~_TV5', _ForwardRef('C')}
     ]
 
     # _TNodes should be unchanged after unification
@@ -357,8 +357,8 @@ def test_builtin_abst_inheritance(draw=False):
     ast_mod, ti = cs._parse_text(src, reset=True)
     tc = ti.type_constraints
     actual_set = tc_to_disjoint(tc)
-    assert {'~_T0', int} in actual_set
-    assert {'~_T1', float} in actual_set
+    assert {'~_TV0', int} in actual_set
+    assert {'~_TV1', float} in actual_set
     if draw:
         gen_graph_from_nodes(tc._nodes)
 


### PR DESCRIPTION
Changing name of type variables to better distinguish between the ones generated by the type inference checker, and the polymorphic type variables included in typeshed
Specifically, `get_poly_vars` would often inadvertently include `~_T1` and `~_T2` as polymorphic type variables when they were really just created very early 