### PR TITLE
Allowing Helper Methods to be called from __init__

### DIFF
--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -180,8 +180,15 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
+
         try:
             r = _check_function_contracts(wrapped, instance, args, kwargs)
+
+            previous_frame = inspect.currentframe().f_back
+            call_site_name = inspect.getframeinfo(previous_frame).function
+            if call_site_name == "__init__":
+                return r
+
             _check_class_type_annotations(klass, instance)
             klass_mod = sys.modules.get(klass.__module__)
             if klass_mod is not None:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -201,19 +201,12 @@ def _instance_init_in_callstack(instance) -> bool:
     """
     frame = inspect.currentframe().f_back
     while frame:
-        if _frame_is_klass_init(frame, instance):
+        frame_context_name = inspect.getframeinfo(frame).function
+        frame_context_self = frame.f_locals.get('self', None)
+        if frame_context_name == '__init__' and frame_context_self == instance:
             return True
         frame = frame.f_back
     return False
-
-
-def _frame_is_klass_init(frame, instance) -> bool:
-    """Return whether the frame is an __init__ for instance
-    """
-    frame_info = inspect.getframeinfo(frame)
-    frame_context_name = frame_info.function
-    frame_context_self = frame.f_locals.get('self', None)
-    return frame_context_name == '__init__' and frame_context_self == instance
 
 
 def _check_class_type_annotations(klass: type, instance: Any) -> None:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -180,13 +180,10 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
 
     @wrapt.decorator
     def wrapper(wrapped, instance, args, kwargs):
-
         try:
             r = _check_function_contracts(wrapped, instance, args, kwargs)
-
             if _instance_init_in_callstack(instance):
                 return r
-
             _check_class_type_annotations(klass, instance)
             klass_mod = sys.modules.get(klass.__module__)
             if klass_mod is not None:
@@ -206,15 +203,12 @@ def _instance_init_in_callstack(instance) -> bool:
     while frame:
         if _frame_is_klass_init(frame, instance):
             return True
-
         frame = frame.f_back
     return False
 
 
 def _frame_is_klass_init(frame, instance) -> bool:
-    """Return whether the frame is the content of klass' init
-
-    Inspect frame's module -> module classes -> class methods -> crosscheck methods with klass init
+    """Return whether the frame is an __init__ for instance
     """
     frame_info = inspect.getframeinfo(frame)
     frame_context_name = frame_info.function

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -356,5 +356,6 @@ def test_no_premature_check_from_deep_helper_in_init() -> None:
     assert dark_widget.primary_color == "black"
     assert dark_widget.secondary_color == "mahogany"
 
+
 if __name__ == '__main__':
     pytest.main(['test_class_contracts.py'])

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -310,13 +310,25 @@ class ThemedWidget:
     - self.primary_color.isalpha()
     - self.secondary_color.isalpha()
     """
+    size: int
     theme: str
     primary_color: str
     secondary_color: str
 
-    def __init__(self, theme: str, color_palette: Tuple[str, str]):
+    def __init__(self, theme: str, color_palette: Tuple[str, str], options: dict = None):
+        if options:
+            self.setup_options(options)
+        else:
+            self.size = 5
         self.apply_theme(theme)
         self.apply_color_palette(color_palette)
+
+    def setup_options(self, options: dict):
+        if 'size' in options:
+            self.setup_size(options['size'])
+
+    def setup_size(self, size: int):
+        self.size = size
 
     def apply_theme(self, theme: str):
         self.theme = theme
@@ -325,15 +337,24 @@ class ThemedWidget:
         self.primary_color, self.secondary_color = color_palette
 
 
-def test_no_premature_check_from_init() -> None:
+def test_no_premature_check_from_helper_in_init() -> None:
     """Test that representation invariants and type annotations of a class still being
-    initialized are not checked
+    initialized are not checked when a helper called directly from the init returns
     """
     dark_widget = ThemedWidget("dark", ("black", "mahogany"))
     assert dark_widget.theme == "dark"
     assert dark_widget.primary_color == "black"
     assert dark_widget.secondary_color == "mahogany"
 
+
+def test_no_premature_check_from_deep_helper_in_init() -> None:
+    """Test that representation invariants and type annotations of a class still being
+    initialized are not checked when a helper of any depth from the init returns
+    """
+    dark_widget = ThemedWidget("dark", ("black", "mahogany"), options={"size": 10})
+    assert dark_widget.theme == "dark"
+    assert dark_widget.primary_color == "black"
+    assert dark_widget.secondary_color == "mahogany"
 
 if __name__ == '__main__':
     pytest.main(['test_class_contracts.py'])

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import pytest
 import math
 from python_ta.contracts import check_all_contracts
-from typing import List, Set, Tuple
+from typing import List, Set, Tuple, Dict
 
 
 def is_valid_name(name):
@@ -306,7 +306,7 @@ def test_override_len_simple() -> None:
 class ThemedWidget:
     """
     Representation Invariants:
-    - self.theme.lower() in {"dark", "light"}
+    - self.theme.lower() in {'dark', 'light'}
     - self.primary_color.isalpha()
     - self.secondary_color.isalpha()
     """
@@ -315,7 +315,7 @@ class ThemedWidget:
     primary_color: str
     secondary_color: str
 
-    def __init__(self, theme: str, color_palette: Tuple[str, str], options: dict = None):
+    def __init__(self, theme: str, color_palette: Tuple[str, str], options: Dict = None) -> None:
         if options:
             self.setup_options(options)
         else:
@@ -323,11 +323,11 @@ class ThemedWidget:
         self.apply_theme(theme)
         self.apply_color_palette(color_palette)
 
-    def setup_options(self, options: dict):
+    def setup_options(self, options: Dict) -> None:
         if 'size' in options:
             self.setup_size(options['size'])
 
-    def setup_size(self, size: int):
+    def setup_size(self, size: int) -> None:
         self.size = size
 
     def apply_theme(self, theme: str):
@@ -341,20 +341,20 @@ def test_no_premature_check_from_helper_in_init() -> None:
     """Test that representation invariants and type annotations of a class still being
     initialized are not checked when a helper called directly from the init returns
     """
-    dark_widget = ThemedWidget("dark", ("black", "mahogany"))
-    assert dark_widget.theme == "dark"
-    assert dark_widget.primary_color == "black"
-    assert dark_widget.secondary_color == "mahogany"
+    dark_widget = ThemedWidget('dark', ('black', 'mahogany'))
+    assert dark_widget.theme == 'dark'
+    assert dark_widget.primary_color == 'black'
+    assert dark_widget.secondary_color == 'mahogany'
 
 
 def test_no_premature_check_from_deep_helper_in_init() -> None:
     """Test that representation invariants and type annotations of a class still being
     initialized are not checked when a helper of any depth from the init returns
     """
-    dark_widget = ThemedWidget("dark", ("black", "mahogany"), options={"size": 10})
-    assert dark_widget.theme == "dark"
-    assert dark_widget.primary_color == "black"
-    assert dark_widget.secondary_color == "mahogany"
+    dark_widget = ThemedWidget('dark', ('black', 'mahogany'), options={'size': 10})
+    assert dark_widget.theme == 'dark'
+    assert dark_widget.primary_color == 'black'
+    assert dark_widget.secondary_color == 'mahogany'
 
 
 if __name__ == '__main__':

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import pytest
 import math
 from python_ta.contracts import check_all_contracts
-from typing import List, Set
+from typing import List, Set, Tuple
 
 
 def is_valid_name(name):
@@ -13,7 +13,7 @@ class Person:
     """
     Represent a person.
 
-    Representation Invariants: 
+    Representation Invariants:
     - self.age > 0
     - len(self.name) > 0
     - is_valid_name(self.name)
@@ -43,7 +43,7 @@ class Person:
         self.age = -10
         self.age = age
         return age
-    
+
     def add_fav_food(self, food):
         self.fav_foods.append(food)
 
@@ -301,6 +301,38 @@ def test_override_len_simple() -> None:
     """Test that we can instantiate OverrideLen, which has a custom __len__ implementation.
     """
     OverrideLen()
+
+
+class ThemedWidget:
+    """
+    Representation Invariants:
+    - self.theme.lower() in {"dark", "light"}
+    - self.primary_color.isalpha()
+    - self.secondary_color.isalpha()
+    """
+    theme: str
+    primary_color: str
+    secondary_color: str
+
+    def __init__(self, theme: str, color_palette: Tuple[str, str]):
+        self.apply_theme(theme)
+        self.apply_color_palette(color_palette)
+
+    def apply_theme(self, theme: str):
+        self.theme = theme
+
+    def apply_color_palette(self, color_palette: Tuple[str, str]):
+        self.primary_color, self.secondary_color = color_palette
+
+
+def test_no_premature_check_from_init() -> None:
+    """Test that representation invariants and type annotations of a class still being
+    initialized are not checked
+    """
+    dark_widget = ThemedWidget("dark", ("black", "mahogany"))
+    assert dark_widget.theme == "dark"
+    assert dark_widget.primary_color == "black"
+    assert dark_widget.secondary_color == "mahogany"
 
 
 if __name__ == '__main__':

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -330,10 +330,10 @@ class ThemedWidget:
     def setup_size(self, size: int) -> None:
         self.size = size
 
-    def apply_theme(self, theme: str):
+    def apply_theme(self, theme: str) -> None:
         self.theme = theme
 
-    def apply_color_palette(self, color_palette: Tuple[str, str]):
+    def apply_color_palette(self, color_palette: Tuple[str, str]) -> None:
         self.primary_color, self.secondary_color = color_palette
 
 

--- a/tests/test_subclass_contracts.py
+++ b/tests/test_subclass_contracts.py
@@ -82,20 +82,6 @@ class TeamMember:
     def __init__(self, team):
         self.team = team
 
-    def change_team(self, team):
-        self.team = team
-
-
-class ComplexMember(TeamMember):
-    """
-    Represents a person who may have complex logic behind what team they should be placed in.
-    """
-
-    def __init__(self, team):
-        super().__init__(team)
-        self.change_team("")
-        self.team = team
-
 
 class TeamLead(Developer, TeamMember):
     """

--- a/tests/test_subclass_contracts.py
+++ b/tests/test_subclass_contracts.py
@@ -207,17 +207,5 @@ def test_call_super_creates_temp_invalid(pe_bio_teacher):
             pe_bio_teacher.wage_per_class * len(pe_bio_teacher.currently_teaching))
 
 
-def test_helper_from_init_violates_if_initialized():
-    """
-    Call an instance method defined in the super (assumed to be already initialized) which will
-    violate said super's representation invariants but remedies the violation post-method call.
-    Expects an exception.
-    """
-    with pytest.raises(AssertionError) as excinfo:
-        teamless_member = ComplexMember("PyTA")
-    msg = str(excinfo.value)
-    assert 'len(self.team) > 0' in msg
-
-
 if __name__ == '__main__':
     pytest.main(['test_subclass_contracts.py'])

--- a/tests/test_subclass_contracts.py
+++ b/tests/test_subclass_contracts.py
@@ -217,3 +217,7 @@ def test_helper_from_init_violates_if_initialized():
         teamless_member = ComplexMember("PyTA")
     msg = str(excinfo.value)
     assert 'len(self.team) > 0' in msg
+
+
+if __name__ == '__main__':
+    pytest.main(['test_subclass_contracts.py'])

--- a/tests/test_subclass_contracts.py
+++ b/tests/test_subclass_contracts.py
@@ -163,7 +163,7 @@ def test_change_teamlead_name(teamlead):
 
 def test_change_teamlead_team_invalid(teamlead):
     """
-    Changes the team of the teamlead to something invalid. Expects an exception.
+    Changes the team of the teamlead to something invalid. Excpects an exception.
     """
     with pytest.raises(AssertionError) as excinfo:
         teamlead.team = ''
@@ -191,7 +191,3 @@ def test_call_super_creates_temp_invalid(pe_bio_teacher):
     assert len(pe_bio_teacher.currently_teaching) == 3
     assert (pe_bio_teacher.wage ==
             pe_bio_teacher.wage_per_class * len(pe_bio_teacher.currently_teaching))
-
-
-if __name__ == '__main__':
-    pytest.main(['test_subclass_contracts.py'])

--- a/tests/test_subclass_contracts.py
+++ b/tests/test_subclass_contracts.py
@@ -82,6 +82,20 @@ class TeamMember:
     def __init__(self, team):
         self.team = team
 
+    def change_team(self, team):
+        self.team = team
+
+
+class ComplexMember(TeamMember):
+    """
+    Represents a person who may have complex logic behind what team they should be placed in.
+    """
+
+    def __init__(self, team):
+        super().__init__(team)
+        self.change_team("")
+        self.team = team
+
 
 class TeamLead(Developer, TeamMember):
     """
@@ -163,7 +177,7 @@ def test_change_teamlead_name(teamlead):
 
 def test_change_teamlead_team_invalid(teamlead):
     """
-    Changes the team of the teamlead to something invalid. Excpects an exception.
+    Changes the team of the teamlead to something invalid. Expects an exception.
     """
     with pytest.raises(AssertionError) as excinfo:
         teamlead.team = ''
@@ -191,3 +205,15 @@ def test_call_super_creates_temp_invalid(pe_bio_teacher):
     assert len(pe_bio_teacher.currently_teaching) == 3
     assert (pe_bio_teacher.wage ==
             pe_bio_teacher.wage_per_class * len(pe_bio_teacher.currently_teaching))
+
+
+def test_helper_from_init_violates_if_initialized():
+    """
+    Call an instance method defined in the super (assumed to be already initialized) which will
+    violate said super's representation invariants but remedies the violation post-method call.
+    Expects an exception.
+    """
+    with pytest.raises(AssertionError) as excinfo:
+        teamless_member = ComplexMember("PyTA")
+    msg = str(excinfo.value)
+    assert 'len(self.team) > 0' in msg


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This PR aims at fixing the unintended behavior where calling a helper method from the `__init__` method would prematurely check class post-conditions (class type annotations and representation invariants). This is unintended behavior as a class should be allowed to initialize before having these conditions checked.

## Your Changes

<!-- Describe your changes here. -->
**Description**:
Added extra check layer between method call and post-condition check. The additional check iterates up the call-stack to see whether the `__init__` for the method's instance exists--if said `__init__` does exist then it follows that the instance is still being initialized hence the post-condition check should be skipped.

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Added test suite to `tests/test_class_contracts.py` (part of PR).

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

Note: this PR is overly strict in the sense that already-initialized parent class contracts can still be violated under the hood due to the check skipping if the instance as a whole is being initialized--not the specific class the called method was defined in. This could be a possible issue due to a situation where a subclass uses its parent's initialization helper but violates said parent's representation invariants. Even if the specific violation is remedied in the subclass, this situation may cause the parent functionality to malfunction entirely as the invariants were violated once outside of class-internally-defined behavior.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
