### PR TITLE
typecheck: Adding support for unifying empty tuple with tuple of variables

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -697,7 +697,11 @@ class TypeConstraints:
 
         arg_inf_types = []
         for a1, a2 in zip(conc_tnode1.type.__args__, conc_tnode2.type.__args__):
-            result = self.unify(a1, a2, ast_node)
+            if a1 is () or a2 is ():
+                result = TypeInfo(())
+            else:
+                result = self.unify(a1, a2, ast_node)
+
             if isinstance(result, TypeFail):
                 arg_inf_types = [TypeFailUnify(tnode1, tnode2, src_node=ast_node)]
                 break

--- a/tests/test_type_inference/test_assign_tuple.py
+++ b/tests/test_type_inference/test_assign_tuple.py
@@ -2,8 +2,10 @@ import astroid
 from nose.tools import eq_
 from typing import TupleMeta
 import tests.custom_hypothesis_support as cs
+from tests.custom_hypothesis_support import lookup_type
 from python_ta.transforms.type_inference_visitor import NoType
 from python_ta.typecheck.base import TypeInfo, TypeFail
+from typing import Tuple
 
 
 def generate_tuple(length: int, t: type=None):
@@ -129,3 +131,17 @@ def test_tuple_attribute_variable():
     module, _ = cs._parse_text(program)
     for assign_node in module.nodes_of_class(astroid.Assign):
         assert not isinstance(assign_node.inf_type, TypeFail)
+
+
+def test_tuple_empty():
+    program = """
+    def f(x):
+        a = ()
+        b = (x,)
+        a = b
+    """
+    module, ti = cs._parse_text(program)
+    functiondef_node = next(module.nodes_of_class(astroid.FunctionDef))
+    eq_(lookup_type(ti, functiondef_node, 'a'), Tuple[()])
+    x_type = lookup_type(ti, functiondef_node, 'x')
+    eq_(lookup_type(ti, functiondef_node, 'b'), Tuple[x_type])


### PR DESCRIPTION
Prevents unification of type variable with empty tuple. Prompted by crashes when type variable is resolved as an empty tuple, which is then passed to a function that expects a type.
Still allows type variables to be unified with _type of_ empty tuple, ie. `Tuple[()]`