### PR TITLE
typecheck: Recursively check for generic annotations without arguments

### DIFF
--- a/python_ta/typecheck/base.py
+++ b/python_ta/typecheck/base.py
@@ -930,6 +930,11 @@ def _ann_node_to_type(node: astroid.Name) -> TypeResult:
         # Attempted to create ForwardRef with invalid string
         return TypeFailAnnotationInvalid(node)
 
+    ann_type = _generic_to_annotation(ann_node_type, node)
+    return ann_type
+
+
+def _generic_to_annotation(ann_node_type: type, node: NodeNG) -> TypeResult:
     if (isinstance(ann_node_type, _GenericAlias) and
             ann_node_type is getattr(typing, getattr(ann_node_type, '_name', '') or '', None)):
         if ann_node_type == Dict:
@@ -939,6 +944,11 @@ def _ann_node_to_type(node: astroid.Name) -> TypeResult:
             ann_type = wrap_container(ann_node_type, Any)
         else:
             ann_type = wrap_container(ann_node_type, Any)
+    elif isinstance(ann_node_type, _GenericAlias):
+        parsed_args = []
+        for arg in ann_node_type.__args__:
+            _generic_to_annotation(arg, node) >> parsed_args.append
+        ann_type = wrap_container(ann_node_type, *parsed_args)
     else:
         try:
             _type_check(ann_node_type, '')

--- a/tests/test_type_inference/test_annassign.py
+++ b/tests/test_type_inference/test_annassign.py
@@ -5,7 +5,7 @@ import tests.custom_hypothesis_support as cs
 from tests.custom_hypothesis_support import lookup_type
 import hypothesis.strategies as hs
 from python_ta.typecheck.base import _node_to_type, TypeFail, TypeFailAnnotationInvalid, TypeFailUnify, NoType
-from typing import List, Set, Dict, Any, Tuple
+from typing import List, Set, Dict, Any, Tuple, Union
 from nose import SkipTest
 from nose.tools import eq_
 settings.load_profile("pyta")
@@ -241,6 +241,17 @@ def test_annotation_forward_ref_space():
     module, inferer = cs._parse_text(src, reset=True)
     for ann_node in module.nodes_of_class(astroid.AnnAssign):
         assert isinstance(ann_node.inf_type, TypeFailAnnotationInvalid)
+
+
+def test_annotation_union_list():
+    src = """
+    x: Union[List, int]
+    """
+    module, inferer = cs._parse_text(src, reset=True)
+    for ann_node in module.nodes_of_class(astroid.AnnAssign):
+        assert not isinstance(ann_node.inf_type, TypeFail)
+    x_type = lookup_type(inferer, module, 'x')
+    eq_(x_type, Union[List[Any], int])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Moving check for generic annotations without proper subscripts into helper functions, so that it can be called recursively
Prompted by crash caused when student annotated something as `Union[list, int]`

(`list` is currently not properly interpreted as `List[Any]`, this should be fixed by #548 )