### PR TITLE
New checker: if-return-bool

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -180,7 +180,8 @@ def reset_linter(config=None, file_linted=None):
         'python_ta/checkers/structure_test_checker',
         'python_ta/checkers/type_annotation_checker',
         'python_ta/checkers/unnecessary_indexing_checker',
-        'python_ta/checkers/shadowing_in_comp_checker'
+        'python_ta/checkers/shadowing_in_comp_checker',
+        'python_ta/checkers/if_return_bool_checker'
         # 'python_ta/checkers/simplified_if_checker'
     ]
 

--- a/python_ta/checkers/if_return_bool_checker.py
+++ b/python_ta/checkers/if_return_bool_checker.py
@@ -12,9 +12,9 @@ class IfReturnBoolChecker(BaseChecker):
     # use dashes for connecting words in message symbol
     msgs = {'E9990': ('This can be simplified to something like `return {if-condition}`.',
                       'if_return_bool',
-                      'Reported if there is only one statment in an If statment that '
-                      'is a boolean return statement'),
-           }
+                      'Reported if there is only one statement in both `If` branches'
+                      ' that is a boolean return statement.'),
+            }
 
     # this is important so that your checker is executed before others
     priority = -1

--- a/python_ta/checkers/if_return_bool_checker.py
+++ b/python_ta/checkers/if_return_bool_checker.py
@@ -28,13 +28,11 @@ class IfReturnBoolChecker(BaseChecker):
         # should we require if body/orelse to have only one statement
         # any statment after return is unreachable anyways?
         for n in (node.body[0], node.orelse[0]):
-            if isinstance(n, astroid.Return) \
-                    and isinstance(n.value, astroid.Const) \
-                    and n.value.value in (True, False):
-                continue
-            break
-        else:
-            self.add_message('if_return_bool', node=node)
+            if not(isinstance(n, astroid.Return)
+                    and isinstance(n.value, astroid.Const)
+                    and n.value.value in (True, False)):
+                return
+        self.add_message('if_return_bool', node=node)
 
 
 def register(linter):

--- a/python_ta/checkers/if_return_bool_checker.py
+++ b/python_ta/checkers/if_return_bool_checker.py
@@ -1,0 +1,41 @@
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker
+from pylint.checkers.utils import check_messages
+
+
+class IfReturnBoolChecker(BaseChecker):
+
+    __implements__ = IAstroidChecker
+    # name is the same as file name but without _checker part
+    name = 'if_return_bool'
+    # use dashes for connecting words in message symbol
+    msgs = {'E9990': ('This can be simplified to something like `return {if-condition}`.',
+                      'if_return_bool',
+                      'Reported if there is only one statment in an If statment that '
+                      'is a boolean return statement'),
+           }
+
+    # this is important so that your checker is executed before others
+    priority = -1
+
+    # pass in message symbol as a parameter of check_messages
+    @check_messages('if_return_bool')
+    def visit_if(self, node: astroid.If):
+        if not isinstance(node.scope(), astroid.FunctionDef):
+            return
+
+        # should we require if body/orelse to have only one statement
+        # any statment after return is unreachable anyways?
+        for n in (node.body[0], node.orelse[0]):
+            if isinstance(n, astroid.Return) \
+                    and isinstance(n.value, astroid.Const) \
+                    and n.value.value in (True, False):
+                continue
+            break
+        else:
+            self.add_message('if_return_bool', node=node)
+
+
+def register(linter):
+    linter.register_checker(IfReturnBoolChecker(linter))


### PR DESCRIPTION
This PR presents a new checker that emits a message if there is only one statement `s` in both branches of an `If` such that `s` is a return statement with values either `True` or `False`.

The idea is that this:
```
if condition:
    return True
else:
    return False
```

can be simplified to:
`return condition`

Note that technically, the simplified statement does not function exactly like the previous block (ex: condition being an object instance). If the returned expression is treated specifically like a boolean then the simplification is justified. However, it is possible that the returned expression is treated something like `var = func_returning_bool()` and so the simplification can change the behavior of the program. I see this as the only problem with this particular check.