### PR TITLE
typecheck: Add support for imported names

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -737,7 +737,12 @@ class TypeConstraints:
         else:
             func_var_tnode = self.get_tnode(func_var)
             parent_tnode = self.find_parent(func_var_tnode)
-            func_type = parent_tnode.type
+            if not parent_tnode:
+                # Function type is unresolved, so create a new generic Callable type
+                func_type = create_Callable([self.fresh_tvar(node) for arg in arg_types], self.fresh_tvar(node))
+                self.unify(func_var, func_type)
+            else:
+               func_type = parent_tnode.type
 
         # Check that the number of parameters matches the number of arguments.
         if func_type.__origin__ is Union:

--- a/tests/test_type_inference/test_imports.py
+++ b/tests/test_type_inference/test_imports.py
@@ -1,0 +1,102 @@
+import astroid
+import tests.custom_hypothesis_support as cs
+from python_ta.typecheck.base import TypeVar, TypeFail
+
+
+def test_imported_module_attribute():
+    src = """
+    import mod
+    
+    y = mod.x
+    z = undefined_mod.x
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for assgn_node in ast_mod.nodes_of_class(astroid.Assign):
+        if assgn_node.targets[0].name == 'y':
+            y = ti.lookup_typevar(assgn_node, 'y')
+            assert isinstance(ti.type_constraints.resolve(y).getValue(), TypeVar)
+        if assgn_node.targets[0].name == 'z':
+            assert isinstance(assgn_node.inf_type, TypeFail)
+
+
+def test_from_import_variable():
+    src = """
+    from mod import x
+    
+    y = x
+    z = w
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for assgn_node in ast_mod.nodes_of_class(astroid.Assign):
+        if assgn_node.targets[0].name == 'y':
+            y = ti.lookup_typevar(assgn_node, 'y')
+            assert isinstance(ti.type_constraints.resolve(y).getValue(), TypeVar)
+        if assgn_node.targets[0].name == 'z':
+            assert isinstance(assgn_node.inf_type, TypeFail)
+
+
+def test_from_import_attribute():
+    src = """
+    from mod import cls
+    
+    y = cls.x1
+    z = undefined_cls.x2
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for assgn_node in ast_mod.nodes_of_class(astroid.Assign):
+        if assgn_node.targets[0].name == 'y':
+            y = ti.lookup_typevar(assgn_node, 'y')
+            assert isinstance(ti.type_constraints.resolve(y).getValue(), TypeVar)
+        if assgn_node.targets[0].name == 'z':
+            assert isinstance(assgn_node.inf_type, TypeFail)
+
+
+def test_imported_module_function():
+    src = """
+    import mod
+
+    mod.func1(0, 1)
+    undefined_mod.func2(0, 1)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        if call_node.func.attrname == 'func1':
+            assert isinstance(call_node.inf_type.getValue(), TypeVar)
+        if call_node.func.attrname == 'func2':
+            assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_from_import_function():
+    src = """
+    from mod import func
+
+    func(0, 1)
+    undefined_func(0, 1)
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for call_node in ast_mod.nodes_of_class(astroid.Call):
+        if call_node.func.name == 'func1':
+            assert isinstance(call_node.inf_type.getValue(), TypeVar)
+        if call_node.func.name == 'func2':
+            assert isinstance(call_node.inf_type, TypeFail)
+
+
+def test_imported_function_delayed_return_resolution():
+    src = """
+    from mod import func
+    
+    y = func(0, 1)
+    z = y + 3
+    w = func(1, 2)
+    u = func('abc', 'def')
+    """
+    ast_mod, ti = cs._parse_text(src, reset=True)
+    for assgn_node in ast_mod.nodes_of_class(astroid.Assign):
+        if assgn_node.targets[0].name == 'y':
+            y = ti.lookup_typevar(assgn_node, 'y')
+            assert ti.type_constraints.resolve(y).getValue() == int
+        if assgn_node.targets[0].name == 'w':
+            w = ti.lookup_typevar(assgn_node, 'w')
+            assert ti.type_constraints.resolve(w).getValue() == int
+        if assgn_node.targets[0].name == 'u':
+            assert isinstance(assgn_node.inf_type, TypeFail)


### PR DESCRIPTION
This is based on #532 (I'll rebase and fix the commit history as soon as it's merged) and is mainly tests (because #532 sort of handles the case automatically). 

Imported names are treated as unresolved `TypeVars`: that way we depend only on the current code file to infer anything about them.