### PR TITLE
Implementing support for unifying Iterable with subclasses of Iterable

### DIFF
--- a/python_ta/typecheck/type_store.py
+++ b/python_ta/typecheck/type_store.py
@@ -108,7 +108,7 @@ class TypeStore:
         if hasattr(child, '__mro__') and ancestor in child.__mro__:
             return True
         elif hasattr(child, '__orig_bases__'):
-            for base in child.__orig_bases__[1:]:
+            for base in child.__orig_bases__:
                 if isinstance(base, GenericMeta) and isinstance(ancestor, GenericMeta) and \
                    issubclass(_gorg(base), _gorg(ancestor)) and \
                    all([self.type_constraints.can_unify(a1, a2) for a1, a2 in

--- a/tests/test_type_inference/test_dict.py
+++ b/tests/test_type_inference/test_dict.py
@@ -2,7 +2,9 @@ import astroid
 import nose
 from hypothesis import assume, given, settings, HealthCheck
 import tests.custom_hypothesis_support as cs
-from typing import Any, Dict
+from tests.custom_hypothesis_support import lookup_type
+from typing import Any, Dict, List
+from nose.tools import eq_
 settings.load_profile("pyta")
 
 
@@ -37,6 +39,16 @@ def test_heterogeneous_dict(node):
         assume(int not in val_types)
     module, _ = cs._parse_text(node)
     cs._verify_type_setting(module, astroid.Dict, Dict[Any, Any])
+
+
+def test_sorted_dict():
+    src = """
+    dict = {'B': 2, 'A': 1}
+    sorted_dict = sorted(dict)
+    """
+    module, ti = cs._parse_text(src)
+    assign_node = list(module.nodes_of_class(astroid.AssignName))[1]
+    eq_(lookup_type(ti, assign_node, assign_node.name), List[str])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Prompted by crash caused by student code where student called sorted() on a Dict object. Type signature for sorted() is Callable[[Iterable[~T]], List[~T]], and unifying Dict with Iterable caused a crash when attempting to create a Dict object with just one argument