### PR TITLE
typecheck: Checking that subscript_concrete_type is a Generic

### DIFF
--- a/python_ta/typecheck/errors.py
+++ b/python_ta/typecheck/errors.py
@@ -1,4 +1,5 @@
 from typing import *
+from typing import _GenericAlias
 import astroid
 from python_ta.typecheck.base import _get_name, _gorg, TypeConstraints
 
@@ -147,6 +148,9 @@ def subscript_error_message(node: astroid.Subscript, constraints: TypeConstraint
     subscript_concrete_type = constraints.resolve(node.value.inf_type).getValue()
     if subscript_concrete_type is type(None):
         return f'NoneType is not subscriptable.'
+
+    if not isinstance(subscript_concrete_type, _GenericAlias):
+        subscript_gorg = subscript_concrete_type
     else:
         subscript_gorg = _gorg(subscript_concrete_type)
 


### PR DESCRIPTION
Prompted by error caused by:
- Variable is annotated as `list` (not `List`)
- Elements of the variable are accessed
- `subscript_error_message`  is called
- `inf_type` of the subscript value is  found to be `list` (as opposed to `List`)
- Calling `_gorg()` on `list` raises an error