### PR TITLE
Added Check For Compare Node

### DIFF
--- a/python_ta/checkers/constant_test_checker.py
+++ b/python_ta/checkers/constant_test_checker.py
@@ -38,6 +38,8 @@ class UsingConstantTestChecker(BaseChecker):
             return self._check_all_constants(node.operand)
         elif isinstance(node, astroid.BoolOp):
             return all(self._check_all_constants(v) for v in node.values)
+        elif isinstance(node, astroid.Compare):
+            return all(self._check_all_constants(operand) for operand in node.get_children())
         else:
             return False
 


### PR DESCRIPTION
`if 10 > 3 > 5`.
In the above code, PyTA doesn't report `10 > 3 > 5` as a style/convention error. It is an error because it will always evaluate to True/False regardless of the program state thus potentially causing one or more blocks in the if construct to always be unreachable.