### PR TITLE
Update VALIDATORS comment directory

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -166,7 +166,7 @@ def reset_linter(config=None, file_linted=None):
         - If the config argument is a dictionary, apply those options afterward.
     Do not re-use a linter object. Returns a new linter.
     """
-    # Tuple of custom options. See 'type' in pylint/config.py `VALIDATORS` dict.
+    # Tuple of custom options. See 'type' in pylint/config/option.py `VALIDATORS` dict.
     new_checker_options = (
         ('pyta-reporter',
             {'default': 'ColorReporter',

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -166,7 +166,7 @@ def reset_linter(config=None, file_linted=None):
         - If the config argument is a dictionary, apply those options afterward.
     Do not re-use a linter object. Returns a new linter.
     """
-    # Tuple of custom options. See 'type' in pylint/config/option.py `VALIDATORS` dict.
+    # Tuple of custom options. Note: 'type' must map to a value equal a key in the pylint/config/option.py `VALIDATORS` dict.
     new_checker_options = (
         ('pyta-reporter',
             {'default': 'ColorReporter',


### PR DESCRIPTION
<!--- Provide a summary of your changes in the Pull Request Title above. -->
<!--- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
 It was difficult to find which dictionary stored all the valid data types for `.pylintrc`. This comment was outdated as pylint no longer has `pylint/config.py`, but rather `pylint/config/` as a directory
<!--- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes
Updated the comment location to be where the current pylint library keeps the `VALIDATORS` dictionary: `pylint/config/option.py`.
<!--- Describe your changes here. -->
**Description**:

**Type of change** (select all that apply):
<!--- Put an `x` in all the boxes that apply. -->
<!--- Remove any lines that do not apply. --> 

- [x] Documentation update (change that modifies or updates documentation only)

## Testing

No testing done; it's just a python comment.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
