### PR TITLE
typecheck: Updating failing test in test_subscript

### DIFF
--- a/tests/test_type_inference/test_subscript.py
+++ b/tests/test_type_inference/test_subscript.py
@@ -125,7 +125,7 @@ def test_subscript_slice():
         '''
     module, _ = cs._parse_text(program)
     assign_node = next(module.nodes_of_class(astroid.Assign))
-    assert isinstance(assign_node.inf_type, TypeFailFunction)
+    assert isinstance(assign_node.inf_type, TypeFail)
 
 
 # TODO: this test needs to be converted, but will also fail


### PR DESCRIPTION
Test case now fails due to `_handle_call` returning a `TypeFail` instance with a message set by `error_func`, instead of `TypeFailFunction`

Also, unsure what this test case is actually testing? `List` is a generic type