### PR TITLE
Redundant Assignment Checker

### DIFF
--- a/examples/redundant_assignment_example.py
+++ b/examples/redundant_assignment_example.py
@@ -1,0 +1,6 @@
+x = 0
+if x > 10:
+    x = 5
+else:
+    y = 5
+print(x + y)    # y might not be defined

--- a/examples/redundant_assignment_example.py
+++ b/examples/redundant_assignment_example.py
@@ -1,6 +1,8 @@
-x = 0
-if x > 10:
+x = 0   # redundant assignment
+y = 10
+if y > 10:
+    print(y)
     x = 5
 else:
-    y = 5
-print(x + y)    # y might not be defined
+    x = 10
+print(x)

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -180,7 +180,8 @@ def reset_linter(config=None, file_linted=None):
         'python_ta/checkers/structure_test_checker',
         'python_ta/checkers/type_annotation_checker',
         'python_ta/checkers/unnecessary_indexing_checker',
-        'python_ta/checkers/shadowing_in_comp_checker'
+        'python_ta/checkers/shadowing_in_comp_checker',
+        'python_ta/checkers/redundant_assignment_checker'
         # 'python_ta/checkers/simplified_if_checker'
     ]
 

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -83,7 +83,8 @@ class RedundantAssignmentChecker(BaseChecker):
         gen = out_facts.copy()
         kill = set()
         for statement in reversed(block.statements):
-            if isinstance(statement, astroid.Expr) and isinstance(statement.value, astroid.Call):
+            if isinstance(statement, astroid.Expr) and isinstance(statement.value, astroid.Call) and \
+                    isinstance(statement.value.func, astroid.Name):
                 for func in (scope.locals.get(statement.value.func.name) or []):
                     if isinstance(func, astroid.FunctionDef) and not gen.issubset(set(func.locals)):
                         kill = kill.union(gen)

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -89,6 +89,7 @@ class RedundantAssignmentChecker(BaseChecker):
                         self._redundant_assignment.add(node.parent)
                     elif node.parent in self._redundant_assignment:
                         self._redundant_assignment.remove(node.parent)
+
                     if node.name in kill:
                         kill.remove(node.name)
                     gen.add(node.name)

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -1,0 +1,114 @@
+"""checker for variables that might not be defined in the program.
+"""
+from typing import Union
+import astroid
+from pylint.interfaces import IAstroidChecker
+from pylint.checkers import BaseChecker, utils
+from pylint.checkers.utils import check_messages
+from python_ta.cfg.graph import CFGBlock, ControlFlowGraph
+from typing import Set
+
+
+class RedundantAssignmentChecker(BaseChecker):
+
+    __implements__ = IAstroidChecker
+    # name is the same as file name but without _checker part
+    name = 'redundant_assignment'
+    # use dashes for connecting words in message symbol
+    msgs = {'E9969': ('Description',
+                      'redundant-assignment',
+                      'Description'),
+           }
+
+    # this is important so that your checker is executed before others
+    priority = -1
+
+    def __init__(self, linter=None):
+        super().__init__(linter=linter)
+        self._redundant_assignment: Set[astroid.Assign] = set()
+
+    @check_messages('redundant-assignment')
+    def visit_assign(self, node):
+        """Adds message if there exists a path from the start block to node where
+        a variable used by node might not be defined."""
+        if node in self._redundant_assignment:
+            self.add_message('redundant-assignment', node=node)
+
+    def visit_module(self, node):
+        self._analyze(node)
+
+    def visit_functiondef(self, node):
+        self._analyze(node)
+
+    def _analyze(self, node: Union[astroid.Module, astroid.FunctionDef]) -> None:
+        """Runs the backward data flow algorithm on a `Module` or `Function` CFG, which in turn
+        appends `Assign` nodes to `self.redundant_assignment` if it is redundant.
+
+        Data flow algorithms retrieved from:
+        https://www.seas.harvard.edu/courses/cs252/2011sp/slides/Lec02-Dataflow.pdf#page=31
+        """
+        in_facts = {}
+        cfg = ControlFlowGraph()
+        cfg.start = node.cfg_block
+        blocks = list(cfg.get_blocks())
+        blocks.reverse()
+
+        all_assigns = self._get_assigns(node)
+        for block in blocks:
+            # out_facts[block] = all_assigns.copy()
+            in_facts[block] = {}
+
+        worklist = blocks
+        while len(worklist) != 0:
+            b = worklist.pop()
+            ins = [in_facts[p.target] for p in b.successors if p.target in in_facts]
+            if ins == []:
+                out_facts = set()
+            else:
+                out_facts = set.intersection(*ins)
+            temp = self._transfer(b, out_facts, all_assigns)
+            if temp != in_facts[b]:
+                in_facts[b] = temp
+                worklist.extend([pred.source for pred in b.predecssors])
+
+    def _transfer(self, block: CFGBlock, out_facts: Set[str]) -> Set[str]:
+        gen = out_facts.copy()
+        kill = set()
+        for statement in reversed(block.statements):
+            if isinstance(statement, astroid.FunctionDef):
+                continue
+            for node in statement.nodes_of_class((astroid.AssignName, astroid.DelName, astroid.Name),
+                                              astroid.FunctionDef):
+                if isinstance(node, astroid.AssignName):
+                    if node.name in gen.difference(kill):
+                        self._redundant_assignment.add(node.parent)
+                        continue
+                    gen.add(node.name)
+                else:
+                    kill.add(node.name)
+        return gen.difference(kill)
+
+    def _get_assigns(self, node: Union[astroid.FunctionDef, astroid.Module]) -> Set[str]:
+        """Returns a set of all local and parameter variables that could be
+        defined in the program (either a function or module).
+
+        IF a variable 'v' is defined in a function and there is no global/nonlocal
+        statement applied to 'v' THEN 'v' is a local variable.
+
+        Note that `local variable` in the context of a module level analysis,
+        refers to global variables.
+        """
+        assigns = set()
+        kills = set()
+        for name, nodes in node.scope().locals.items():
+            if any(isinstance(elem, astroid.AssignName) for elem in nodes):
+                assigns.add(name)
+        for statement in node.nodes_of_class((astroid.Nonlocal, astroid.Global), astroid.FunctionDef):
+            for name in statement.names:
+                kills.add(name)
+
+        return assigns.difference(kills)
+
+
+def register(linter):
+    linter.register_checker(RedundantAssignmentChecker(linter))

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -78,7 +78,7 @@ class RedundantAssignmentChecker(BaseChecker):
             temp = self._transfer(b, in_facts)
             if temp != out_facts[b]:
                 out_facts[b] = temp
-                worklist.extend([pred.source for pred in b.predecessors])
+                worklist.extend([pred.source for pred in b.predecessors if pred.source.reachable])
 
     def _transfer(self, block: CFGBlock, out_facts: Set[str]) -> Set[str]:
         gen = out_facts.copy()

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -85,7 +85,7 @@ class RedundantAssignmentChecker(BaseChecker):
         kill = set()
         for statement in reversed(block.statements):
             if isinstance(statement, astroid.FunctionDef):
-                # `nodes_of_class` below does block looking for required nodes
+                # `nodes_of_class` below doesnt block looking for required nodes
                 # in function definitions, hence this case.
                 continue
             for node in statement.nodes_of_class((astroid.AssignName, astroid.DelName, astroid.Name,
@@ -99,6 +99,8 @@ class RedundantAssignmentChecker(BaseChecker):
 
                     kill.discard(node.name)
                     gen.add(node.name)
+                elif isinstance(node, (astroid.Nonlocal, astroid.Global)):
+                    kill.difference_update(set(node.names))
                 else:
                     kill.add(node.name)
 

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -1,9 +1,9 @@
-"""checker for variables that might not be defined in the program.
+"""checker for redundant assignment in the program.
 """
 from typing import Union
 import astroid
 from pylint.interfaces import IAstroidChecker
-from pylint.checkers import BaseChecker, utils
+from pylint.checkers import BaseChecker
 from pylint.checkers.utils import check_messages
 from python_ta.cfg.graph import CFGBlock, ControlFlowGraph
 from typing import Set

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -15,9 +15,11 @@ class RedundantAssignmentChecker(BaseChecker):
     # name is the same as file name but without _checker part
     name = 'redundant_assignment'
     # use dashes for connecting words in message symbol
-    msgs = {'E9959': ('Description',
+    msgs = {'E9959': ('This assignment statement is redundant;' \
+                      ' You can remove it from the program.',
                       'redundant-assignment',
-                      'Description'),
+                      'This assignment statement is redundant;' \
+                      ' You can remove it from the program.')
            }
 
     # this is important so that your checker is executed before others
@@ -90,8 +92,7 @@ class RedundantAssignmentChecker(BaseChecker):
                     elif node.parent in self._redundant_assignment:
                         self._redundant_assignment.remove(node.parent)
 
-                    if node.name in kill:
-                        kill.remove(node.name)
+                    kill.discard(node.name)
                     gen.add(node.name)
                 else:
                     kill.add(node.name)

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -56,6 +56,8 @@ class RedundantAssignmentChecker(BaseChecker):
         Data flow algorithms retrieved from:
         https://www.seas.harvard.edu/courses/cs252/2011sp/slides/Lec02-Dataflow.pdf#page=31
         """
+        # stores all the variables that will be re-defined before any usage at a
+        # particular program point.
         out_facts = {}
         cfg = ControlFlowGraph()
         cfg.start = node.cfg_block
@@ -87,7 +89,7 @@ class RedundantAssignmentChecker(BaseChecker):
             if isinstance(statement, astroid.Expr) and isinstance(statement.value, astroid.Call) and \
                     isinstance(statement.value.func, astroid.Name):
                 for func in (scope.locals.get(statement.value.func.name) or []):
-                    if isinstance(func, astroid.FunctionDef) and not gen.issubset(set(func.locals)):
+                    if isinstance(func, astroid.FunctionDef) and not set(func.locals).issubset(gen):
                         kill = kill.union(gen)
             for node in statement.nodes_of_class((astroid.AssignName, astroid.DelName, astroid.Name),
                                               astroid.FunctionDef):

--- a/tests/test_custom_checkers/test_redundant_assignment_checker.py
+++ b/tests/test_custom_checkers/test_redundant_assignment_checker.py
@@ -162,3 +162,20 @@ class TestRedundantAssignmentChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_module(mod)
         with self.assertNoMessages():
             self.checker.visit_assign(assign_x)
+
+    def test_no_message_scope(self):
+        src = """
+        x = 25
+        def func():
+            def func2():
+                print(x - 1)
+            func2()
+        x = 10
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+
+        self.checker.visit_module(mod)
+        with self.assertNoMessages():
+            self.checker.visit_assign(assign_x)

--- a/tests/test_custom_checkers/test_redundant_assignment_checker.py
+++ b/tests/test_custom_checkers/test_redundant_assignment_checker.py
@@ -1,0 +1,117 @@
+import pylint.testutils
+import astroid
+from python_ta.checkers.redundant_assignment_checker import RedundantAssignmentChecker
+from python_ta.cfg import CFGVisitor
+
+
+class TestRedundantAssignmentChecker(pylint.testutils.CheckerTestCase):
+    CHECKER_CLASS = RedundantAssignmentChecker
+
+    def setUp(self):
+        self.setup_method()
+
+    def test_no_messages_simple(self):
+        src = """
+        x = 10
+        print(x)
+        x = 10
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_1 = mod.nodes_of_class(astroid.Assign)
+
+        with self.assertNoMessages():
+            self.checker.visit_module(mod)
+            self.checker.visit_assign(assign_1)
+
+    def test_message_simple(self):
+        src = """
+        x = 10
+        x = 230
+        print(x)
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_1, _ = mod.nodes_of_class(astroid.Assign)
+
+        self.checker.visit_module(mod)
+        with self.assertAddsMessages(
+            pylint.testutils.Message(
+                msg_id='redundant-assignment',
+                node=assign_1,
+            ),
+        ):
+            self.checker.visit_assign(assign_1)
+
+    def test_message_if_stmt(self):
+        src = """
+        x = 10
+        y = 5
+        if y > 5:
+            x = 20
+        else:
+            x = 15
+        print(x)
+            
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+
+        self.checker.visit_module(mod)
+        with self.assertAddsMessages(
+            pylint.testutils.Message(
+                msg_id='redundant-assignment',
+                node=assign_x,
+            ),
+        ):
+            self.checker.visit_assign(assign_x)
+
+    def test_no_message_loop(self):
+        src = """
+        y = 5
+        while y > 5:
+            x = 10
+            print(x)
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        _, assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+        self.checker.visit_module(mod)
+        with self.assertNoMessages():
+            self.checker.visit_assign(assign_x)
+
+    def test_no_message_loop_(self):
+        src = """
+        y = 0
+        for x in range(1, 10):
+            x = 10
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        _, assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+        print(assign_x.as_string())
+
+        self.checker.visit_module(mod)
+        with self.assertNoMessages():
+            self.checker.visit_assign(assign_x)
+
+    def test_no_message_if_complex(self):
+        src = """
+        x = 10
+        y = 5
+        if y > 5:
+            x = 20
+        elif y > 50:
+            x = 15
+        else:
+            pass
+        print(x)
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+
+        self.checker.visit_module(mod)
+        with self.assertNoMessages():
+            self.checker.visit_assign(assign_x)

--- a/tests/test_custom_checkers/test_redundant_assignment_checker.py
+++ b/tests/test_custom_checkers/test_redundant_assignment_checker.py
@@ -203,3 +203,21 @@ class TestRedundantAssignmentChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_module(mod)
         with self.assertNoMessages():
             self.checker.visit_assign(assign_x)
+
+    def test_no_message_function_def(self):
+        src = """
+        x = 10
+        if False:
+            x = 20
+        else:
+            def func():
+                x = 1
+        print(x)
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        assign_x, *_ = mod.nodes_of_class(astroid.Assign)
+
+        self.checker.visit_module(mod)
+        with self.assertNoMessages():
+            self.checker.visit_assign(assign_x)

--- a/tests/test_custom_checkers/test_redundant_assignment_checker.py
+++ b/tests/test_custom_checkers/test_redundant_assignment_checker.py
@@ -186,24 +186,6 @@ class TestRedundantAssignmentChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_assign(assign_x)
 
-    def test_no_message_scope(self):
-        src = """
-        x = 25
-        def func():
-            def func2():
-                print(x - 1)
-            func2()
-        func()
-        x = 10
-        """
-        mod = astroid.parse(src)
-        mod.accept(CFGVisitor())
-        assign_x, *_ = mod.nodes_of_class(astroid.Assign)
-
-        self.checker.visit_module(mod)
-        with self.assertNoMessages():
-            self.checker.visit_assign(assign_x)
-
     def test_no_message_function_def(self):
         src = """
         x = 10


### PR DESCRIPTION
This checker reports an error if a `redundant` assignment statement is found in a python program.

For an assignment statement `s` of variable `v` to be `redundant`, it must satisfy the following properties:

> 1. Every path from `s` to `v`'s  first usage goes through at least one re-definition of `v`.

> 2. Removing the statement from the program does not affect the behavior of the program in any way.

An example:
```python
y = 10    # redundant assignment
y = 20
```

A more exciting example:
```python
t = 10    # redundant assignment
for t in range(1, 10):
    print(t)
    x = 5    # redundant assignment
else:
    x = 10
```

**Note**: only `local` assignment statements are covered in this check. This is because finding statements that satisfy property (2) is hard, however, for `local` assignments, property (1) implies property (2).