### PR TITLE
Bug Fix: accessing nonexistent DictComp object attribute

### DIFF
--- a/python_ta/checkers/possibly_undefined_checker.py
+++ b/python_ta/checkers/possibly_undefined_checker.py
@@ -127,7 +127,11 @@ class PossiblyUndefinedChecker(BaseChecker):
         elif isinstance(statement, (astroid.ListComp, astroid.SetComp, astroid.DictComp, astroid.GeneratorExp)):
             # Comprehension targets are assigned before expression is evaluated.
             yield from multiple_nodes(statement.generators)  # statement.generators is a list of nodes
-            yield from self.get_nodes(statement.elt)
+            if not hasattr(statement, 'elt'):
+                yield from self.get_nodes(statement.key) # keys evaluated first
+                yield from self.get_nodes(statement.value)
+            else:
+                yield from self.get_nodes(statement.elt)
         else:
             yield from statement.nodes_of_class((astroid.AssignName, astroid.DelName, astroid.Name),
                                                 astroid.FunctionDef)

--- a/tests/test_custom_checkers/test_possibly_undefined_checker.py
+++ b/tests/test_custom_checkers/test_possibly_undefined_checker.py
@@ -410,6 +410,23 @@ class TestPossiblyUndefinedChecker(pylint.testutils.CheckerTestCase):
         self.checker.visit_functiondef(func_node)
         with self.assertNoMessages():
             self.checker.visit_name(name_node_x)
+    
+    def test_with_dict_comprehension(self):
+        src = """
+        def func(lst):
+            test = {key:val for key, val in lst}
+            key = 0
+            print(key)
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        func_node = mod.body[0]
+        # expression `key` at line `test = ...`
+        name_node_key = next(func_node.nodes_of_class(astroid.Name))
+
+        self.checker.visit_functiondef(func_node)
+        with self.assertNoMessages():
+            self.checker.visit_name(name_node_key)
 
     def test_assign(self):
         src = """


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->
In the previous bug fix for the possibly undefined checker, the DictComp object case was being incorrectly processed. This PR fixes it.

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here: -->
<!--- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->
**Description**: DictComp object does not have  `elt` property, instead the `key` and `value` properties is used.

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
