### PR TITLE
typecheck: Resolving type in error functions and checking for subscripts of type None

### DIFF
--- a/python_ta/transforms/type_inference_visitor.py
+++ b/python_ta/transforms/type_inference_visitor.py
@@ -635,7 +635,7 @@ class TypeInferer:
         func_type = self.type_store.lookup_method(function_name, *arg_inf_types, node=node)
 
         if isinstance(func_type, TypeFail) and error_func is not None:
-            return TypeFail(error_func(node))
+            return TypeFail(error_func(node, self.type_constraints))
         else:
             return self.type_constraints.unify_call(func_type, *arg_types, node=node)
 

--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -1,6 +1,6 @@
 from typing import *
 import astroid
-from python_ta.typecheck.base import _get_name, _gorg
+from python_ta.typecheck.base import _get_name, _gorg, TypeConstraints
 
 
 ###############################################################################
@@ -114,10 +114,10 @@ def binary_op_hints(op, args):
             return "Perhaps you wanted to cast the integer into a string or vice versa?"
 
 
-def binop_error_message(node: astroid.BinOp) -> str:
+def binop_error_message(node: astroid.BinOp, constraints: TypeConstraints) -> str:
     op_name = BINOP_TO_ENGLISH[node.op]
-    left_type = _get_name(node.left.inf_type.getValue())
-    right_type = _get_name(node.right.inf_type.getValue())
+    left_type = _get_name(constraints.resolve(node.left.inf_type).getValue())
+    right_type = _get_name(constraints.resolve(node.right.inf_type).getValue())
     hint = binary_op_hints(node.op, [left_type, right_type]) or ''
 
     return (
@@ -130,9 +130,9 @@ def binop_error_message(node: astroid.BinOp) -> str:
 ###############################################################################
 # UnaryOp message
 ###############################################################################
-def unaryop_error_message(node: astroid.UnaryOp) -> str:
+def unaryop_error_message(node: astroid.UnaryOp, constraints: TypeConstraints) -> str:
     op_name = UNARY_TO_ENGLISH[node.op]
-    operand = _get_name(node.operand.inf_type.getValue())
+    operand = _get_name(constraints.resolve(node.operand.inf_type).getValue())
 
     return (
         f'You cannot {op_name} {_correct_article(operand)}, {node.operand.as_string()}.'
@@ -142,21 +142,27 @@ def unaryop_error_message(node: astroid.UnaryOp) -> str:
 ###############################################################################
 # Subscript message
 ###############################################################################
-def subscript_error_message(node: astroid.Subscript) -> str:
+def subscript_error_message(node: astroid.Subscript, constraints: TypeConstraints) -> str:
     # Accessing an element of a List with an incompatible index type (non-integers)
-    if _gorg(node.value.inf_type.getValue()) is list:
+    subscript_concrete_type = constraints.resolve(node.value.inf_type).getValue()
+    if subscript_concrete_type is type(None):
+        return f'NoneType is not subscriptable.'
+    else:
+        subscript_gorg = _gorg(subscript_concrete_type)
+
+    if subscript_gorg is list:
         slice_type = _get_name(node.slice.inf_type.getValue())
         return f'You can only access elements of a list using an int. ' \
                f'You used {_correct_article(slice_type)}, {node.slice.value.as_string()}.'
-    elif _gorg(node.value.inf_type.getValue()) is tuple:
+    elif subscript_gorg is tuple:
         slice_type = _get_name(node.slice.inf_type.getValue())
         return f'You can only access elements of a tuple using an int. ' \
                f'You used {_correct_article(slice_type)}, {node.slice.value.as_string()}.'
-    elif _gorg(node.value.inf_type.getValue()) is dict:
+    elif subscript_gorg is dict:
         slice_type = _get_name(node.slice.inf_type.getValue())
         return f'You tried to access an element of this dictionary using ' \
                f'{_correct_article(slice_type)}, {node.slice.value.as_string()}, ' \
-               f'but the keys are of type {_get_name(node.value.inf_type.getValue().__args__[0])}.'
+               f'but the keys are of type {_get_name(subscript_concrete_type.__args__[0])}.'
 
 
 def _correct_article(noun : str) -> str:


### PR DESCRIPTION
Prompted by crashes when calling `subscript_error_message` while the subscript value `inf_type` is TypeVar or type(None)