### PR TITLE
typecheck: Generalizing str-based test in test_lambda

### DIFF
--- a/tests/test_type_inference/test_lambda.py
+++ b/tests/test_type_inference/test_lambda.py
@@ -60,7 +60,8 @@ def test_lambda_polymorphic_simple():
     """
     ast_mod, ti = cs._parse_text(src, reset=True)
     for lambda_node in ast_mod.nodes_of_class(astroid.Lambda):
-        assert str(lambda_node.inf_type.getValue()) == 'typing.Callable[[~_T0], ~_T0]'
+        x = ti.lookup_inf_type(lambda_node, 'x').getValue()
+        assert str(lambda_node.inf_type.getValue()) == f'typing.Callable[[{x}], {x}]'
     for var_node in ast_mod.nodes_of_class(astroid.AssignName):
         if var_node.name == 'y':
             y = ti.lookup_typevar(var_node, 'y')


### PR DESCRIPTION
Previous version of lambda test was specific to type variables that followed the `~_T` naming convention, however this was changed with #521 