### PR TITLE
typecheck: Implementing support for unifying compatible generics with different numbers of parameters

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -678,9 +678,14 @@ class TypeConstraints:
             else:
                 arg_inf_types.append(result)
 
+        if len(g1.__parameters__) > len(arg_inf_types):
+            for i in range(len(arg_inf_types), len(g1.__parameters__)):
+                arg_inf_types.append(TypeInfo(conc_tnode1.type.__args__[i]))
+
         unified_args = failable_collect(arg_inf_types)
 
         result = _wrap_generic_meta(g1, unified_args)
+
         if not isinstance(result, TypeFail):
             self.create_edges(tnode1, tnode2, ast_node)
         return result

--- a/tests/test_type_inference/test_dict.py
+++ b/tests/test_type_inference/test_dict.py
@@ -2,7 +2,9 @@ import astroid
 import nose
 from hypothesis import assume, given, settings, HealthCheck
 import tests.custom_hypothesis_support as cs
-from typing import Any, Dict
+from tests.custom_hypothesis_support import lookup_type
+from typing import Any, Dict, List
+from nose.tools import eq_
 settings.load_profile("pyta")
 
 
@@ -37,6 +39,16 @@ def test_heterogeneous_dict(node):
         assume(int not in val_types)
     module, _ = cs._parse_text(node)
     cs._verify_type_setting(module, astroid.Dict, Dict[Any, Any])
+
+
+def test_sorted_dict():
+    src = """
+    dict = {'B': 2, 'A': 1}
+    sorted_dict = sorted(dict)
+    """
+    module, ti = cs._parse_text(src)
+    assign_node = list(module.nodes_of_class(astroid.AssignName))[1]
+    eq_(lookup_type(ti, assign_node, assign_node.name), List[str])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prompted by crash caused by student code where student called `sorted()` on a Dict object. Type signature for `sorted()` is `Callable[[Iterable[~T]], List[~T]]`, and unifying `Dict` with `Iterable` caused a crash when attempting to create a `Dict` object with just one argument