### PR TITLE
C0415 import outside toplevel docs

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -802,6 +802,13 @@ docstring.
 ```{literalinclude} /../examples/pylint/C0413_wrong_import_position.py
 ```
 
+### Import outside toplevel (C0415) [](#C0415)
+
+Imports should be placed at the top-level of the module, not inside function or class bodies.
+
+```{literalinclude} /../examples/pylint/C0415_import_outside_toplevel.py
+```
+
 ### Unused import (W0611) [](#W0611)
 
 This error occurs when we import a module which is not used anywhere in our code.

--- a/examples/pylint/C0415_import_outside_toplevel.py
+++ b/examples/pylint/C0415_import_outside_toplevel.py
@@ -1,0 +1,2 @@
+def import_module():
+    import something  # Error on this line


### PR DESCRIPTION
Added C0415 example file in `examples/pylint`
Added C0415 in `index.md` (under the `imports` section in numeric order with the other C041X errors)