### PR TITLE
R1726 simplifiable condition docs

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -335,6 +335,7 @@ else:
 ### Simplifiable condition (R1726) [](#R1726)
 
 This error occurs when a boolean test condition can be simplified.
+Test conditions are expressions evaluated inside of statements such as `if`, `while`, or `assert`.
 
 ```{literalinclude} /../examples/pylint/R1726_simplifiable_condition.py
 ```

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -332,6 +332,20 @@ else:
     number_category = 'non-negative'
 ```
 
+### Simplifiable condition (R1726) [](#R1726)
+
+This error occurs when a boolean test condition can be simplified.
+
+```{literalinclude} /../examples/pylint/R1726_simplifiable_condition.py
+```
+
+The above can be modified to:
+
+```python
+if a:  # Error was on this line
+  pass
+```
+
 ### Singleton comparison (C0121) [](#C0121)
 
 This error occurs when an expression is compared to a singleton value like `True`, `False` or `None`

--- a/examples/pylint/R1726_simplifiable_condition.py
+++ b/examples/pylint/R1726_simplifiable_condition.py
@@ -1,0 +1,2 @@
+if True and a:  # Error on this line
+    pass


### PR DESCRIPTION
Added R1726 example file to `examples/pylint`

Added R1726 to `index.md` (under `Code complexity` and `Unneeded not (C0113)` because it was a complexity-related boolean error). Also specified that R1726 is only evaluated in the context of a test condition, not any boolean operation.

Added an example correcting R1727 in `index.md`