### PR TITLE
Let PlainReporter and its subclasses set relative paths using `set_output_filepath`

### DIFF
--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -73,7 +73,7 @@ def _check(module_name='', level='all', local_config='', output=None):
       - no argument -- checks the python file containing the function call.
     `level` is used to specify which checks should be made.
     `local_config` is a dict of config options or string (config file name).
-    `output` is an absolute path to capture pyta data output. Default std out.
+    `output` is an absolute or relative path to capture pyta data output. Default std out.
     """
 
     # Add reporters to an internal pylint data structure, for use with setting

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -186,7 +186,7 @@ class PlainReporter(BaseReporter):
             try:
                 output_stream = open(self._output_filepath, 'a')
             except FileNotFoundError:
-                raise IOError('path {} does not exist.'.format(output_filepath_arg))
+                raise IOError('path {} does not exist.'.format(self._output_filepath))
         print(self.filename_to_display(self.current_file_linted), file=output_stream)
         print(result, file=output_stream)
         if self._output_filepath:

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -140,8 +140,6 @@ class PlainReporter(BaseReporter):
 
         # Paths may contain system-specific or relative syntax, e.g. `~`, `../`
         correct_path = os.path.expanduser(output_filepath_arg)
-        if not os.path.exists(os.path.dirname(correct_path)):
-            raise IOError('path {} does not exist.'.format(output_filepath_arg))
         if os.path.isdir(correct_path):
             correct_path = os.path.join(correct_path, OUTPUT_FILENAME)
 
@@ -185,7 +183,10 @@ class PlainReporter(BaseReporter):
 
         output_stream = sys.stdout
         if self._output_filepath:
-            output_stream = open(self._output_filepath, 'a')
+            try:
+                output_stream = open(self._output_filepath, 'a')
+            except FileNotFoundError:
+                raise IOError('path {} does not exist.'.format(output_filepath_arg))
         print(self.filename_to_display(self.current_file_linted), file=output_stream)
         print(result, file=output_stream)
         if self._output_filepath:


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

the `python_ta` module's `check_all` was previously raising an error when a relative path was passed into `output=`, which aligned with the given docstring. This PR aims at changing the "absolute-path-only" restriction to allow relative paths to be passed in as well.
This also plays in to #711 as it would be inconvenient to require an absolute path for just producing the HTML in the root directory but also inconvenient to preserve the current behavior of _only_ outputting to the root directory. The relative pathing helps solve both of these inconveniences. 

## Your Changes

<!-- Describe your changes here. -->
**Description**:
`PlainReporter`'s `set_output_filepath` no longer raises its previous `IOError` when an absolute path does not exist. The file check was moved to the actual file creation in `print_messages` where the error will now be raised if Python cannot find the given directory/file when attempting to open it.
Also updated the docstring of `_check`'s output parameter appropriately. 

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

`sandbox.py` contents
```python
import os

import python_ta

plain_reporter_config = {'pyta-reporter': 'PlainReporter'}
color_reporter_config = {'pyta-reporter': 'ColorReporter'}

absolute_path = r"..."  # absolute path on local device

python_ta.check_all(config=plain_reporter_config, output='plain_report')
python_ta.check_all(config=color_reporter_config, output='color_report')

python_ta.check_all(config=plain_reporter_config,
                    output=os.path.join(absolute_path, 'plain_report'))
python_ta.check_all(config=color_reporter_config,
                    output=os.path.join(absolute_path, 'color_report'))

python_ta.check_all(config=plain_reporter_config,
                    output=r"lijsef asdkfj\faskldjf")  # invalid path
```

^^^ THIS WILL CREATE FILES WITHOUT DELETING THEM. ^^^

File structure
```
pyta
|
python_ta
    |
    reporters
        |
        plain_reporter.py
        color_reporter.py
sandbox.py  # untracked file in root dir used for testing
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
