### PR TITLE
Removes duplicated messages for config file loading

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -92,6 +92,8 @@ def _check(module_name='', level='all', local_config='', output=None):
                 linter.check(file_py)  # Lint !
                 current_reporter.print_messages(level)
                 current_reporter.reset_messages()  # Clear lists for any next file.
+                print('[INFO] File: {} was checked using the configuration file: {}'.format(
+                    file_py, linter.config_file))
         current_reporter.output_blob()
         return current_reporter
     except Exception as e:
@@ -120,7 +122,6 @@ def _load_config(linter, config_location):
     linter.read_config_file(config_location)
     linter.config_file = config_location
     linter.load_config_file()
-    print('[INFO] Loaded configuration file: {}'.format(config_location))
 
 
 def reset_linter(config=None, file_linted=None):


### PR DESCRIPTION
Replaces that message with a message that indicated what file was linted with what config.
This new message is printed after the linting is done.

Before:
<img width="660" alt="Screen Shot 2020-01-12 at 1 43 27 PM" src="https://user-images.githubusercontent.com/34199090/72224045-e20ff900-3543-11ea-88e4-574b46ada1af.png">

After:
<img width="1322" alt="Screen Shot 2020-01-12 at 1 44 01 PM" src="https://user-images.githubusercontent.com/34199090/72224052-f05e1500-3543-11ea-9f75-f58bba322289.png">
