### PR TITLE
contracts: Fix bug when class overrides __len__.

### DIFF
--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -111,7 +111,7 @@ def add_class_invariants(klass: type) -> None:
 def _check_function_contracts(wrapped, instance, args, kwargs):
     params = wrapped.__code__.co_varnames[:wrapped.__code__.co_argcount]
     annotations = typing.get_type_hints(wrapped)
-    args_with_self = (instance,) + args if instance else args
+    args_with_self = args if instance is None else (instance,) + args
 
     # Check function parameter types
     for arg, param in zip(args_with_self, params):

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -285,5 +285,23 @@ def setup_module() -> None:
     check_all_contracts(__name__, decorate_main=False)
 
 
+class OverrideLen:
+    """A class that overrides its len method.
+    """
+    x: int
+
+    def __init__(self) -> None:
+        self.x = 1
+
+    def __len__(self) -> int:
+        return self.x
+
+
+def test_override_len_simple() -> None:
+    """Test that we can instantiate OverrideLen, which has a custom __len__ implementation.
+    """
+    OverrideLen()
+
+
 if __name__ == '__main__':
     pytest.main(['test_class_contracts.py'])


### PR DESCRIPTION
Previously we were implicitly converting a class instance into a boolean
in _check_function_contracts. This led to an infinite recursion error if
__len__ was overridden (and __bool__ was not), or if __bool__ was
overridden, because those methods would be decorated with contract
checking as well.

Fixed this by changing the implicit boolean conversion into an explicit
`instance is None` check.