### PR TITLE
contracts: Some code cleanup.

### DIFF
--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -1,16 +1,15 @@
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional, Set
 import sys
 import typing
 import inspect
 import wrapt
 
 
-class InvalidAssertion(Exception):
-    """Exception raised when a Assertion is invalid
+def check_all_contracts(module_name: str = '__main__') -> None:
+    """Automatically check contracts for all functions and classes in the given module.
+
+    When called with no arguments, the current module's functions and classes are checked.
     """
-
-
-def check_all_contracts(module_name='__main__'):
     module = sys.modules[module_name]
 
     for name, value in inspect.getmembers(module):
@@ -22,137 +21,141 @@ def check_all_contracts(module_name='__main__'):
 
 @wrapt.decorator
 def check_contracts(wrapped, instance, args, kwargs):
-    if instance and inspect.isclass(instance):
-        # This is a class method, so there is no instance.
-        return check_function_contracts(wrapped, None, args, kwargs)
-    else:
-        return check_function_contracts(wrapped, instance, args, kwargs)
+    """A decorator for automatically checking preconditions and type contracts for a function."""
+    try:
+        if instance and inspect.isclass(instance):
+            # This is a class method, so there is no instance.
+            return _check_function_contracts(wrapped, None, args, kwargs)
+        else:
+            return _check_function_contracts(wrapped, instance, args, kwargs)
+    except AssertionError as e:
+        raise AssertionError(str(e)) from None
 
 
-def instance_method_wrapper(wrapped, rep_invariants=None):
+def add_class_invariants(klass: type) -> None:
+    """Modify the given class to check representation invariants and method contracts."""
+    if '__representation_invariants__' in klass.__dict__:
+        # This means the class has already been decorated
+        return
+
+    # Update representation invariants from this class' docstring and those of its superclasses.
+    rep_invariants = set()
+
+    # Iterate over all inherited classes except object
+    for cls in klass.__mro__[:-1]:
+        if '__representation_invariants__' in cls.__dict__:
+            rep_invariants = rep_invariants.union(cls.__representation_invariants__)
+        else:
+            rep_invariants.update(parse_assertions(cls.__doc__ or '', parse_token='Representation Invariant'))
+
+    setattr(klass, '__representation_invariants__', rep_invariants)
+
+    def new_setattr(self: klass, name: str, value: Any) -> None:
+        """Set the value of the given attribute on self to the given value.
+
+        Check representation invariants for this class when not within an instance method of the class.
+        """
+        super(klass, self).__setattr__(name, value)
+        curframe = inspect.currentframe()
+        callframe = inspect.getouterframes(curframe, 2)
+        frame_locals = callframe[1].frame.f_locals
+        if self is not frame_locals.get('self'):
+            # Only validating if the attribute is not being set in a instance/class method
+            init = getattr(klass, '__init__')
+            try:
+                _check_invariants(self, rep_invariants, init.__globals__)
+            except AssertionError as e:
+                raise AssertionError(str(e)) from None
+
+    for attr, value in klass.__dict__.items():
+        if inspect.isroutine(value):
+            if isinstance(value, (staticmethod, classmethod)):
+                # Don't check rep invariants for staticmethod and classmethod
+                setattr(klass, attr, check_contracts(value))
+            else:
+                setattr(klass, attr, _instance_method_wrapper(value, rep_invariants))
+
+    klass.__setattr__ = new_setattr
+
+
+def _check_function_contracts(wrapped, instance, args, kwargs):
+    params = wrapped.__code__.co_varnames[:wrapped.__code__.co_argcount]
+    annotations = typing.get_type_hints(wrapped)
+    args_with_self = (instance,) + args if instance else args
+
+    # Check function parameter types
+    for arg, param in zip(args_with_self, params):
+        if param in annotations:
+            assert check_type_annotation(annotations[param], arg),\
+                f'{wrapped.__name__} argument {repr(arg)} did not match type annotation for parameter "{param}: {annotations[param]}"'
+
+    # Check function preconditions
+    preconditions = parse_assertions(wrapped.__doc__ or '')
+    function_locals = dict(zip(params, args_with_self))
+    _check_assertions(wrapped, function_locals, preconditions)
+
+    # Check return type
+    r = wrapped(*args, **kwargs)
+    if 'return' in annotations:
+        return_type = annotations['return']
+        assert check_type_annotation(return_type, r),\
+            f'{wrapped.__name__} return value {r} does not match annotated return type {return_type.__name__}'
+
+    return r
+
+
+def _instance_method_wrapper(wrapped, rep_invariants=None):
     if rep_invariants is None:
         return check_contracts
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
-        r = check_function_contracts(wrapped, instance, args, kwargs)
-        init = getattr(instance, "__init__")
-        check_invariants(instance, rep_invariants, init.__globals__)
-        return r
+        init = getattr(instance, '__init__')
+        try:
+            r = _check_function_contracts(wrapped, instance, args, kwargs)
+            _check_invariants(instance, rep_invariants, init.__globals__)
+        except AssertionError as e:
+            raise AssertionError(str(e)) from None
+        else:
+            return r
 
     return wrapper(wrapped)
 
 
-def add_class_invariants(klass):
-    if "__representation_invariants__" in klass.__dict__:
-        # This means it has already been decorated
-        return
-
-    rep_invariants = set()
-
-    # Iterating over all inherited classes except Object
-    for cls in klass.__mro__[:-1]:
-        if "__representation_invariants__" in cls.__dict__:
-            rep_invariants = rep_invariants.union(
-                cls.__representation_invariants__)
-        else:
-            rep_invariants.update(parse_assertions(
-                cls.__doc__ or '', parse_token="Representation Invariant"))
-
-    setattr(klass, "__representation_invariants__", rep_invariants)
-
-    def new_setattr(self, name, value):
-        super_class = klass.__mro__[-1]
-        super_class.__setattr__(self, name, value)
-        curframe = inspect.currentframe()
-        callframe = inspect.getouterframes(curframe, 2)
-        frame_members = dict((name, member) for name,
-                             member in inspect.getmembers(callframe[1].frame))
-        frame_locals = frame_members['f_locals']
-        if self is not frame_locals.get('self'):
-            # Only validating if the attribute is not being set in a instance/class method
-            init = getattr(klass, "__init__")
-            check_invariants(self, rep_invariants, init.__globals__)
-
-    for attr in klass.__dict__:
-        value = klass.__dict__[attr]
-        if inspect.isroutine(value):
-            if isinstance(value, staticmethod) or isinstance(value, classmethod):
-                # Don't check rep invariants for staticmethod and classmethod
-                setattr(klass, attr, check_contracts(value))
-            else:
-                setattr(klass, attr, instance_method_wrapper(
-                    value, rep_invariants))
-
-    klass.__setattr__ = new_setattr
-
-
-def check_function_contracts(wrapped, instance, args, kwargs):
-    params = wrapped.__code__.co_varnames[:wrapped.__code__.co_argcount]
-    annotations = typing.get_type_hints(wrapped)
-
-    args_with_self = (instance,) + args if instance else args
-
-    for arg, param in zip(args_with_self, params):
-        if param in annotations:
-            assert check_type_annotation(annotations[param], arg),\
-                f'Argument {repr(arg)} did not match type annotation for parameter "{param}: {annotations[param]}"'
-
-    preconditions = parse_assertions(wrapped.__doc__ or '')
-
-    function_locals = dict(zip(params, args_with_self))
-    check_assertions(wrapped, function_locals, preconditions)
-
-    r = wrapped(*args, **kwargs)
-
-    if 'return' in annotations:
-        return_type = annotations['return']
-        assert check_type_annotation(return_type, r),\
-            f'Return value {r} does not match annotated return type {return_type.__name__}'
-    return r
-
-
-def check_invariants(instance, rep_invariants, global_scope):
-    """
-    Checks to see if the representation invariants for the instance are satisfied.
+def _check_invariants(instance, rep_invariants: Set[str], global_scope: dict) -> None:
+    """Check that the representation invariants for the instance are satisfied.
     """
     for invariant in rep_invariants:
         try:
-            check = eval(invariant, global_scope, {"self": instance})
+            check = eval(invariant, global_scope, {'self': instance})
         except:
-            # TODO: Decide what to do here, e.g. "Invalid invariant"
-            raise InvalidAssertion(
-                f'Error evaluating invariant: {invariant}')
+            print(f'[python_ta] Warning: could not evaluate invariant: {invariant}', file=sys.stderr)
         else:
             assert check,\
-                f'Invariant "{invariant}" violated.'
+                f'Representation invariant "{invariant}" violated.'
 
 
-def check_assertions(wrapped, function_locals, assertions):
-    """
-    Checks if the assertions are still satisfied.
+def _check_assertions(wrapped: Callable[..., Any], function_locals: dict, assertions: List[str]) -> None:
+    """Check that the given assertions are still satisfied.
     """
     for assertion in assertions:
         try:
             check = eval(assertion, wrapped.__globals__, function_locals)
         except:
-            # TODO: Decide what to do here, e.g. "Invalid assertion"
-            raise InvalidAssertion(
-                f'Error evaluating assertion: {assertion}')
+            print(f'[python_ta] Warning: could not evaluate invariant: {assertion}', file=sys.stderr)
         else:
             assert check,\
-                f'Assertion "{assertion}" violated for arguments {function_locals}'
+                f'{wrapped.__name__} precondition "{assertion}" violated for arguments {function_locals}.'
 
 
 def check_type_annotation(annotation: Optional[type], v: Any) -> bool:
-    """
-    Return whether v is compatible with the given type annotation.
+    """Return whether v is compatible with the given type annotation.
     """
     if annotation is None:
         return v is None
 
     # TODO: Use typing.get_origin and typing.get_args in Python 3.8
-    origin = getattr(annotation, '__origin__', None)\
+    origin = getattr(annotation, '__origin__', None)
 
     if origin is None:
         return isinstance(v, annotation)
@@ -166,8 +169,8 @@ def check_type_annotation(annotation: Optional[type], v: Any) -> bool:
             return True
 
 
-def parse_assertions(docstring: str, parse_token: str = "Precondition") -> List[str]:
-    """Return a list of preconditions/representation invariants parsed from the given docstring. 
+def parse_assertions(docstring: str, parse_token: str = 'Precondition') -> List[str]:
+    """Return a list of preconditions/representation invariants parsed from the given docstring.
     Uses parse_token to determine what to look for. parse_token defaults to Precondition.
 
     Currently only supports two forms:

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -52,7 +52,7 @@ def test_my_sum_list_int_argument() -> None:
 
 def test_my_sum_empty_list_argument() -> None:
     """Calling _my_sum with an empty list passes type check."""
-    _my_sum([1])
+    _my_sum([])
 
 
 def test_my_sum_list_mixed_argument() -> None:


### PR DESCRIPTION
Added some docstrings and type contracts to functions, and marked some
functions as private. Used error re-raising to hide private functions from
traceback when an assertion fails. Tweaked error messages.