### PR TITLE
typecheck: Fix crash when an __init__ is declared without arguments

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -629,7 +629,7 @@ class TypeInferer:
                 inferred_return = return_node.inf_type
             else:
                 inferred_return = self.lookup_inf_type(node, 'return')
-        elif node.name == '__init__':
+        elif node.name == '__init__' and inferred_args:
             inferred_return = inferred_args[0]
         else:
             inferred_return = TypeInfo(type(None))


### PR DESCRIPTION
There is a checker that handles this case already, but our code was previously crashing due to an index error.