### PR TITLE
Remove redundant code

### DIFF
--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -26,7 +26,6 @@ class CFGVisitor:
 
     def visit_module(self, module: astroid.Module) -> None:
         self.cfg = ControlFlowGraph()
-        self._current_block = self.cfg.start
 
         for child in module.body:
             child.accept(self)


### PR DESCRIPTION
self._current_block = self.cfg.start is already included in self.cfg = ControlFlowGraph().