### PR TITLE
typecheck: Adding helper function to better handle annotations of collection types

### DIFF
--- a/tests/test_type_inference/test_annassign.py
+++ b/tests/test_type_inference/test_annassign.py
@@ -4,8 +4,8 @@ from hypothesis import given, settings, HealthCheck
 import tests.custom_hypothesis_support as cs
 from tests.custom_hypothesis_support import lookup_type
 import hypothesis.strategies as hs
-from python_ta.typecheck.base import _node_to_type, TypeFail, TypeFailAnnotationInvalid, TypeFailUnify, NoType
-from typing import List, Set, Dict, Any, Tuple
+from python_ta.typecheck.base import _node_to_type, TypeFail, TypeFailAnnotationInvalid, TypeFailUnify, NoType, _gorg
+from typing import List, Set, Dict, Any, Tuple, _GenericAlias
 from nose import SkipTest
 from nose.tools import eq_
 settings.load_profile("pyta")
@@ -42,7 +42,10 @@ def test_annassign(variables_annotations_dict):
     for node in module.nodes_of_class(astroid.AnnAssign):
         variable_type = lookup_type(inferer, node, node.target.name)
         annotated_type = variables_annotations_dict[node.target.name]
-        assert variable_type == annotated_type
+        if isinstance(variable_type, _GenericAlias):
+            assert _gorg(variable_type) == annotated_type
+        else:
+            assert variable_type == annotated_type
 
 
 def test_annassign_subscript_list():


### PR DESCRIPTION
Prompted by errors in student code where variables were annotated with class type instead of the generic representation (ie, `list` instead of `List[Any]`), resulting in later errors when the variable is treated as a List