### PR TITLE
CFG Function Definition Visitor

### DIFF
--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -12,14 +12,16 @@ class CFGVisitor:
         The top of the stack corresponds to the end of the list.
         (compound statement [while], {'Break'/'Continue': CFGBlock to link to})
     """
-    cfg: ControlFlowGraph
+    cfgs: List[ControlFlowGraph]
+    _current_cfg: ControlFlowGraph
     _current_block: CFGBlock
     _control_boundaries: List[Tuple[NodeNG, Dict[str, CFGBlock]]]
 
     def __init__(self) -> None:
         super().__init__()
-        self.cfg = ControlFlowGraph()
-        self._current_block = self.cfg.start
+        self.cfgs = []
+        self._current_cfg = None
+        self._current_block = None
         self._control_boundaries = []
 
     def __getattr__(self, attr: str):
@@ -33,19 +35,42 @@ class CFGVisitor:
         self._current_block.add_statement(node)
 
     def visit_module(self, module: astroid.Module) -> None:
-        self.cfg = ControlFlowGraph()
-        self._current_block = self.cfg.start
+        self.cfgs.append(ControlFlowGraph())
+        self._current_cfg = self.cfgs[0]
+        self._current_block = self._current_cfg.start
 
         for child in module.body:
             child.accept(self)
-        self.cfg.link_or_merge(self._current_block, self.cfg.end)
+
+        self._current_cfg.link_or_merge(self._current_block, self._current_cfg.end)
+
+    def visit_functiondef(self, func: astroid.FunctionDef) -> None:
+        previous_cfg = self._current_cfg
+        previous_block = self._current_block
+        previous_block.add_statement(func)
+
+        self.cfgs.append(ControlFlowGraph())
+        self._current_cfg = self.cfgs[-1]
+
+        self._current_block = self._current_cfg.start
+        self._current_block.add_statement(func)
+
+        body_block = self._current_cfg.create_block(self._current_block)
+        self._current_block = body_block
+
+        for child in func.body:
+            child.accept(self)
+
+        self._current_cfg.link_or_merge(self._current_block, self._current_cfg.end)
+        self._current_block = previous_block
+        self._current_cfg = previous_cfg
 
     def visit_if(self, node: astroid.If) -> None:
         self._current_block.add_statement(node.test)
         old_curr = self._current_block
 
         # Handle "then" branch.
-        then_block = self.cfg.create_block(old_curr)
+        then_block = self._current_cfg.create_block(old_curr)
         self._current_block = then_block
         for child in node.body:
             child.accept(self)
@@ -55,15 +80,15 @@ class CFGVisitor:
         if node.orelse == []:
             end_else = old_curr
         else:
-            else_block = self.cfg.create_block(old_curr)
+            else_block = self._current_cfg.create_block(old_curr)
             self._current_block = else_block
             for child in node.orelse:
                 child.accept(self)
             end_else = self._current_block
 
-        after_if_block = self.cfg.create_block()
-        self.cfg.link_or_merge(end_if, after_if_block)
-        self.cfg.link_or_merge(end_else, after_if_block)
+        after_if_block = self._current_cfg.create_block()
+        self._current_cfg.link_or_merge(end_if, after_if_block)
+        self._current_cfg.link_or_merge(end_else, after_if_block)
 
         self._current_block = after_if_block
 
@@ -71,35 +96,35 @@ class CFGVisitor:
         old_curr = self._current_block
 
         # Handle "test" block
-        test_block = self.cfg.create_block()
+        test_block = self._current_cfg.create_block()
         test_block.add_statement(node.test)
-        self.cfg.link_or_merge(old_curr, test_block)
+        self._current_cfg.link_or_merge(old_curr, test_block)
 
-        after_while_block = self.cfg.create_block()
+        after_while_block = self._current_cfg.create_block()
 
         # step into while
         self._control_boundaries.append((node, {astroid.Break.__name__: after_while_block,
                                                 astroid.Continue.__name__: test_block}))
 
         # Handle "body" branch
-        body_block = self.cfg.create_block(test_block)
+        body_block = self._current_cfg.create_block(test_block)
         self._current_block = body_block
         for child in node.body:
             child.accept(self)
         end_body = self._current_block
-        self.cfg.link_or_merge(end_body, test_block)
+        self._current_cfg.link_or_merge(end_body, test_block)
 
         # step out of while
         self._control_boundaries.pop()
 
         # Handle "else" branch
-        else_block = self.cfg.create_block(test_block)
+        else_block = self._current_cfg.create_block(test_block)
         self._current_block = else_block
         for child in node.orelse:
             child.accept(self)
         end_else = self._current_block
 
-        self.cfg.link_or_merge(end_else, after_while_block)
+        self._current_cfg.link_or_merge(end_else, after_while_block)
         self._current_block = after_while_block
 
     def visit_break(self, node: astroid.Break) -> None:
@@ -112,10 +137,11 @@ class CFGVisitor:
         old_curr = self._current_block
         for boundary, exits in reversed(self._control_boundaries):
             if isinstance(boundary, astroid.While):
-                self.cfg.link(old_curr, exits[type(node).__name__])
+                self._current_cfg.link(old_curr, exits[type(node).__name__])
                 old_curr.add_statement(node)
                 break
         else:
             raise SyntaxError(f'\'{type(node).__name__}\' outside loop')
-        unreachable_block = self.cfg.create_block()
+        unreachable_block = self._current_cfg.create_block()
         self._current_block = unreachable_block
+

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -12,14 +12,14 @@ class CFGVisitor:
         The top of the stack corresponds to the end of the list.
         (compound statement [while], {'Break'/'Continue': CFGBlock to link to})
     """
-    cfgs: List[ControlFlowGraph]
+    cfgs: Dict[Union[astroid.FunctionDef, astroid.Module], ControlFlowGraph]
     _current_cfg: ControlFlowGraph
     _current_block: CFGBlock
     _control_boundaries: List[Tuple[NodeNG, Dict[str, CFGBlock]]]
 
     def __init__(self) -> None:
         super().__init__()
-        self.cfgs = []
+        self.cfgs = {}
         self._current_cfg = None
         self._current_block = None
         self._control_boundaries = []
@@ -35,8 +35,8 @@ class CFGVisitor:
         self._current_block.add_statement(node)
 
     def visit_module(self, module: astroid.Module) -> None:
-        self.cfgs.append(ControlFlowGraph())
-        self._current_cfg = self.cfgs[0]
+        self.cfgs[module] = ControlFlowGraph()
+        self._current_cfg = self.cfgs[module]
         self._current_block = self._current_cfg.start
 
         for child in module.body:
@@ -49,8 +49,8 @@ class CFGVisitor:
         previous_block = self._current_block
         previous_block.add_statement(func)
 
-        self.cfgs.append(ControlFlowGraph())
-        self._current_cfg = self.cfgs[-1]
+        self.cfgs[func] = ControlFlowGraph()
+        self._current_cfg = self.cfgs[func]
 
         self._current_block = self._current_cfg.start
         self._current_block.add_statement(func)

--- a/sample_usage/draw_cfg.py
+++ b/sample_usage/draw_cfg.py
@@ -41,7 +41,7 @@ def main(filepath: str) -> None:
     visitor = CFGVisitor()
     mod.accept(visitor)
 
-    display(visitor.cfg, filename)
+    display(visitor.cfgs[0], filename)
 
 
 if __name__ == '__main__':

--- a/sample_usage/draw_cfg.py
+++ b/sample_usage/draw_cfg.py
@@ -41,7 +41,7 @@ def main(filepath: str) -> None:
     visitor = CFGVisitor()
     mod.accept(visitor)
 
-    display(visitor.cfgs[0], filename)
+    display(visitor.cfgs[mod], filename)
 
 
 if __name__ == '__main__':

--- a/tests/test_cfg/test_functions.py
+++ b/tests/test_cfg/test_functions.py
@@ -34,7 +34,7 @@ def test_simple_function() -> None:
     assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
-        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['x:int'],
         ['print(x + 1)'],
         []
     ]
@@ -60,7 +60,7 @@ def test_simple_function_with_surrounding_statements() -> None:
     assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
-        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['x:int'],
         ['print(x + 1)'],
         []
     ]
@@ -88,14 +88,14 @@ def test_multiple_simple_functions() -> None:
     assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_func = [
-        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['x:int'],
         ['print(x + 1)'],
         []
     ]
     assert expected_blocks_func == _extract_blocks(cfgs[keys[1]])
 
     expected_blocks_func2 = [
-        ['\ndef func2(y:int)->None:\n    print(y - 1)'],
+        ['y:int'],
         ['print(y - 1)'],
         []
     ]
@@ -123,8 +123,7 @@ def test_function_with_while() -> None:
     assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
-        ['\ndef func(x:int)->None:\n    while x > 10:\n        '
-         'print(x)\n    else:\n        print(j)'],
+        ['x:int'],
         ['x > 10'],
         ['print(x)'],
         ['print(j)'],

--- a/tests/test_cfg/test_functions.py
+++ b/tests/test_cfg/test_functions.py
@@ -1,9 +1,9 @@
-from typing import List, Tuple
+from typing import List, Tuple, Dict, Union
 import astroid
 from python_ta.cfg import CFGVisitor, ControlFlowGraph
 
 
-def build_cfgs(src: str) -> List[ControlFlowGraph]:
+def build_cfgs(src: str) -> Dict[Union[astroid.FunctionDef, astroid.Module], ControlFlowGraph]:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)
@@ -25,18 +25,20 @@ def test_simple_function() -> None:
     cfgs = build_cfgs(src)
     assert len(cfgs) == 2
 
+    keys = list(cfgs)
+
     expected_blocks_module = [
         ['\ndef func(x:int)->None:\n    print(x + 1)'],
         []
     ]
-    assert expected_blocks_module == _extract_blocks(cfgs[0])
+    assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
         ['\ndef func(x:int)->None:\n    print(x + 1)'],
         ['print(x + 1)'],
         []
     ]
-    assert expected_blocks_function == _extract_blocks(cfgs[1])
+    assert expected_blocks_function == _extract_blocks(cfgs[keys[1]])
 
 
 def test_simple_function_with_surrounding_statements() -> None:
@@ -49,18 +51,20 @@ def test_simple_function_with_surrounding_statements() -> None:
     cfgs = build_cfgs(src)
     assert len(cfgs) == 2
 
+    keys = list(cfgs)
+
     expected_blocks_module = [
         ['x = 10', '\ndef func(x:int)->None:\n    print(x + 1)', 'print(x)'],
         []
     ]
-    assert expected_blocks_module == _extract_blocks(cfgs[0])
+    assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
         ['\ndef func(x:int)->None:\n    print(x + 1)'],
         ['print(x + 1)'],
         []
     ]
-    assert expected_blocks_function == _extract_blocks(cfgs[1])
+    assert expected_blocks_function == _extract_blocks(cfgs[keys[1]])
 
 
 def test_multiple_simple_functions() -> None:
@@ -74,26 +78,28 @@ def test_multiple_simple_functions() -> None:
     cfgs = build_cfgs(src)
     assert len(cfgs) == 3
 
+    keys = list(cfgs)
+
     expected_blocks_module = [
         ['\ndef func(x:int)->None:\n    print(x + 1)',
          '\ndef func2(y:int)->None:\n    print(y - 1)'],
         []
     ]
-    assert expected_blocks_module == _extract_blocks(cfgs[0])
+    assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_func = [
         ['\ndef func(x:int)->None:\n    print(x + 1)'],
         ['print(x + 1)'],
         []
     ]
-    assert expected_blocks_func == _extract_blocks(cfgs[1])
+    assert expected_blocks_func == _extract_blocks(cfgs[keys[1]])
 
     expected_blocks_func2 = [
         ['\ndef func2(y:int)->None:\n    print(y - 1)'],
         ['print(y - 1)'],
         []
     ]
-    assert expected_blocks_func2 == _extract_blocks(cfgs[2])
+    assert expected_blocks_func2 == _extract_blocks(cfgs[keys[2]])
 
 
 def test_function_with_while() -> None:
@@ -107,12 +113,14 @@ def test_function_with_while() -> None:
     cfgs = build_cfgs(src)
     assert len(cfgs) == 2
 
+    keys = list(cfgs)
+
     expected_blocks_module = [
         ['\ndef func(x:int)->None:\n    while x > 10:\n        '
          'print(x)\n    else:\n        print(j)'],
         []
     ]
-    assert expected_blocks_module == _extract_blocks(cfgs[0])
+    assert expected_blocks_module == _extract_blocks(cfgs[keys[0]])
 
     expected_blocks_function = [
         ['\ndef func(x:int)->None:\n    while x > 10:\n        '
@@ -122,4 +130,4 @@ def test_function_with_while() -> None:
         ['print(j)'],
         []
     ]
-    assert expected_blocks_function == _extract_blocks(cfgs[1])
+    assert expected_blocks_function == _extract_blocks(cfgs[keys[1]])

--- a/tests/test_cfg/test_functions.py
+++ b/tests/test_cfg/test_functions.py
@@ -3,7 +3,7 @@ import astroid
 from python_ta.cfg import CFGVisitor, ControlFlowGraph
 
 
-def build_cfgs(src: str) -> ControlFlowGraph:
+def build_cfgs(src: str) -> List[ControlFlowGraph]:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)

--- a/tests/test_cfg/test_functions.py
+++ b/tests/test_cfg/test_functions.py
@@ -1,0 +1,125 @@
+from typing import List, Tuple
+import astroid
+from python_ta.cfg import CFGVisitor, ControlFlowGraph
+
+
+def build_cfgs(src: str) -> ControlFlowGraph:
+    mod = astroid.parse(src)
+    t = CFGVisitor()
+    mod.accept(t)
+    return t.cfgs
+
+
+def _extract_blocks(cfg: ControlFlowGraph) -> List[List[str]]:
+    return [
+        [s.as_string() for s in block.statements]
+        for block in cfg.get_blocks()
+    ]
+
+
+def test_simple_function() -> None:
+    src = """
+    def func(x: int) -> None:
+        print(x + 1)
+    """
+    cfgs = build_cfgs(src)
+    assert len(cfgs) == 2
+
+    expected_blocks_module = [
+        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        []
+    ]
+    assert expected_blocks_module == _extract_blocks(cfgs[0])
+
+    expected_blocks_function = [
+        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['print(x + 1)'],
+        []
+    ]
+    assert expected_blocks_function == _extract_blocks(cfgs[1])
+
+
+def test_simple_function_with_surrounding_statements() -> None:
+    src = """
+    x = 10
+    def func(x: int) -> None:
+        print(x + 1)
+    print(x)
+    """
+    cfgs = build_cfgs(src)
+    assert len(cfgs) == 2
+
+    expected_blocks_module = [
+        ['x = 10', '\ndef func(x:int)->None:\n    print(x + 1)', 'print(x)'],
+        []
+    ]
+    assert expected_blocks_module == _extract_blocks(cfgs[0])
+
+    expected_blocks_function = [
+        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['print(x + 1)'],
+        []
+    ]
+    assert expected_blocks_function == _extract_blocks(cfgs[1])
+
+
+def test_multiple_simple_functions() -> None:
+    src = """
+    def func(x: int) -> None:
+        print(x + 1)
+    
+    def func2(y: int) -> None:
+        print(y - 1)
+    """
+    cfgs = build_cfgs(src)
+    assert len(cfgs) == 3
+
+    expected_blocks_module = [
+        ['\ndef func(x:int)->None:\n    print(x + 1)',
+         '\ndef func2(y:int)->None:\n    print(y - 1)'],
+        []
+    ]
+    assert expected_blocks_module == _extract_blocks(cfgs[0])
+
+    expected_blocks_func = [
+        ['\ndef func(x:int)->None:\n    print(x + 1)'],
+        ['print(x + 1)'],
+        []
+    ]
+    assert expected_blocks_func == _extract_blocks(cfgs[1])
+
+    expected_blocks_func2 = [
+        ['\ndef func2(y:int)->None:\n    print(y - 1)'],
+        ['print(y - 1)'],
+        []
+    ]
+    assert expected_blocks_func2 == _extract_blocks(cfgs[2])
+
+
+def test_function_with_while() -> None:
+    src = """
+    def func(x: int) -> None:
+        while x > 10:
+            print(x)
+        else:
+            print(j)
+    """
+    cfgs = build_cfgs(src)
+    assert len(cfgs) == 2
+
+    expected_blocks_module = [
+        ['\ndef func(x:int)->None:\n    while x > 10:\n        '
+         'print(x)\n    else:\n        print(j)'],
+        []
+    ]
+    assert expected_blocks_module == _extract_blocks(cfgs[0])
+
+    expected_blocks_function = [
+        ['\ndef func(x:int)->None:\n    while x > 10:\n        '
+         'print(x)\n    else:\n        print(j)'],
+        ['x > 10'],
+        ['print(x)'],
+        ['print(j)'],
+        []
+    ]
+    assert expected_blocks_function == _extract_blocks(cfgs[1])

--- a/tests/test_cfg/test_if.py
+++ b/tests/test_cfg/test_if.py
@@ -7,7 +7,7 @@ def build_cfg(src: str) -> ControlFlowGraph:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)
-    return t.cfg
+    return t.cfgs[0]
 
 
 def _extract_blocks(cfg: ControlFlowGraph) -> List[List[str]]:

--- a/tests/test_cfg/test_if.py
+++ b/tests/test_cfg/test_if.py
@@ -7,7 +7,8 @@ def build_cfg(src: str) -> ControlFlowGraph:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)
-    return t.cfgs[0]
+
+    return t.cfgs[mod]
 
 
 def _extract_blocks(cfg: ControlFlowGraph) -> List[List[str]]:

--- a/tests/test_cfg/test_while.py
+++ b/tests/test_cfg/test_while.py
@@ -7,7 +7,7 @@ def build_cfg(src: str) -> ControlFlowGraph:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)
-    return t.cfgs[0]
+    return t.cfgs[mod]
 
 
 def _extract_blocks(cfg: ControlFlowGraph) -> List[List[str]]:

--- a/tests/test_cfg/test_while.py
+++ b/tests/test_cfg/test_while.py
@@ -7,7 +7,7 @@ def build_cfg(src: str) -> ControlFlowGraph:
     mod = astroid.parse(src)
     t = CFGVisitor()
     mod.accept(t)
-    return t.cfg
+    return t.cfgs[0]
 
 
 def _extract_blocks(cfg: ControlFlowGraph) -> List[List[str]]:


### PR DESCRIPTION
Note: This visitor does not handle function calls only function definitions. 

Functions (or Methods) by themselves are essentially mini-programs, and because of that, I decided to create a control flow graph for each individual function (or method). Conventionally, a control flow graph is built from the `main` function of the program which results in a huge control flow graph that encapsulates all the functions used in the program. I have opted against that implementation because of the following reasons:

1. A program can include code from multiple source files but `pyta` only checks individual source files. 
2. A lot of source files (based on  CSC148) primarily have class definitions that are used in other files, and as a result, don't have a `main` function.