### PR TITLE
Update node attributes and examples 1/3

### DIFF
--- a/nodes/ann_assign.py
+++ b/nodes/ann_assign.py
@@ -4,18 +4,23 @@ AnnAssign astroid node
 A node representing an annotated assignment statement.
 
 Attributes:
-    - annotation         (Node)
+    - annotation         (NodeNG)
         - A Name node representing the type of the variable.
-    - target        (Node)
+    - simple        (int)
+        - Whether target is a pure name or complex statement.
+    - target        (NodeNG)
         - An AssignName node representing the name of the variable being
         assigned to.
+    - value         (NodeNG)
+        - An node that is being assigned to the variables.
 
 Example:
-    - annotation   -> Name.str(name='str')
-    - target       -> AssignName.name(name='name')
+    - AnnAssign(simple=1,
+               target=AssignName(name='x'),
+               annotation=Name(name='int'),
+               value=Const(value=3))
 """
 
+
 class Student:
-    name: str
-    age: int
-    status: bool
+    x: int = 3    # This is the example

--- a/nodes/ann_assign.py
+++ b/nodes/ann_assign.py
@@ -4,23 +4,24 @@ AnnAssign astroid node
 A node representing an annotated assignment statement.
 
 Attributes:
-    - annotation         (NodeNG)
+    - annotation    (NodeNG)
         - A Name node representing the type of the variable.
     - simple        (int)
         - Whether target is a pure name or complex statement.
-    - target        (NodeNG)
+    - target        (Optional[NodeNG])
         - An AssignName node representing the name of the variable being
         assigned to.
-    - value         (NodeNG)
+    - value         (Optional[Expr])
         - An node that is being assigned to the variables.
 
 Example:
-    - AnnAssign(simple=1,
-               target=AssignName(name='x'),
-               annotation=Name(name='int'),
-               value=Const(value=3))
+    AnnAssign(
+        simple=1,
+        target=AssignName(name='x'),
+        annotation=Name(name='int'),
+        value=Const(value=3))
 """
 
 
 class Student:
-    x: int = 3    # This is the example
+    x: int = 3  # This is the example

--- a/nodes/arguments.py
+++ b/nodes/arguments.py
@@ -4,33 +4,71 @@ Arguments astroid node
 The arguments for a function.
 
 Attributes:
-    - args         (List[arg])
+    - annotations                 (List[NodeNG]])
+        - The type annotations of arguments that can be passed positionally.
+    - args                       (List[NodeNG])
         - A list of non-keyword argument names. If None, args is an empty list.
-    - defaults     (List[Node])
+    - defaults                  (List[NodeNG])
         - A list of default values for arguments that can be passed
           positionally. If None, defaults is an empty list.
-    - kwonlyargs   (List[arg])
-        - A list of keyword-only argument names. If None, kwonlyargs is an empty
-          list.
-    - kw_defaults  (List[arg])
+    - kw_defaults               (List[NodeNG])
         - A list of default values for keyword-only arguments. If None,
           kw_defaults is an empty list.
-    - vararg       (arg|None)
-        - A variable-length argument.
-    - kwarg        (arg|None)
-        - Single arg nodes and keyword only arguments.
+    - kwarg                     (str)
+        - The name of the variable length keyword arguments.
+    - kwargannotation           (NodeNG)
+        - The type annotation for the variable length keyword arguments.
+    - kwonlyargs                (List[AssignName])
+        - A list of keyword-only argument names. If None, kwonlyargs is an empty
+          list.
+    - kwonlyargs_annotations    (List[NodeNG])
+        - The type annotations of arguments that cannot be passed positionally.
+    - posonlyargs               (List[AssignName])
+        - The arguments that can only be passed positionally.
+    - posonlyargs_annotations   (List[NodeNG])
+        - The type annotations of arguments that can only be passed positionally.
+    - type_comment_args         (List[NodeNG])
+        - The type annotation, passed by a type comment, of each argument. None if not specified.
+    - type_comment_kwonlyargs   (List[NodeNG])
+        - The type annotation, passed by a type comment, of each keyword only argument. None if
+        not specified.
+    - type_comment_posonlyargs  (List[NodeNG])
+        - The type annotation, passed by a type comment, of each positional argument. None if not
+        specified.
+    - vararg                    (str)
+        - A variable-length argument's name.
+    - varargannotation          (NodeNG)
+        - The type annotation for the variable length arguments.
 
 Example:
-    - args         -> [arg(arg='a', annotation=Str(s='annotation')),arg(arg='b',
-                      annotation=None),arg(arg='c', annotation=None)]
-    - defaults     -> [Num(n=1),Num(n=2)]
-    - kwonlyargs   -> [arg(arg='e', annotation=None),arg(arg='f',
-                      annotation=None)]
-    - kw_defaults  -> [Num(n=3)]
-    - vararg       -> arg(arg='g', annotation=None)
-    - kwarg        -> arg(arg='g', annotation=None)
-    - defaults     -> [Num(n=1),Num(n=2)]
+    - Arguments(
+               vararg='d',
+               kwarg='g',
+               args=[
+                  AssignName(name='a'),
+                  AssignName(name='b'),
+                  AssignName(name='c')],
+               defaults=[Const(value=1), Const(value=2)],
+               kwonlyargs=[AssignName(name='e'), AssignName(name='f')],
+               posonlyargs=[],
+               posonlyargs_annotations=[],
+               kw_defaults=[None, Const(value=3)],
+               annotations=[
+                  Const(value='annotation'),
+                  None,
+                  None],
+               varargannotation=None,
+               kwargannotation=None,
+               kwonlyargs_annotations=[None, None],
+               type_comment_args=[
+                  None,
+                  None,
+                  None],
+               type_comment_kwonlyargs=[None, None],
+               type_comment_posonlyargs=[])
+
 """
+
 
 def f(a: 'annotation', b=1, c=2, *d, e, f=3, **g):
     pass

--- a/nodes/arguments.py
+++ b/nodes/arguments.py
@@ -4,68 +4,68 @@ Arguments astroid node
 The arguments for a function.
 
 Attributes:
-    - annotations                 (List[NodeNG]])
+    - annotations                 (list[NodeNG]])
         - The type annotations of arguments that can be passed positionally.
-    - args                       (List[NodeNG])
+    - args                       (list[AssignName])
         - A list of non-keyword argument names. If None, args is an empty list.
-    - defaults                  (List[NodeNG])
+    - defaults                  (list[NodeNG])
         - A list of default values for arguments that can be passed
           positionally. If None, defaults is an empty list.
-    - kw_defaults               (List[NodeNG])
+    - kw_defaults               (list[NodeNG])
         - A list of default values for keyword-only arguments. If None,
           kw_defaults is an empty list.
-    - kwarg                     (str)
+    - kwarg                     (Optional[str])
         - The name of the variable length keyword arguments.
     - kwargannotation           (NodeNG)
         - The type annotation for the variable length keyword arguments.
-    - kwonlyargs                (List[AssignName])
+    - kwonlyargs                (list[AssignName])
         - A list of keyword-only argument names. If None, kwonlyargs is an empty
           list.
-    - kwonlyargs_annotations    (List[NodeNG])
+    - kwonlyargs_annotations    (list[NodeNG])
         - The type annotations of arguments that cannot be passed positionally.
-    - posonlyargs               (List[AssignName])
+    - posonlyargs               (list[AssignName])
         - The arguments that can only be passed positionally.
-    - posonlyargs_annotations   (List[NodeNG])
+    - posonlyargs_annotations   (list[NodeNG])
         - The type annotations of arguments that can only be passed positionally.
-    - type_comment_args         (List[NodeNG])
+    - type_comment_args         (list[Optional[NodeNG]])
         - The type annotation, passed by a type comment, of each argument. None if not specified.
-    - type_comment_kwonlyargs   (List[NodeNG])
+    - type_comment_kwonlyargs   (list[Optional[NodeNG]])
         - The type annotation, passed by a type comment, of each keyword only argument. None if
         not specified.
-    - type_comment_posonlyargs  (List[NodeNG])
+    - type_comment_posonlyargs  (list[Optional[NodeNG]])
         - The type annotation, passed by a type comment, of each positional argument. None if not
         specified.
-    - vararg                    (str)
+    - vararg                    (Optional[str])
         - A variable-length argument's name.
     - varargannotation          (NodeNG)
         - The type annotation for the variable length arguments.
 
 Example:
-    - Arguments(
-               vararg='d',
-               kwarg='g',
-               args=[
-                  AssignName(name='a'),
-                  AssignName(name='b'),
-                  AssignName(name='c')],
-               defaults=[Const(value=1), Const(value=2)],
-               kwonlyargs=[AssignName(name='e'), AssignName(name='f')],
-               posonlyargs=[],
-               posonlyargs_annotations=[],
-               kw_defaults=[None, Const(value=3)],
-               annotations=[
-                  Const(value='annotation'),
-                  None,
-                  None],
-               varargannotation=None,
-               kwargannotation=None,
-               kwonlyargs_annotations=[None, None],
-               type_comment_args=[
-                  None,
-                  None,
-                  None],
-               type_comment_kwonlyargs=[None, None],
-               type_comment_posonlyargs=[])
+    Arguments(
+        vararg='d',
+        kwarg='g',
+        args=[
+            AssignName(name='a'),
+            AssignName(name='b'),
+            AssignName(name='c')],
+        defaults=[Const(value=1), Const(value=2)],
+        kwonlyargs=[AssignName(name='e'), AssignName(name='f')],
+        posonlyargs=[],
+        posonlyargs_annotations=[],
+        kw_defaults=[None, Const(value=3)],
+        annotations=[
+            Const(value='annotation'),
+            None,
+            None],
+        varargannotation=None,
+        kwargannotation=None,
+        kwonlyargs_annotations=[None, None],
+        type_comment_args=[
+            None,
+            None,
+            None],
+        type_comment_kwonlyargs=[None, None],
+        type_comment_posonlyargs=[])
 
 """
 

--- a/nodes/assert.py
+++ b/nodes/assert.py
@@ -4,17 +4,17 @@ Assert astroid node
 An assertion.
 
 Attributes:
-    - test  (Expr)
+    - fail  (NodeNG)
+        - A message that is shown when the assertion fails.
+    - test  (NodeNG)
         - This holds the condition, such as a Compare node, to be evaluated
           True or False
-    - fail  (Node | None)
-        - Usually a str; the message shown if condition is False. If None, only
-          AssertionError is shown.
 
 Example:
-    - test  -> Compare(left=Name(name='x'), ops=[['==', Const(value=0)]])
-    - fail  -> Const("x isn't 0!") # AssertionError and this message if condition is
-               False
+    - Assert(test=Compare(
+             left=Name(name='x'),
+             ops=[['==', Const(value=0)]]),
+             fail=Const(value='error'))
 """
 
-assert x == 0, "x isn't 0!"
+assert x == 0, 'error'

--- a/nodes/assert.py
+++ b/nodes/assert.py
@@ -4,17 +4,18 @@ Assert astroid node
 An assertion.
 
 Attributes:
-    - fail  (NodeNG)
+    - fail  (Optional[NodeNG])
         - A message that is shown when the assertion fails.
-    - test  (NodeNG)
+    - test  (Optional[Expr])
         - This holds the condition, such as a Compare node, to be evaluated
           True or False
 
 Example:
-    - Assert(test=Compare(
-             left=Name(name='x'),
-             ops=[['==', Const(value=0)]]),
-             fail=Const(value='error'))
+    Assert(
+        test=Compare(
+            left=Name(name='x'),
+            ops=[['==', Const(value=0)]]),
+        fail=Const(value='error'))
 """
 
 assert x == 0, 'error'

--- a/nodes/assign.py
+++ b/nodes/assign.py
@@ -4,28 +4,35 @@ Assign astroid node
 An assignment.
 
 Attributes:
-    - targets  (List[Name | Tuple[Name | Starred] | List[Name | Starred]])
-        - A list of nodes.
-    - value    (Node)
-        - A single node.
+    - targets  (List[NodeNG])
+        - A list of nodes being assigned to.
+    - value    (NodeNG)
+        - The value being assigned to the variables.
 
 Example 1:
-    - targets  -> [AssignName(id='x')]
-    - value    -> Const(n=3)
+    - Assign(
+           targets=[AssignName(name='x')],
+           value=Const(value=3))
 
 Example 2:
-    - targets  -> [AssignName(id='a'), AssignName(id='b')]
-    - value    -> Const(n=1)
-
+    - Assign(
+           targets=[AssignName(name='a'), AssignName(name='b')],
+           value=Const(value=1))
 Example 3:
-    - targets  -> [Tuple(elts=[AssignName(id='a'), AssignName(id='b'),
-                   ctx=Store()]
-    - value    -> Name(id='c')
+    - Assign(
+           targets=[Tuple(
+                 ctx=<Context.Store: 2>,
+                 elts=[AssignName(name='a'), AssignName(name='b')])],
+           value=Name(name='c'))
 
 Example 4:
-    - targets  -> [List(elts=[AssignName(name='a'),
-                   Starred(value=AssignName(name='b'), ctx=Store())]
-    - value    -> Name(id='d')
+    - Assign(
+           targets=[List(
+                 ctx=<Context.Store: 2>,
+                 elts=[AssignName(name='a'), Starred(
+                       ctx=<Context.Store: 2>,
+                       value=AssignName(name='b'))])],
+           value=Name(name='d'))
 
 Type-checking:
     - Single identifiers are associated with the type of the expression on the RHS of the =.

--- a/nodes/assign.py
+++ b/nodes/assign.py
@@ -4,43 +4,49 @@ Assign astroid node
 An assignment.
 
 Attributes:
-    - targets  (List[NodeNG])
+    - targets           (Optional[list[NodeNG]])
         - A list of nodes being assigned to.
-    - value    (NodeNG)
+    - type_annotation   (Optional[NodeNG])
+        - If present, this will contain the type annotation passed by a type comment.
+    - value             (Optional[Expr])
         - The value being assigned to the variables.
 
 Example 1:
-    - Assign(
-           targets=[AssignName(name='x')],
-           value=Const(value=3))
+    Assign(
+        targets=[AssignName(name='x')],
+        value=Const(value=3))
 
 Example 2:
-    - Assign(
-           targets=[AssignName(name='a'), AssignName(name='b')],
-           value=Const(value=1))
+    Assign(
+        targets=[
+            AssignName(name='a'),
+            AssignName(name='b')],
+        value=Const(value=1))
+
 Example 3:
-    - Assign(
-           targets=[Tuple(
-                 ctx=<Context.Store: 2>,
-                 elts=[AssignName(name='a'), AssignName(name='b')])],
-           value=Name(name='c'))
+    Assign(
+        targets=[
+            Tuple(
+                ctx=<Context.Store: 2>,
+                elts=[AssignName(name='a'), AssignName(name='b')])],
+        value=Name(name='c'))
 
 Example 4:
-    - Assign(
-           targets=[List(
-                 ctx=<Context.Store: 2>,
-                 elts=[AssignName(name='a'), Starred(
-                       ctx=<Context.Store: 2>,
-                       value=AssignName(name='b'))])],
-           value=Name(name='d'))
+    Assign(
+        targets=[List(
+                ctx=<Context.Store: 2>,
+                elts=[AssignName(name='a'), Starred(
+                        ctx=<Context.Store: 2>,
+                        value=AssignName(name='b'))])],
+        value=Name(name='d'))
 
 Type-checking:
     - Single identifiers are associated with the type of the expression on the RHS of the =.
     - For (unpacking) tuple/list assignment, the RHS must be an iterable of the same length as
       the number of identifiers on the LHS.
-      - An exception is when the * operator is used preceding a variable,
-        in this case, the remaining values in the iterable will assigned to
-        that variable as a list.
+    - An exception is when the * operator is used preceding a variable,
+      in this case, the remaining values in the iterable will assigned to
+      that variable as a list.
 """
 
 # Example 1

--- a/nodes/assign_attr.py
+++ b/nodes/assign_attr.py
@@ -5,14 +5,15 @@ To assign a value to the relationship attribute. (This is the astroid
 Attribute node in the specific Load context.)
 
 Attributes:
-    - expr      (Node)
-        - The node object whose attribute is assigned.
     - attrname  (str)
         - The name of the attribute that is assigned.
+    - expr      (NodeNG)
+        - The node object whose attribute is assigned.
 
 Example:
-    - expr      -> ClassName
-    - attrname  -> "name"
+    - AssignAttr(
+         attrname='name',
+         expr=Name(name='self'))
 """
 
 class ClassName():

--- a/nodes/assign_attr.py
+++ b/nodes/assign_attr.py
@@ -5,15 +5,15 @@ To assign a value to the relationship attribute. (This is the astroid
 Attribute node in the specific Load context.)
 
 Attributes:
-    - attrname  (str)
+    - attrname  (Optional[str])
         - The name of the attribute that is assigned.
-    - expr      (NodeNG)
+    - expr      (Optional[NodeNG])
         - The node object whose attribute is assigned.
 
 Example:
-    - AssignAttr(
-         attrname='name',
-         expr=Name(name='self'))
+    AssignAttr(
+        attrname='name',
+        expr=Name(name='self'))
 """
 
 class ClassName():

--- a/nodes/assign_name.py
+++ b/nodes/assign_name.py
@@ -4,11 +4,11 @@ AssignName astroid node
 An assignment for a name node that appears in a Store (assignment) context.
 
 Attributes:
-    - name  (str)
-        - The name node to be assigned.
+    - name  (Optional[str])
+        - The name which is assigned to.
 
 Example:
-    - AssignName(name='x')
+    AssignName(name='x')
 """
 
 x = 3

--- a/nodes/assign_name.py
+++ b/nodes/assign_name.py
@@ -4,11 +4,11 @@ AssignName astroid node
 An assignment for a name node that appears in a Store (assignment) context.
 
 Attributes:
-    - name  (Name)
+    - name  (str)
         - The name node to be assigned.
 
 Example:
-    - name  -> Name(id='x')
+    - AssignName(name='x')
 """
 
 x = 3

--- a/nodes/async_for.py
+++ b/nodes/async_for.py
@@ -7,22 +7,20 @@ Subclass of For astroid node. This node iterates over async code with a for-loop
  AsyncFunctionDef astroid node.
 
 Attributes:
-    - target  (Name | Tuple | List)
-        - Holds the variable(s) the loop assigns to as a single node.
-    - iter    (Node)
-        - The single node to be looped over.
-    - body    (List[Node])
-        - The node to be executed.
-    - orelse  (List[Node] | None)
-        - Node will execute if the loop finished normally rather than via a
-        break statement.
+    # Derives directly from "For" node; see "For" node for attributes.
 
  Example:
-     - target  -> AssignName(name='a')
-     - iter    -> Name(name='b')
-     - body    -> [If(test=Compare(left=Name(id='a'), ops=[['>', Const(value=5)]]),
-                   body=[Break()], orelse=[])]
-     - orelse  -> [Continue()]
+     - AsyncFor(
+               target=AssignName(name='a'),
+               iter=Name(name='b'),
+               body=[If(
+                     test=Compare(
+                        left=Name(name='a'),
+                        ops=[['>', Const(value=5)]]),
+                     body=[Break()],
+                     orelse=[Continue()])],
+               orelse=[])
+
 """
 
 async def fun():

--- a/nodes/async_for.py
+++ b/nodes/async_for.py
@@ -9,17 +9,18 @@ Subclass of For astroid node. This node iterates over async code with a for-loop
 Attributes:
     # Derives directly from "For" node; see "For" node for attributes.
 
- Example:
-     - AsyncFor(
-               target=AssignName(name='a'),
-               iter=Name(name='b'),
-               body=[If(
-                     test=Compare(
-                        left=Name(name='a'),
-                        ops=[['>', Const(value=5)]]),
-                     body=[Break()],
-                     orelse=[Continue()])],
-               orelse=[])
+Example:
+    AsyncFor(
+        target=AssignName(name='a'),
+        iter=Name(name='b'),
+        body=[
+            If(
+                test=Compare(
+                left=Name(name='a'),
+                ops=[['>', Const(value=5)]]),
+                body=[Break()],
+                orelse=[])],
+        orelse=[Continue()])
 
 """
 

--- a/nodes/async_function_def.py
+++ b/nodes/async_function_def.py
@@ -5,29 +5,35 @@ Subclass of FunctionDef astroid node. An async def function definition and used
 for async astroid nodes like AsyncFor and AsyncWith.
 
 Attributes:
-    - name        (str)
-        - The function's name.
-    - args        (Arguments)
-        - An arguments node. See Arguments.py for more details.
-    - doc         (str)
-        - The docstring of the function.
-    - body        (List[Node])
-        - The list of nodes inside the function.
-    - decorators  (Decorator)
-        - The decorator to be applied on this function.
-    - returns     (None)
-        - The return annotation.
+    # Derives directly from "FunctionDef" node; see "FunctionDef" node for attributes.
 
 Example:
-    - name        -> 'animal'
-    - args        -> Arguments(args=[AssignName(name='arg')], vararg=None, kwonlyargs=[],
-                               kw_defaults=[], kwarg=None, defaults=[])
-    - doc         -> Const(value="This is function animal.")
-    - body        -> [Assign(targets=[AssignName(name='dog')],
-                             value=Const(value="an animal")],
-                             Return(value=Name(name='dog'))]
-    - decorators  -> Decorators(nodes=[Name(name='wrapper')])
-    - returns     -> None
+    - AsyncFunctionDef(
+                   name='animal',
+                   doc='\n    This is function animal.\n    ',
+                   decorators=None,
+                   args=Arguments(
+                      vararg=None,
+                      kwarg=None,
+                      args=[AssignName(name='arg')],
+                      defaults=[],
+                      kwonlyargs=[],
+                      posonlyargs=[],
+                      posonlyargs_annotations=[],
+                      kw_defaults=[],
+                      annotations=[None],
+                      varargannotation=None,
+                      kwargannotation=None,
+                      kwonlyargs_annotations=[],
+                      type_comment_args=[None],
+                      type_comment_kwonlyargs=[],
+                      type_comment_posonlyargs=[]),
+                   returns=None,
+                   body=[Assign(
+                         targets=[AssignName(name='dog')],
+                         value=Const(value='an animal')),
+                      Return(value=Name(name='dog'))])
+
 """
 
 @wrapper

--- a/nodes/async_function_def.py
+++ b/nodes/async_function_def.py
@@ -8,31 +8,32 @@ Attributes:
     # Derives directly from "FunctionDef" node; see "FunctionDef" node for attributes.
 
 Example:
-    - AsyncFunctionDef(
-                   name='animal',
-                   doc='\n    This is function animal.\n    ',
-                   decorators=None,
-                   args=Arguments(
-                      vararg=None,
-                      kwarg=None,
-                      args=[AssignName(name='arg')],
-                      defaults=[],
-                      kwonlyargs=[],
-                      posonlyargs=[],
-                      posonlyargs_annotations=[],
-                      kw_defaults=[],
-                      annotations=[None],
-                      varargannotation=None,
-                      kwargannotation=None,
-                      kwonlyargs_annotations=[],
-                      type_comment_args=[None],
-                      type_comment_kwonlyargs=[],
-                      type_comment_posonlyargs=[]),
-                   returns=None,
-                   body=[Assign(
-                         targets=[AssignName(name='dog')],
-                         value=Const(value='an animal')),
-                      Return(value=Name(name='dog'))])
+    AsyncFunctionDef(
+        name='animal',
+        doc='\n    This is function animal.\n    ',
+        decorators=None,
+        args=Arguments(
+            vararg=None,
+            kwarg=None,
+            args=[AssignName(name='arg')],
+            defaults=[],
+            kwonlyargs=[],
+            posonlyargs=[],
+            posonlyargs_annotations=[],
+            kw_defaults=[],
+            annotations=[None],
+            varargannotation=None,
+            kwargannotation=None,
+            kwonlyargs_annotations=[],
+            type_comment_args=[None],
+            type_comment_kwonlyargs=[],
+            type_comment_posonlyargs=[]),
+        returns=None,
+        body=[
+            Assign(
+                targets=[AssignName(name='dog')],
+                value=Const(value='an animal')),
+                Return(value=Name(name='dog'))])
 
 """
 

--- a/nodes/async_with.py
+++ b/nodes/async_with.py
@@ -10,14 +10,17 @@ Attributes:
     - # Derives directly from "With" node; see "with" node for attributes.
 
 Example:
-    - AsyncWith(
-           items=[[Call(
+    AsyncWith(
+        items=[
+            [
+                Call(
                     func=Name(name='open'),
                     args=[Const(value='/foo/bar'), Const(value='r')],
                     keywords=None),
-                 AssignName(name='f')]],
-           body=[Pass()])
+                AssignName(name='f')]],
+        body=[Pass()])
 """
+
 
 async def fun():
     async with open('/foo/bar', 'r') as f:

--- a/nodes/async_with.py
+++ b/nodes/async_with.py
@@ -7,18 +7,16 @@ to complete, rather the code executes all operations in one go. Only valid in
 body of an AsyncFunctionDef astroid node.
 
 Attributes:
-    - items  (List[Expr])
-        - The expressions or expression-reassigned Name pairs that are to be
-          set up by this "with" and torn down after the completion of body.
-          Expressions are usually Call or Name nodes.
-    - body   (List[Statement])
-        - The code to be performed until the with statement closes.
+    - # Derives directly from "With" node; see "with" node for attributes.
 
 Example:
-    - items  -> [Call(func=Name(name='open'),
-                      args=[Const(value='/foo/bar'), Const(value='r')]),
-                 AssignName(name='f')]]
-    - body   -> [Pass()]
+    - AsyncWith(
+           items=[[Call(
+                    func=Name(name='open'),
+                    args=[Const(value='/foo/bar'), Const(value='r')],
+                    keywords=None),
+                 AssignName(name='f')]],
+           body=[Pass()])
 """
 
 async def fun():

--- a/nodes/attribute.py
+++ b/nodes/attribute.py
@@ -5,15 +5,15 @@ An expression accessing an object's attribute (This is only for Attribute nodes 
 in a Load context. For more information, see the README.)
 
 Attributes:
-    - attrname  (str)
+    - attrname  (Optional[str])
         - The name of the accessed attribute.
-    - expr (Name)
+    - expr (Optional[Name])
         - The Name object whose attribute is given access to.
 
 Example:
-    - Attribute(
-               attrname='colour',
-               expr=Name(name='snake'))
+    Attribute(
+        attrname='colour',
+        expr=Name(name='snake'))
 
 Type-checking:
     The type of `expr` is resolved, and attrname is looked up for that type.

--- a/nodes/attribute.py
+++ b/nodes/attribute.py
@@ -5,14 +5,15 @@ An expression accessing an object's attribute (This is only for Attribute nodes 
 in a Load context. For more information, see the README.)
 
 Attributes:
-    - expr (Node)
-        - The node object whose attribute is given access to.
     - attrname  (str)
         - The name of the accessed attribute.
+    - expr (Name)
+        - The Name object whose attribute is given access to.
 
 Example:
-    - expr      -> Name(name='snake')
-    - attrname  -> "colour"
+    - Attribute(
+               attrname='colour',
+               expr=Name(name='snake'))
 
 Type-checking:
     The type of `expr` is resolved, and attrname is looked up for that type.

--- a/nodes/aug_assign.py
+++ b/nodes/aug_assign.py
@@ -5,11 +5,11 @@ An augmented assignment, which is the combination, in a single statement, of a
 binary operation and an assignment statement.
 
 Attributes:
-    - op      (str)
+    - op      (Optional[str])
         - The operator to be performed on target.
-    - target  (NodeNG)
+    - target  (Optional[Name | Subscript | Attribute])
         - What is being assigned to.
-    - value   (NodeNG)
+    - value   (Optional[NodeNG])
         - A single node to be assigned to target.
 
 Type-checking:
@@ -21,10 +21,10 @@ Type-checking:
 
 
 Example:
-    - AugAssign(
-               op='+=',
-               target=AssignName(name='x'),
-               value=Const(value=1))
+    AugAssign(
+        op='+=',
+        target=AssignName(name='x'),
+        value=Const(value=1))
 """
 
 # Example:

--- a/nodes/aug_assign.py
+++ b/nodes/aug_assign.py
@@ -5,12 +5,12 @@ An augmented assignment, which is the combination, in a single statement, of a
 binary operation and an assignment statement.
 
 Attributes:
-    - target  (Name | Subscript | Attribute)
-        - A single node
-    - value   (Node)
-        - A single node to be assigned to target.
     - op      (str)
         - The operator to be performed on target.
+    - target  (NodeNG)
+        - What is being assigned to.
+    - value   (NodeNG)
+        - A single node to be assigned to target.
 
 Type-checking:
     See https://docs.python.org/3.6/reference/datamodel.html#emulating-numeric-types.
@@ -21,9 +21,10 @@ Type-checking:
 
 
 Example:
-    - target  -> AssignName(name='x')
-    - value   -> Const(value=1)
-    - op      -> '+='
+    - AugAssign(
+               op='+=',
+               target=AssignName(name='x'),
+               value=Const(value=1))
 """
 
 # Example:

--- a/nodes/await.py
+++ b/nodes/await.py
@@ -4,12 +4,14 @@ Await astroid node
 An await expression. Only valid in the body of an AsyncFunctionDef.
 
 Attributes:
-    - value  (Node)
+    - value  (NodeNG)
         - What the expression waits for.
 
 Example:
-    - value  -> Call(func=Name(id='async_coroutine'), args=[],
-                keywords=[])
+    - Await(value=Call(
+                        func=Name(name='async_coroutine'),
+                        args=[],
+                        keywords=None))
 """
 
 def async_coroutine():

--- a/nodes/await.py
+++ b/nodes/await.py
@@ -4,18 +4,21 @@ Await astroid node
 An await expression. Only valid in the body of an AsyncFunctionDef.
 
 Attributes:
-    - value  (NodeNG)
+    - value     (Optional[Expr])
         - What the expression waits for.
 
 Example:
-    - Await(value=Call(
-                        func=Name(name='async_coroutine'),
-                        args=[],
-                        keywords=None))
+    Await(
+        value=Call(
+            func=Name(name='async_coroutine'),
+            args=[],
+            keywords=None))
 """
+
 
 def async_coroutine():
     pass
+
 
 async def fun():
     await async_coroutine()

--- a/nodes/bin_op.py
+++ b/nodes/bin_op.py
@@ -4,17 +4,18 @@ BinOp astroid node
 A binary operation (like addition or division).
 
 Attributes:
-    - left   (Expr)
-        - Any expression node.
-    - right  (Expr)
-        - Any expression node.
+    - left   (NodeNG)
+        - What is being applied to the operator on the left side.
     - op     (str)
         - The operator to be performed on left and right.
+    - right  (NodeNG)
+        - What is being applied to the operator on the right side.
 
 Example 1:
-    - left   -> Const(value=1)
-    - right  -> Const(value=2)
-    - op     -> '+'
+    - BinOp(
+           op='+',
+           left=Const(value=1),
+           right=Const(value=2))
 
 Examples of operators on primitive types; dunder function -> call and symbol:
     - __add__   -> +

--- a/nodes/bin_op.py
+++ b/nodes/bin_op.py
@@ -4,18 +4,18 @@ BinOp astroid node
 A binary operation (like addition or division).
 
 Attributes:
-    - left   (NodeNG)
+    - left   (Optional[Expr])
         - What is being applied to the operator on the left side.
-    - op     (str)
+    - op     (Optional[str])
         - The operator to be performed on left and right.
-    - right  (NodeNG)
+    - right  (Optional[Expr])
         - What is being applied to the operator on the right side.
 
 Example 1:
-    - BinOp(
-           op='+',
-           left=Const(value=1),
-           right=Const(value=2))
+    BinOp(
+        op='+',
+        left=Const(value=1),
+        right=Const(value=2))
 
 Examples of operators on primitive types; dunder function -> call and symbol:
     - __add__   -> +

--- a/nodes/bool_op.py
+++ b/nodes/bool_op.py
@@ -4,23 +4,27 @@ BoolOp astroid node
 A boolean operation, 'or' or 'and'.
 
 Attributes:
-    - values  ([Expr])
-        - A list of the argument expressions
     - op      (str)
         - The operator, 'or' or 'and'.
+    - values  (List[NodeNG])
+        - A list of the argument expressions
 
 Example 1:
-    - values  -> [Const(value=None), Const(value=1)]
-    - op      -> 'or'
+    - BoolOp(
+               op='or',
+               values=[Const(value=None), Const(value=1)])
 
 Example 2:
-    - values  -> [Const(value=None), Const(value=1), Const(value=2)]
-    - op      -> 'or'
+    - BoolOp(
+               op='or',
+               values=[Const(value=None), Const(value=1), Const(value=2)])
 
 Example 3:
-    - values  -> [Const(value=None), BoolOp(op='and', values=[Const(value=1),
-                  Const(value=2)])]
-    - op      -> 'or'
+    - BoolOp(
+               op='or',
+               values=[Const(value=None), BoolOp(
+                     op='and',
+                     values=[Const(value=1), Const(value=2)])])
 
 Type-checking:
     If all of the values have the type type, that type is used as the type of the of BoolOp itself.

--- a/nodes/bool_op.py
+++ b/nodes/bool_op.py
@@ -4,27 +4,29 @@ BoolOp astroid node
 A boolean operation, 'or' or 'and'.
 
 Attributes:
-    - op      (str)
+    - op      (Optional[str])
         - The operator, 'or' or 'and'.
-    - values  (List[NodeNG])
+    - values  (Optional[list[Expr]])
         - A list of the argument expressions
 
 Example 1:
-    - BoolOp(
-               op='or',
-               values=[Const(value=None), Const(value=1)])
+    BoolOp(
+        op='or',
+        values=[Const(value=None), Const(value=1)])
 
 Example 2:
-    - BoolOp(
-               op='or',
-               values=[Const(value=None), Const(value=1), Const(value=2)])
+    BoolOp(
+        op='or',
+        values=[Const(value=None), Const(value=1), Const(value=2)])
 
 Example 3:
-    - BoolOp(
-               op='or',
-               values=[Const(value=None), BoolOp(
-                     op='and',
-                     values=[Const(value=1), Const(value=2)])])
+    BoolOp(
+        op='or',
+        values=[
+            Const(value=None),
+            BoolOp(
+                op='and',
+                values=[Const(value=1), Const(value=2)])])
 
 Type-checking:
     If all of the values have the type type, that type is used as the type of the of BoolOp itself.

--- a/nodes/break.py
+++ b/nodes/break.py
@@ -8,7 +8,7 @@ Attributes:
     # No attributes.
 
 Example:
-    - Break()
+    Break()
 """
 
 for i in range(3):

--- a/nodes/break.py
+++ b/nodes/break.py
@@ -3,6 +3,12 @@ Break astroid node
 
 Represents a Break Node. The break statement breaks out of the smallest
 enclosing for or while loop. Break has no attributes.
+
+Attributes:
+    # No attributes.
+
+Example:
+    - Break()
 """
 
 for i in range(3):

--- a/nodes/call.py
+++ b/nodes/call.py
@@ -4,45 +4,48 @@ Call astroid node
 A function call.
 
 Attributes:
-    - args      (List[NodeNG])
+    - args      (Optional[list[NodeNG]])
         - List of the arguments passed by position.
-    - func      (NodeNG)
+    - func      (Optional[Name | Attribute])
         - The function being called.
-    - keywords  (List[NodeNG])
+    - keywords  (Optional[list[NodeNG]])
         - List of keyword objects representing arguments passed by keyword.
           If None, keywords is an empty list.
-    - kwargs    (List[Keyword])
+    - kwargs    (list[Keyword])
         - The keyword arguments that unpack something.
-    - starargs  (List[Starred])
+    - starargs  (list[Starred])
         - The positional arguments that unpack something.
 
 Example 1:
-    - Call(
-          func=Name(name='ord'),
-          args=[Name(name='c')],
-          keywords=None)
+    Call(
+        func=Name(name='ord'),
+        args=[Name(name='c')],
+        keywords=None)
 
 Example 2:
-    - Call(
-           func=Name(name='func'),
-           args=[Name(name='a'), Starred(
-                 ctx=<Context.Load: 1>,
-                 value=Name(name='d'))],
-           keywords=[Keyword(
-                 arg='b',
-                 value=Name(name='c')),
-              Keyword(
-                 arg=None,
-                 value=Name(name='e'))])
+    Call(
+        func=Name(name='func'),
+        args=[
+            Name(name='a'),
+            Starred(
+                ctx=<Context.Load: 1>,
+                value=Name(name='d'))],
+        keywords=[
+            Keyword(
+                arg='b',
+                value=Name(name='c')),
+                Keyword(
+                    arg=None,
+                    value=Name(name='e'))])
 
 
 Example 3:
-    - Call(
-           func=Attribute(
-              attrname='method',
-              expr=Name(name='self')),
-           args=[Name(name='x')],
-           keywords=None)
+    Call(
+        func=Attribute(
+            attrname='method',
+            expr=Name(name='self')),
+        args=[Name(name='x')],
+        keywords=None)
 
 Type-checking:
     The type of func must be a function type; the argument types are matched with the parameter types

--- a/nodes/call.py
+++ b/nodes/call.py
@@ -4,28 +4,45 @@ Call astroid node
 A function call.
 
 Attributes:
-    - func      (Name | Attribute)
-        - The function.
-    - args      (List[Node])
+    - args      (List[NodeNG])
         - List of the arguments passed by position.
-    - keywords  (List[Keyword] | None)
+    - func      (NodeNG)
+        - The function being called.
+    - keywords  (List[NodeNG])
         - List of keyword objects representing arguments passed by keyword.
           If None, keywords is an empty list.
+    - kwargs    (List[Keyword])
+        - The keyword arguments that unpack something.
+    - starargs  (List[Starred])
+        - The positional arguments that unpack something.
 
 Example 1:
-    - func      -> Name(name='ord')
-    - args      -> Name(name='c')
-    - keywords  -> []
+    - Call(
+          func=Name(name='ord'),
+          args=[Name(name='c')],
+          keywords=None)
 
 Example 2:
-    - func      -> Name(name='func')
-    - args      -> [Name(name='a')]
-    - keywords  -> [keyword(arg='b', value=Name(id='c'))]
+    - Call(
+           func=Name(name='func'),
+           args=[Name(name='a'), Starred(
+                 ctx=<Context.Load: 1>,
+                 value=Name(name='d'))],
+           keywords=[Keyword(
+                 arg='b',
+                 value=Name(name='c')),
+              Keyword(
+                 arg=None,
+                 value=Name(name='e'))])
+
 
 Example 3:
-    -func       -> Attribute(expr=Name(name='self'), attrname='method')
-    -args       -> Name(name='x')
-    -keywords   -> []
+    - Call(
+           func=Attribute(
+              attrname='method',
+              expr=Name(name='self')),
+           args=[Name(name='x')],
+           keywords=None)
 
 Type-checking:
     The type of func must be a function type; the argument types are matched with the parameter types

--- a/nodes/class_def.py
+++ b/nodes/class_def.py
@@ -4,23 +4,36 @@ ClassDef astroid node
 A class definition.
 
 Attributes:
-    - name        (str)
-        - A raw string for the class name.
-    - doc         (str)
-        - The docstring of this function.
-    - decorators  (Decorators)
-        - The decorator to be applied on this function.
-    - bases       (List[Node])
+    - basenames             (List[str])
+        - The names of the parent classes. Names are given in the order they appear in the
+        class definition.
+    - bases                 (List[NodeNG])
         - List of nodes for explicitly specified base classes.
-    - body        (List[Node])
-        - List of nodes representing the code within the class definition.
+    - body                  (List[NodeNG])
+        - The contents of the class body.
+    - decorators            (Decorators)
+        - The decorator to be applied on this function.
+    - doc                   (str)
+        - The docstring of this function.
+    - kewords               (List[Keyword])
+        - The keywords given to the class definition.
+    - name                  (str)
+        - A raw string for the class name.
+    - newstyle              (bool)
+        - Whether this is a "new style" class or not.
+    - special_attributes    (objectmodel.ClassModel)
+        - The names of special attributes that this class has.
+    - type                  (str)
+        - The class type for this node. Possible values: "class", "metaclass", and "exception".
 
 Example:
-    - name        -> 'Foo'
-    - doc         -> ''
-    - decorators  -> Decorator(@wrapper)
-    - bases       -> [Name(name='base1'),Name(name='base2')]
-    - body        -> [Pass()]
+    - ClassDef(
+               name='Foo',
+               doc=None,
+               decorators=Decorators(nodes=[Name(name='wrapper')]),
+               bases=[Name(name='base1'), Name(name='base2')],
+               keywords=[],
+               body=[Pass()])
 
 Type-checking:
     The class name is added to the parent's type environment.

--- a/nodes/class_def.py
+++ b/nodes/class_def.py
@@ -4,22 +4,22 @@ ClassDef astroid node
 A class definition.
 
 Attributes:
-    - basenames             (List[str])
+    - basenames             (list[str])
         - The names of the parent classes. Names are given in the order they appear in the
         class definition.
-    - bases                 (List[NodeNG])
+    - bases                 (list[NodeNG])
         - List of nodes for explicitly specified base classes.
-    - body                  (List[NodeNG])
+    - body                  (list[NodeNG])
         - The contents of the class body.
-    - decorators            (Decorators)
+    - decorators            (Optional[Decorators])
         - The decorator to be applied on this function.
-    - doc                   (str)
+    - doc                   (Optional[str])
         - The docstring of this function.
-    - kewords               (List[Keyword])
+    - keywords               (Optional[list[Keyword]])
         - The keywords given to the class definition.
     - name                  (str)
         - A raw string for the class name.
-    - newstyle              (bool)
+    - newstyle              (Optional[bool])
         - Whether this is a "new style" class or not.
     - special_attributes    (objectmodel.ClassModel)
         - The names of special attributes that this class has.
@@ -27,13 +27,15 @@ Attributes:
         - The class type for this node. Possible values: "class", "metaclass", and "exception".
 
 Example:
-    - ClassDef(
-               name='Foo',
-               doc=None,
-               decorators=Decorators(nodes=[Name(name='wrapper')]),
-               bases=[Name(name='base1'), Name(name='base2')],
-               keywords=[],
-               body=[Pass()])
+    ClassDef(
+        name='Foo',
+        doc=None,
+        decorators=Decorators(nodes=[Name(name='wrapper')]),
+        bases=[
+            Name(name='base1'),
+            Name(name='base2')],
+        keywords=[],
+        body=[Pass()])
 
 Type-checking:
     The class name is added to the parent's type environment.

--- a/nodes/compare.py
+++ b/nodes/compare.py
@@ -7,14 +7,15 @@ Expressions are always evaluated at most once (PRIOR to comparison) and the valu
 Multi-comparison expressions are logically equivalent to the conjunction of the individual value comparisons.
 
 Attributes:
-    - left  (value)
+    - left  (NodeNG)
         - The first value in the comparison.
-    - ops   (List[Tuple(str, value)])
+    - ops   (List[Tuple(str, NodeNG)])
         - The list of operators to be performed on left.
 
 Example:
-    - left  -> Const(value=0)
-    - ops   -> [('<', Const(value=1)), ('!=", Const(value=1))]
+    - Compare(
+           left=Const(value=0),
+           ops=[['<', Const(value=1)], ['!=', Const(value=1)]])
 
 Type-checking:
     An individual comparison is converted to its corresponding method and type-checked.

--- a/nodes/compare.py
+++ b/nodes/compare.py
@@ -7,15 +7,17 @@ Expressions are always evaluated at most once (PRIOR to comparison) and the valu
 Multi-comparison expressions are logically equivalent to the conjunction of the individual value comparisons.
 
 Attributes:
-    - left  (NodeNG)
+    - left  (Optional[Expr])
         - The first value in the comparison.
-    - ops   (List[Tuple(str, NodeNG)])
+    - ops   (Optional[list[tuple(str, NodeNG)]])
         - The list of operators to be performed on left.
 
 Example:
-    - Compare(
-           left=Const(value=0),
-           ops=[['<', Const(value=1)], ['!=', Const(value=1)]])
+    Compare(
+        left=Const(value=0),
+        ops=[
+            ['<', Const(value=1)],
+            ['!=', Const(value=1)]])
 
 Type-checking:
     An individual comparison is converted to its corresponding method and type-checked.

--- a/nodes/comprehension.py
+++ b/nodes/comprehension.py
@@ -4,44 +4,46 @@ Comprehension astroid node
 Constructs that allow sequences to be built from other sequences.
 
 Attributes:
-    - ifs               (List[NodeNG])
+    - ifs               (Optional[list[Expr]])
         - List of test expressions. If None, ifs is an empty list.
-    - is_async          (bool)
+    - is_async          (Optional[bool])
         - Whether this is an asynchronous comprehension or not.
-    - iter              (NodeNG)
+    - iter              (Optional[NodeNG])
         - The object to iterate over.
     - optional_assign   (bool)
         - Whether this node optionally assigns a variable
-    - target            (NodeNG)
+    - target            (Optional[NodeNG])
         - Typically a name or tuple node; the reference to use for each element.
 
 Example 1:
     * NOTE : The example below is of a Comprehension Node "for x in range(3)" within
-             a ListComprehension Node "[x for x in range(3)]".
+             a ListComprehension Node "[x for x in range(3)]". is_async=0 was the return of the
+             .repr_tree() method on the node.
 
-    - Comprehension(
-                     is_async=0,    # This was the return of repr_tree.__str__() as an int
-                     target=AssignName(name='x'),
-                     iter=Call(
-                        func=Name(name='range'),
-                        args=[Const(value=3)],
-                        keywords=None),
-                     ifs=[])
+    Comprehension(
+        is_async=0,
+        target=AssignName(name='x'),
+            iter=Call(
+                func=Name(name='range'),
+                args=[Const(value=3)],
+                keywords=None),
+                ifs=[])])
 
 Example 2:
     * NOTE : The example below is of a Comprehension Node "b in range(3) if b < 2" within
              a ListComprehension Node "[b for b in range(3) if b < 2]".
 
-    - Comprehension(
-                     is_async=0,
-                     target=AssignName(name='b'),
-                     iter=Call(
-                        func=Name(name='range'),
-                        args=[Const(value=3)],
-                        keywords=None),
-                     ifs=[Compare(
-                           left=Name(name='b'),
-                           ops=[['<', Const(value=2)]])])
+    Comprehension(
+        is_async=0,
+        target=AssignName(name='b'),
+        iter=Call(
+            func=Name(name='range'),
+            args=[Const(value=3)],
+            keywords=None),
+            ifs=[
+                Compare(
+                    left=Name(name='b'),
+                    ops=[['<', Const(value=2)]])])
 
 Type-checking:
     Unify the target against the "contained" type in the iterable.

--- a/nodes/comprehension.py
+++ b/nodes/comprehension.py
@@ -4,28 +4,44 @@ Comprehension astroid node
 Constructs that allow sequences to be built from other sequences.
 
 Attributes:
-    - target  (Node)
-        - Typically a name or tuple node; the reference to use for each element.
-    - iter    (Node)
-        - The object to iterate over.
-    - ifs     (List[Expr])
+    - ifs               (List[NodeNG])
         - List of test expressions. If None, ifs is an empty list.
+    - is_async          (bool)
+        - Whether this is an asynchronous comprehension or not.
+    - iter              (NodeNG)
+        - The object to iterate over.
+    - optional_assign   (bool)
+        - Whether this node optionally assigns a variable
+    - target            (NodeNG)
+        - Typically a name or tuple node; the reference to use for each element.
 
 Example 1:
     * NOTE : The example below is of a Comprehension Node "for x in range(3)" within
              a ListComprehension Node "[x for x in range(3)]".
 
-    - target  -> AssignName(name='x')
-    - iter    -> Call(func=Name(name='range'), args=[Const(value=3)])
-    - ifs     -> []
+    - Comprehension(
+                     is_async=0,    # This was the return of repr_tree.__str__() as an int
+                     target=AssignName(name='x'),
+                     iter=Call(
+                        func=Name(name='range'),
+                        args=[Const(value=3)],
+                        keywords=None),
+                     ifs=[])
 
 Example 2:
     * NOTE : The example below is of a Comprehension Node "b in range(3) if b < 2" within
              a ListComprehension Node "[b for b in range(3) if b < 2]".
 
-    - target  -> AssignName(name='b')
-    - iter    -> Call(func=Name(name='range'), args=[Const(value=3)])
-    - ifs     -> [Compare(left=Name(name='b'), ops=[['<', Const(value=2)]])]
+    - Comprehension(
+                     is_async=0,
+                     target=AssignName(name='b'),
+                     iter=Call(
+                        func=Name(name='range'),
+                        args=[Const(value=3)],
+                        keywords=None),
+                     ifs=[Compare(
+                           left=Name(name='b'),
+                           ops=[['<', Const(value=2)]])])
 
 Type-checking:
     Unify the target against the "contained" type in the iterable.

--- a/nodes/const.py
+++ b/nodes/const.py
@@ -5,14 +5,14 @@ Represents a literal constant node like num, str, bool, None, bytes, not
 computed values.
 
 Attributes:
-    - value  (num | str | bool | None | bytes)
-        - A literal constant
+    - value  (object)
+        - The value that the constant represents.
 
 Example 1:
-    - value  -> 1
+    - Const(value=1)
 
 Example 2:
-    - value  -> b'6'
+    - Const(value=b'6')
 
 Type-checking:
     The type of a Const node is the type of its value attribute.

--- a/nodes/const.py
+++ b/nodes/const.py
@@ -6,13 +6,13 @@ computed values.
 
 Attributes:
     - value  (object)
-        - The value that the constant represents.
+        - The value that the constant represents. These are Python literals.
 
 Example 1:
-    - Const(value=1)
+    Const(value=1)
 
 Example 2:
-    - Const(value=b'6')
+    Const(value=b'6')
 
 Type-checking:
     The type of a Const node is the type of its value attribute.

--- a/nodes/continue.py
+++ b/nodes/continue.py
@@ -8,7 +8,7 @@ Attributes:
     # No attributes.
 
 Example:
-    - Continue()
+    Continue()
 """
 
 for i in range(3):

--- a/nodes/continue.py
+++ b/nodes/continue.py
@@ -3,6 +3,12 @@ Continue astroid node
 
 Represents a Continue node. The continue statement continues with the next
 iteration of the loop. Continue has no attributes.
+
+Attributes:
+    # No attributes.
+
+Example:
+    - Continue()
 """
 
 for i in range(3):

--- a/nodes/decorators.py
+++ b/nodes/decorators.py
@@ -7,11 +7,14 @@ the function being decorated. A Decorators node is a child node of FunctionDef
 node.
 
 Attributes:
-    - nodes  (List[Union[Name, Call]])
+    - nodes  (Optional[list[Name | Call]])
         - A list of decorators this node contains.
 
 Example:
-    - Decorators(nodes=[Name(name='wrapper'), Name(name='decor')])
+    Decorators(
+        nodes=[
+            Name(name='wrapper'),
+            Name(name='decor')])
 """
 
 @wrapper

--- a/nodes/decorators.py
+++ b/nodes/decorators.py
@@ -7,11 +7,11 @@ the function being decorated. A Decorators node is a child node of FunctionDef
 node.
 
 Attributes:
-    - nodes  (List[Name])
-        - A list of names of the decorators
+    - nodes  (List[Union[Name, Call]])
+        - A list of decorators this node contains.
 
 Example:
-    - nodes  -> [Name(name='wrapper'), Name(name='decor')]
+    - Decorators(nodes=[Name(name='wrapper'), Name(name='decor')])
 """
 
 @wrapper

--- a/nodes/del_attr.py
+++ b/nodes/del_attr.py
@@ -5,18 +5,19 @@ This node represents an attribute of an object being deleted.
 This is an astroid Attribute node specifically in the Del (being deleted) context.
 
 Attributes:
-    - attrname  (str)
+    - attrname  (Optional[str])
         - The name of the attribute being deleted.
-    - expr      (Name)
+    - expr      (Optional[Name])
         - The node object whose attribute is being deleted.
 
 Example:
-    - DelAttr(
-         attrname='attr',
-         expr=Name(name='self'))
+    DelAttr(
+        attrname='attr',
+        expr=Name(name='self'))
 """
 
-class Foo():
+
+class Foo:
     def __init__(self):
         self.attr = 1
         del self.attr

--- a/nodes/del_attr.py
+++ b/nodes/del_attr.py
@@ -5,14 +5,15 @@ This node represents an attribute of an object being deleted.
 This is an astroid Attribute node specifically in the Del (being deleted) context.
 
 Attributes:
-    - expr      (Name)
-        - The node object whose attribute is being deleted.
     - attrname  (str)
         - The name of the attribute being deleted.
+    - expr      (Name)
+        - The node object whose attribute is being deleted.
 
 Example:
-    - expr      -> Name(name="self")
-    - attrname  -> "attr"
+    - DelAttr(
+         attrname='attr',
+         expr=Name(name='self'))
 """
 
 class Foo():


### PR DESCRIPTION
Updated first 1/3rd of `pyta/nodes/...` files to be more consistent and up to date with astroid documentation. 
Added undocumented attributes to the node documentations.

Changed example documentation from:
```python
"""
Example 2:
    - targets  -> [DelName(x), DelAttr(Name("self"), "attr"),
                  Subscript(Name(y), Index(0), Del)]
"""
```
to a format like:
```python
"""
Example 2:
    Delete(
        targets=[
            DelName(name='x'),
            DelAttr(
                attrname='attr',
                expr=Name(name='self')),
            Subscript(
                ctx=<Context.Del: 3>,
                value=Name(name='y'),
                slice=Const(value=0))])
"""
```
Format is based off of the `repr_tree()` method of astroid nodes. 
Ensured that `Node` object references got renamed to `NodeNG` objects.