### PR TITLE
Transform Arguments node to contain parentheses

### DIFF
--- a/python_ta/transforms/setendings.py
+++ b/python_ta/transforms/setendings.py
@@ -213,7 +213,7 @@ def init_register_ending_setters(source_code):
 
     # Ad hoc transformations
     ending_transformer.register_transform(astroid.Tuple, _set_start_from_first_child)
-    ending_transformer.register_transform(astroid.Arguments, fix_start_attributes)
+    ending_transformer.register_transform(astroid.Arguments, fix_arguments(source_code))
     ending_transformer.register_transform(astroid.Arguments, set_arguments)
     ending_transformer.register_transform(astroid.Slice, fix_slice(source_code))
 
@@ -286,6 +286,28 @@ def fix_slice(source_code):
         return node
 
     return _find_colon
+
+
+def fix_arguments(source_code):
+    """For an Arguments node"""
+    def _find(node):
+        if _get_last_child(node):
+            return fix_start_attributes(node)
+        # no children
+        line_i = node.parent.fromlineno - 1  # convert 1 to 0 index.
+        char_i = node.parent.col_offset
+        # left bracket if parent is FunctionDef, colon if Lambda
+        while char_i < len(source_code[line_i]) and source_code[line_i][char_i] != '(' \
+                and source_code[line_i][char_i] != ':':
+            if char_i == len(source_code[line_i]) - 1 or source_code[line_i][char_i] is '#':
+                char_i = 0
+                line_i += 1
+            else:
+                char_i += 1
+        node.fromlineno, node.col_offset = line_i + 1, char_i
+        node.end_lineno, node.end_col_offset = line_i + 1, char_i
+        return node
+    return _find
 
 
 def fix_start_attributes(node):
@@ -384,6 +406,7 @@ def set_arguments(node):
     else:  # node does not have children.
         # TODO: this should be replaced with the string parsing strategy
         node.end_lineno, node.end_col_offset = node.fromlineno, node.col_offset
+
     return node
 
 def _get_last_child(node):
@@ -597,7 +620,7 @@ def register_transforms(source_code, obj):
             lambda node: node.fromlineno is None or node.col_offset is None)
 
     # Ad hoc transformations
-    obj.register_transform(astroid.Arguments, fix_start_attributes)
+    obj.register_transform(astroid.Arguments, fix_start_attributes) #TODO: changed to fix_arguments?
     obj.register_transform(astroid.Arguments, set_arguments)
 
     for node_class in NODES_WITH_CHILDREN:

--- a/python_ta/transforms/setendings.py
+++ b/python_ta/transforms/setendings.py
@@ -169,6 +169,7 @@ def _is_arg_name(s, index, node):
 # Elements here are in the form
 # (node class, predicate for start | None, predicate for end | None)
 NODES_REQUIRING_SOURCE = [
+    (astroid.Arguments, _token_search('('), _token_search(')')),
     (astroid.AssignAttr, None, _is_attr_name),
     (astroid.AsyncFor, _keyword_search('async'), None),
     (astroid.AsyncWith, _keyword_search('async'), None),

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -5,7 +5,7 @@ Checks that `end_lineno` and `end_col_offset` node properties are set.
 import unittest
 from python_ta.transforms.setendings import *
 
-PATH = '../examples/ending_locations/'
+PATH = 'examples/ending_locations/'
 
 
 class TestEndingLocations(unittest.TestCase):

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -5,7 +5,7 @@ Checks that `end_lineno` and `end_col_offset` node properties are set.
 import unittest
 from python_ta.transforms.setendings import *
 
-PATH = 'examples/ending_locations/'
+PATH = '../examples/ending_locations/'
 
 
 class TestEndingLocations(unittest.TestCase):
@@ -45,10 +45,10 @@ class TestEndingLocations(unittest.TestCase):
         ]
         self.assertEqual(expected, props)
 
-    # def test_arguments(self):
-    #     expected = [(1, 2, 8, 30), (5, 5, 14, 14), (8, 8, 12, 12), (9, 9, 14, 18)]
-    #     module = self.get_file_as_module(PATH + 'arguments.py')
-    #     self.set_and_check(module, astroid.Arguments, expected)
+    def test_arguments(self):
+        expected = [(1, 2, 7, 31), (5, 5, 13, 15), (8, 8, 12, 12), (9, 9, 14, 18), (11, 11, 5, 49)]
+        module = self.get_file_as_module(PATH + 'arguments.py')
+        self.set_and_check(module, astroid.Arguments, expected)
 
     def test_assert(self):
         expected = [(1, 1, 0, 43), (2, 2, 0, 11)]

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -5,7 +5,7 @@ Checks that `end_lineno` and `end_col_offset` node properties are set.
 import unittest
 from python_ta.transforms.setendings import *
 
-PATH = '/examples/ending_locations/'
+PATH = '../examples/ending_locations/'
 
 
 class TestEndingLocations(unittest.TestCase):
@@ -47,7 +47,7 @@ class TestEndingLocations(unittest.TestCase):
 
     def test_arguments(self):
         expected = [(1, 2, 7, 31), (5, 5, 13, 15), (8, 8, 12, 12), (9, 9, 14, 18), (11, 11, 5, 49)]
-        module = self.get_file_as_module(PATH + 'arguments.py')
+        module = self.get_file_as_module(PATH + 'Arguments.py')
         self.set_and_check(module, astroid.Arguments, expected)
 
     def test_assert(self):

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -5,7 +5,7 @@ Checks that `end_lineno` and `end_col_offset` node properties are set.
 import unittest
 from python_ta.transforms.setendings import *
 
-PATH = '../examples/ending_locations/'
+PATH = '/examples/ending_locations/'
 
 
 class TestEndingLocations(unittest.TestCase):


### PR DESCRIPTION
This change with commit 2f4fc24 (Add custom renderer for R0913_too_many_arguments), you will see this:
<img width="671" alt="screen shot 2019-01-22 at 9 44 58 pm" src="https://user-images.githubusercontent.com/37294635/51579770-28ca9600-1e90-11e9-9e11-d6342c98dc65.png">
This change with commit 3381e6a (Adjust what gets highlighted), you will see this:
<img width="836" alt="screen shot 2019-01-22 at 9 48 21 pm" src="https://user-images.githubusercontent.com/37294635/51579824-5b748e80-1e90-11e9-8aa7-3f2fb4a18ebf.png">
