### PR TITLE
typecheck: Adding support for subscript and attribute targets in visit_for

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -604,7 +604,13 @@ class TypeInferer:
         iter_type_result = self._handle_call(node, '__iter__', node.iter.inf_type)
         if isinstance(node.target, astroid.AssignName):
             target_inf_type = self.lookup_inf_type(node.target, node.target.name)
-        else:
+        elif isinstance(node.target, astroid.AssignAttr):
+            target_inf_type = self._lookup_attribute_type(node.target, node.target.expr.inf_type, node.target.attrname)
+        elif isinstance(node.target, astroid.Subscript):
+            target_inf_type = iter_type_result >> (
+                lambda t: self._handle_call(node.target, '__setitem__', node.target.value.inf_type,
+                                            node.target.slice.inf_type, t.__args__[0]))
+        elif isinstance(node.target, astroid.Tuple):
             target_inf_type = wrap_container(
                 Tuple, *[self.lookup_inf_type(subtarget, subtarget.name) for subtarget in node.target.elts])
         iter_type_result >> (

--- a/tests/test_type_inference/test_for.py
+++ b/tests/test_type_inference/test_for.py
@@ -6,6 +6,7 @@ from hypothesis import given, settings, assume,  HealthCheck
 from typing import Callable, Any, Tuple
 import tests.custom_hypothesis_support as cs
 from tests.custom_hypothesis_support import lookup_type
+from python_ta.typecheck.base import NoType
 settings.load_profile("pyta")
 
 
@@ -127,6 +128,34 @@ def test_for_dict():
             eq_(lookup_type(ti, assign_node, assign_node.name), str)
         elif assign_node.name == 'y' or assign_node.name == 'b':
             eq_(lookup_type(ti, assign_node, assign_node.name), int)
+
+
+def test_for_target_attr():
+    program = """
+    class A:
+        def __init__(self):
+            self.attr = 0
+
+    a = A()
+
+    for a.attr in range(5):
+        a.attr
+    """
+    module, ti = cs._parse_text(program)
+    for_node = next(module.nodes_of_class(astroid.For))
+    assert isinstance(for_node.inf_type, NoType)
+
+
+def test_for_target_subscript():
+    program = """
+    lst = [0, 1, 2]
+
+    for lst[0] in lst:
+        lst[0]
+    """
+    module, ti = cs._parse_text(program)
+    for_node = next(module.nodes_of_class(astroid.For))
+    assert isinstance(for_node.inf_type, NoType)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prompted by crashes when students attempted similar code
Although the test cases listed below are valid python code, it may be worth raising an error that this is not good practice