### PR TITLE
Fix empty Arguments node

### DIFF
--- a/python_ta/transforms/setendings.py
+++ b/python_ta/transforms/setendings.py
@@ -212,7 +212,7 @@ def init_register_ending_setters(source_code):
 
     # Ad hoc transformations
     ending_transformer.register_transform(astroid.Tuple, _set_start_from_first_child)
-    ending_transformer.register_transform(astroid.Arguments, fix_start_attributes)
+    ending_transformer.register_transform(astroid.Arguments, fix_arguments(source_code))
     ending_transformer.register_transform(astroid.Arguments, set_arguments)
     ending_transformer.register_transform(astroid.Slice, fix_slice(source_code))
 
@@ -286,6 +286,27 @@ def fix_slice(source_code):
 
     return _find_colon
 
+
+def fix_arguments(source_code):
+    """For an Arguments node"""
+    def _find(node):
+        if _get_last_child(node):
+            return fix_start_attributes(node)
+        # no children
+        line_i = node.parent.fromlineno - 1  # convert 1 to 0 index.
+        char_i = node.parent.col_offset
+        # left bracket if parent is FunctionDef, colon if Lambda
+        while char_i < len(source_code[line_i]) and source_code[line_i][char_i] != ')' \
+                and source_code[line_i][char_i] != ':':
+            if char_i == len(source_code[line_i]) - 1 or source_code[line_i][char_i] is '#':
+                char_i = 0
+                line_i += 1
+            else:
+                char_i += 1
+        node.fromlineno, node.col_offset = line_i + 1, char_i
+        node.end_lineno, node.end_col_offset = line_i + 1, char_i
+        return node
+    return _find
 
 def fix_start_attributes(node):
     """Some nodes don't always have the `col_offset` property set by Astroid:
@@ -596,7 +617,7 @@ def register_transforms(source_code, obj):
             lambda node: node.fromlineno is None or node.col_offset is None)
 
     # Ad hoc transformations
-    obj.register_transform(astroid.Arguments, fix_start_attributes)
+    obj.register_transform(astroid.Arguments, fix_arguments(source_code))
     obj.register_transform(astroid.Arguments, set_arguments)
 
     for node_class in NODES_WITH_CHILDREN:

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -45,10 +45,10 @@ class TestEndingLocations(unittest.TestCase):
         ]
         self.assertEqual(expected, props)
 
-    # def test_arguments(self):
-    #     expected = [(1, 2, 8, 30), (5, 5, 14, 14), (8, 8, 12, 12), (9, 9, 14, 18)]
-    #     module = self.get_file_as_module(PATH + 'arguments.py')
-    #     self.set_and_check(module, astroid.Arguments, expected)
+    def test_arguments(self):
+        expected = [(1, 2, 8, 30), (5, 5, 14, 14), (8, 8, 12, 12), (9, 9, 14, 18), (11, 11, 6, 21)]
+        module = self.get_file_as_module(PATH + 'arguments.py')
+        self.set_and_check(module, astroid.Arguments, expected)
 
     def test_assert(self):
         expected = [(1, 1, 0, 43), (2, 2, 0, 11)]


### PR DESCRIPTION
Addressed these 2 things
- if the parent is a `FunctionDef`, the Arguments node spans from the open parenthesis to the closing parenthesis, but not including either.
- if the parent is a `Lambda`, just set it to be the location of the colon after the `lambda` keyword