### PR TITLE
Adding Flags to CFG Blocks

### DIFF
--- a/python_ta/cfg/graph.py
+++ b/python_ta/cfg/graph.py
@@ -145,5 +145,3 @@ class CFGEdge:
 class Flag(enum.Enum):
     LOOP_START = 'LOOP_START'
     LOOP_END = 'LOOP_END'
-    IF_START = 'IF_START'
-    IF_END = 'IF_END'

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -78,7 +78,7 @@ class CFGVisitor:
 
     def visit_if(self, node: astroid.If) -> None:
         self._current_block.add_statement(node.test)
-        self._current_block.add_flag(Flag.IF_START)
+        self._current_block.add_flag()
         old_curr = self._current_block
 
         # Handle "then" branch.
@@ -98,7 +98,7 @@ class CFGVisitor:
                 child.accept(self)
             end_else = self._current_block
 
-        after_if_block = self._current_cfg.create_block(flag=Flag.IF_END)
+        after_if_block = self._current_cfg.create_block()
         self._current_cfg.link_or_merge(end_if, after_if_block)
         self._current_cfg.link_or_merge(end_else, after_if_block)
 

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -78,7 +78,6 @@ class CFGVisitor:
 
     def visit_if(self, node: astroid.If) -> None:
         self._current_block.add_statement(node.test)
-        self._current_block.add_flag()
         old_curr = self._current_block
 
         # Handle "then" branch.


### PR DESCRIPTION
While working on rewriting the checker for the [always_returning_checker](https://github.com/pyta-uoft/pyta/blob/master/python_ta/checkers/always_returning_checker.py) using the control flow graph implementation, I realized how complicated looking for the starting node of a for/while node could get.

Looking for the starting node (of a loop) without flags could go like this:

Check every block in the cfg to see if the last statement `s` has an ancestor that's a loop. If yes, check if `s` is a descendant of the test node of the loop. If yes, then you have the starting node. However, this is not enough since test nodes that are expanded (like `BoolOp` and potentially `If expressions`   ) would require further checks.

I find this to be unnecessarily complicated (nested loops would complicate things even further) and so decided to add flags to blocks indicating whether the block is a start/end of a loop. This will simplify checks we do specifically on loops. 

I opted for flagging blocks over having the `control_boundaries` attribute similar to the one in the `CFGVisitor` class because it would also help with data flow analysis. One example would be when performing unreachable code analysis, we would be able to identify the starting/ending node of branching statements (loops, if, try/catch) while traversing through the graph itself.