### PR TITLE
E9994: fix bug with checker in nested comprehensions

### DIFF
--- a/examples/unnecessary_indexing_example.py
+++ b/examples/unnecessary_indexing_example.py
@@ -37,3 +37,59 @@ def sum_pairs(lst1: List[int], lst2: List[int]) -> int:
         s += lst1[i] * lst2[i]
 
     return s
+
+
+def nested_sum(items: List[List[int]]) -> int:
+    """Return a repeated sum of the items in the list."""
+    s = 0
+    for i in range(len(items)):  # Error on this line (i is highlighted).
+        s += sum([2 * x for x in items[i]])
+    return s
+
+
+def nested_comprehension(items: list) -> None:
+    """Illustrate this checker in a nested comprehension."""
+    for i in range(len(items)):  # Error on this line (i is highlighted).
+        print([[items[i] for _ in range(10)] for _ in [1, 2, 3]])
+
+
+def nested_comprehensions2(items: list) -> None:
+    """Illustrate this checker in a nested comprehension, where the
+    loop variable is unused."""
+
+    # NO error reported; j is initialized outside the loop.
+    j = 0
+    for _ in range(len(items)):
+        print([[items[j] for _ in range(10)] for _ in [1, 2, 3]])
+
+
+def nested_comprehensions3(items: list) -> None:
+    """Illustrate this checker in a nested comprehension,
+
+    where the index into the list is not defined."""
+    # NO error reported; j is undefined.
+    for _ in range(len(items)):
+        print([[items[j] for _ in range(10)] for _ in [1, 2, 3]])
+
+
+def nested_comprehensions4(items: list) -> None:
+    """Illustrate this checker in a nested comprehension,
+    where the index into the list is defined in an outer comprehension."""
+
+    # NO error reported; j is undefined.
+    for _ in range(len(items)):
+        print([[items[j] for _ in range(10)] for j in [1, 2, 3]])
+
+
+def loop_variable_reassigned(items: List[int]) -> int:
+    """Illustrate this checker on a loop where the loop variable is reassigned
+    in the loop body."""
+    s = 0
+
+    # NO error reported; the loop variable assignment i is unused,
+    # but is not redundant.
+    for i in range(len(items)):
+        i = 0
+        s += items[i]
+
+    return s


### PR DESCRIPTION
The following code snippet was raising an error:

```python
def nested_comprehension(items: list) -> None:
    """Illustrate this checker in a nested comprehension."""
    for i in range(len(items)):  # Error on this line (i is highlighted).
        print([[items[i] for _ in range(10)] for _ in [1, 2, 3]])
```

The reason seems to be the using the astroid `lookup` method doesn't correctly handle nested comprehensions, and instead jumps from a comprehension to the module scope when searching for an assignment node.

https://github.com/PyCQA/astroid/blob/46297774d1a0e57815500a50b2323ea906bd50da/astroid/scoped_nodes.py#L204-L208

So I changed this by rolling my own primitive `_scope_lookup`.