### PR TITLE
Missing nodes documentation

### DIFF
--- a/nodes/DictUnpack.py
+++ b/nodes/DictUnpack.py
@@ -1,0 +1,22 @@
+"""
+DictUnpack astroid node
+
+Represents the unpacking of dicts into dicts using PEP 448.
+
+Attributes:
+    *This node does not have any explicit attributes*
+
+Example:
+    - The double star (**) preceding the dictionary represents dictionary
+      unpacking for the nested dictionary. Here is the astroid AST representation
+      of them example:
+          - Dict(items=[[Const(value=1), Const(value=1)],
+                        [DictUnpack(), Dict(items=[[Const(value=2), Const(value=2)]]]]
+    - Note that 'DictUnpack()' node is the 'key' and the nested dictionary is
+      'value' in the [key, value] pair of the outermost Dict node.
+
+Type-checking:
+    - To be documented
+"""
+
+{1: 1, **{2: 2}}

--- a/nodes/FormattedValue.py
+++ b/nodes/FormattedValue.py
@@ -1,0 +1,34 @@
+"""
+FormattedValue astroid node
+
+Represents a single formatting field in an f-string (formatted string literal).
+
+Attributes:
+    - value  (Expr)
+        - The value to be formatted into the string.
+    - format_spec  (JoinedStr | None)
+        - The formatting to be applied to the value.
+
+Example 1:
+    * NOTE : The example below is of a FormattedValue Node "{name}" within
+             a JoinedStr Node "f'My name is {name}'".
+
+    - value       -> Name(name='name')
+    - format_spec -> None
+
+Example 2:
+    * NOTE : The example below is of a FormattedValue Node "{3.14159:.3}'" within
+                 a JoinedStr Node "f'{3.14159:.3}'".
+
+    - value       -> Const(value=3.14159)
+    - format_spec -> JoinedStr(values=[Const(value='.3')])
+
+Type-checking:
+    - To be documented
+"""
+
+# Example 1
+f'My name is {name}'
+
+# Example 2
+f'{3.14159:.3}'

--- a/nodes/JoinedStr.py
+++ b/nodes/JoinedStr.py
@@ -1,0 +1,28 @@
+"""
+JoinedStr astroid node
+
+Represents a list of string expressions to be joined in
+f-strings (formatted string literals).
+
+Attributes:
+    - values  ([FormattedValue | Const | None])
+        - The string expressions to be joined.
+
+Example 1:
+    - values -> [Const(value='hello world')]
+
+Example 2:
+    - values -> [Const(value='name '),
+                 FormattedValue(value=Name(name='name'), format_spec=None),
+                 Const(value=', age: '),
+                 FormattedValue(value=Name(name='age'), format_spec=None)]
+
+Type-checking:
+    - To be documented
+"""
+
+# Example 1
+F'hello world'
+
+# Example 2
+f'name: {name}, age: {age}'

--- a/sample_usage/TODO.md
+++ b/sample_usage/TODO.md
@@ -1,0 +1,17 @@
+## print_nodes.py
+
+### print_nodes function
+    
+    # To fix:
+    
+    AnnAssign Node:
+        An AttributeError is raised because the transformer did not add
+        'end_lineno' attribute to the AnnAssign node. In the current example
+        found in `nodes/AnnAssign.py`, only the last statement has the
+        'end_lineno' attribute added to it.
+    
+    DictUnpack Node:
+        An AttributeError is raised because the transformer did not augment this
+        node with the ending columns/line attribute. I tried adding this node to
+        the NODES_WITHOUT_CHILDREN variable in `setendings.py` but it only added
+        the incorrect column offset.


### PR DESCRIPTION
Added astroid node documentation for the missing nodes: `FormattedValue`, `JoinedStr`, `DictUnpack`. However I did not add documentation for the following nodes: `Print`, `Exec`, `Repr`, and `EmptyNode`.

`Print`, `Exec`, and `Repr` correspond to the Python 2 statements `print`, `exec`, `(backticks as an alias for the repr() function)` which are deprecated in Python 3. Support for Python 2 will only extend till 2020 and so having documentation for it would redundant. 

`EmptyNode` has no example or explicit use even in the astroid documentation thus I chose to omit it. 

Examples for the `FormattedValue` and `JoinedStr` classes work when printed out using the `print_nodes` function, however `DictUnpack` does not and it has been outlined in the Todo file.
