### PR TITLE
typecheck: Fix literal_substitute returning reference to original Callable

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -768,6 +768,10 @@ def literal_substitute(t: type, type_map: Dict[str, type]) -> type:
     """Make substitutions in t according to type_map, returning resulting type."""
     if isinstance(t, TypeVar) and t.__name__ in type_map:
         return type_map[t.__name__]
+    elif isinstance(t, TypeVar):
+        return TypeVar(t.__name__)
+    elif isinstance(t, _ForwardRef):
+        return _ForwardRef(literal_substitute(t.__forward_arg__, type_map))
     elif isinstance(t, TuplePlus):
         subbed_args = [literal_substitute(t1, type_map) for t1 in t.__constraints__]
         return TuplePlus('tup+', *subbed_args)

--- a/tests/test_type_inference/test_classdef.py
+++ b/tests/test_type_inference/test_classdef.py
@@ -44,7 +44,7 @@ def test_classdef_method_call():
     attribute_node = list(module.nodes_of_class(astroid.Attribute))[1]
     expected_rtype = attribute_node.parent.inf_type.getValue()
     actual_rtype = inferer.type_constraints.resolve(attribute_node.inf_type.getValue().__args__[-1]).getValue()
-    assert actual_rtype == expected_rtype
+    assert actual_rtype.__name__ == expected_rtype.__name__
 
 
 def test_classdef_method_call_annotated_concrete():


### PR DESCRIPTION
This ensures that `literal_substitute` returns a copy of the original Callable when no substitutions are made.