### PR TITLE
typecheck: Checking that generic subscript value is index and not slice

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -543,7 +543,7 @@ class TypeInferer:
             except AttributeError:
                 value_gorg = None
 
-            if value_gorg == Type:
+            if value_gorg == Type and isinstance(node.slice, astroid.Index):
                 if isinstance(node.slice.value, astroid.Tuple):
                     node.inf_type = wrap_container(_node_to_type(node.value), *_node_to_type(node.slice.value))
                 else:

--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -4,7 +4,7 @@ from nose import SkipTest
 from hypothesis import given, settings, HealthCheck
 from typing import List
 import tests.custom_hypothesis_support as cs
-from python_ta.typecheck.base import TypeFail
+from python_ta.typecheck.base import TypeFail, TypeFailFunction
 from python_ta.transforms.type_inference_visitor import NoType
 settings.load_profile("pyta")
 
@@ -117,6 +117,15 @@ def test_inference_ext_slice():
     module, _ = cs._parse_text(program)
     subscript_node = list(module.nodes_of_class(astroid.Subscript))[1]
     assert subscript_node.inf_type.getValue() == int
+
+
+def test_subscript_slice():
+    program = '''
+        x = List[:]
+        '''
+    module, _ = cs._parse_text(program)
+    assign_node = next(module.nodes_of_class(astroid.Assign))
+    assert isinstance(assign_node.inf_type, TypeFailFunction)
 
 
 # TODO: this test needs to be converted, but will also fail


### PR DESCRIPTION
Prompted by crash when student code attempted:
```
for x in list[2:]:
    ...
```
Resulted in a crash on line 547 because `node.slice`  was an instance of `Slice` and not `Index`, and thus did not have a `value` attribute