### PR TITLE
Modify default renderer for FunctionDef and ClassDef

### DIFF
--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -14,13 +14,14 @@ def render_generic(msg, source_lines=None):
     if hasattr(msg, 'node') and msg.node is not None:
         node = msg.node
         start_line, start_col = node.fromlineno, node.col_offset
-        end_line, end_col = node.end_lineno, node.end_col_offset
+
+        if isinstance(node, astroid.FunctionDef) or isinstance(node, astroid.ClassDef):
+            end_line, end_col = start_line, None
+        else:
+            end_line, end_col = node.end_lineno, node.end_col_offset
 
         # Display up to 2 lines before node for context:
         yield from render_context(start_line - 2, start_line, source_lines)
-
-        if isinstance(node, astroid.FunctionDef) or isinstance(node, astroid.ClassDef):
-            end_line = start_line
 
         if start_line == end_line:
             yield (start_line, slice(start_col, end_col), LineType.ERROR, source_lines[start_line-1])

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -19,6 +19,9 @@ def render_generic(msg, source_lines=None):
         # Display up to 2 lines before node for context:
         yield from render_context(start_line - 2, start_line, source_lines)
 
+        if isinstance(node, astroid.FunctionDef) or isinstance(node, astroid.ClassDef):
+            end_line = start_line
+
         if start_line == end_line:
             yield (start_line, slice(start_col, end_col), LineType.ERROR, source_lines[start_line-1])
         else:

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -15,7 +15,7 @@ def render_generic(msg, source_lines=None):
         node = msg.node
         start_line, start_col = node.fromlineno, node.col_offset
 
-        if isinstance(node, astroid.FunctionDef) or isinstance(node, astroid.ClassDef):
+        if isinstance(node, (astroid.FunctionDef, astroid.ClassDef)):
             end_line, end_col = start_line, None
         else:
             end_line, end_col = node.end_lineno, node.end_col_offset


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This pull request modifies the default renderer so that it no longer highlights the entire function or class when displaying the error message. 

## Your Changes

<!-- Describe your changes here. -->
**Description**:

In `render_generic()` an additional case was added for FunctionDef/ClassDef and assigns end_line, end_col accordingly so that a single line will be highlighted and display up to 2 lines above/below. 

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Ran PythonTA on E0102 and E0239 code examples (messages that have a FunctionDef or ClassDef node attribute) to observe the output

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the TravisCI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
