### PR TITLE
Add dropdown arrows

### DIFF
--- a/python_ta/reporters/templates/script.js
+++ b/python_ta/reporters/templates/script.js
@@ -1,6 +1,6 @@
 $("body").on("click", ".slider", function () {
     $(this).parent().next().toggleClass("hide-and-maintain-width");
-    $(this).children().children().toggleClass("collapsed");
+    $(this).children().toggleClass("collapsed");
 });
 
 //$(".collapsible").on("click", ".collapse-trigger", function (evt) {

--- a/python_ta/reporters/templates/script.js
+++ b/python_ta/reporters/templates/script.js
@@ -1,3 +1,9 @@
 $("body").on("click", ".slider", function () {
     $(this).parent().next().toggleClass("hide-and-maintain-width");
+    $(this).children().children().toggleClass("collapsed");
 });
+
+//$(".collapsible").on("click", ".collapse-trigger", function (evt) {
+//    $(this).closest(".collapsible").children("ul").toggle()
+//    $(this).toggleClass("collapsed")
+//});

--- a/python_ta/reporters/templates/script.js
+++ b/python_ta/reporters/templates/script.js
@@ -2,8 +2,3 @@ $("body").on("click", ".slider", function () {
     $(this).parent().next().toggleClass("hide-and-maintain-width");
     $(this).children().toggleClass("collapsed");
 });
-
-//$(".collapsible").on("click", ".collapse-trigger", function (evt) {
-//    $(this).closest(".collapsible").children("ul").toggle()
-//    $(this).toggleClass("collapsed")
-//});

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -197,6 +197,7 @@ section {
 .slider button {
     background: none;
     border: none;
+    cursor: pointer;
 }
 
 .slider button:hover {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -177,14 +177,17 @@ section {
 .slider {
     margin-left: auto;
 }
+.slider button {
+    background: none;
+    border: none;
+}
 
-.slider svg:hover {
+.slider button:hover {
     filter: brightness(120%);
 }
 
-svg.collapsed {
-    transform-origin: center;
-    transform: rotateX(180deg) translateY(-6px);
+button.collapsed {
+    transform: scaleY(-1);
 }
 
 .collapsible {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -74,6 +74,8 @@ section {
 .category-heading {
     display: flex;  /*Narrow width viewports*/
     -webkit-font-smoothing: antialiased;
+    align-items: center;
+    margin-top: 7px;
 }
 
 .error-instance {
@@ -182,7 +184,7 @@ section {
 
 svg.collapsed {
     transform-origin: center;
-    transform: rotateX(180deg);
+    transform: rotateX(180deg) translateY(-6px);
 }
 
 .collapsible {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -176,21 +176,13 @@ section {
     margin-left: auto;
 }
 
-.slider button {
-    cursor: pointer;
-    background: #427fed;
-    border: 1px solid transparent;
-    border-radius: 2px;
-    padding: 4px 12px;
-    min-width: 54px;
-    margin-left: 16px;
-    color: #fff;
-    font-weight: bold;
-    -webkit-font-smoothing: antialiased;
-    font-size: 12px;
+.slider svg:hover {
+    background-color: #fff;
 }
-.slider button:hover {
-    text-decoration: underline;
+
+svg .collapsed {
+    transform-origin: center;
+    transform: rotate(180deg);
 }
 
 .collapsible {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -180,6 +180,7 @@ section {
 .slider button {
     background: none;
     border: none;
+    cursor: pointer;
 }
 
 .slider button:hover {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -177,12 +177,12 @@ section {
 }
 
 .slider svg:hover {
-    background-color: #fff;
+    filter: invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%);
 }
 
-svg .collapsed {
+svg.collapsed {
     transform-origin: center;
-    transform: rotate(180deg);
+    transform: rotateX(180deg);
 }
 
 .collapsible {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -177,7 +177,7 @@ section {
 }
 
 .slider svg:hover {
-    filter: invert(27%) sepia(51%) saturate(2878%) hue-rotate(346deg) brightness(104%) contrast(97%);
+    filter: brightness(120%);
 }
 
 svg.collapsed {

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -180,7 +180,6 @@ section {
 .slider button {
     background: none;
     border: none;
-    cursor: pointer;
 }
 
 .slider button:hover {

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -23,7 +23,12 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
-                            <button>Expand/Collapse Section</button>
+                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer">
+                                <g transform="scale(0.13 0.13)">
+                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#427fed" stroke-width="15px"
+                                        fill="transparent"/>
+                                </g>
+                            </svg>
                         </span>
                     </h3>
                     <div class="content collapsible">
@@ -58,7 +63,12 @@
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                         <span class="slider">
-                                            <button style="float: right; background: #458B00;"> Expand/Collapse </button>
+                                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
+                                                <g transform="scale(0.13 0.13)">
+                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#458B00" stroke-width="15px"
+                                                        fill="transparent"/>
+                                                </g>
+                                            </svg>
                                         </span>
                                     </h4>
                                     {% if indiv.snippet != '' %}
@@ -81,7 +91,12 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.style_err_title }}</span>
                         <span class="slider">
-                            <button>Expand/Collapse Section</button>
+                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer">
+                                <g transform="scale(0.13 0.13)">
+                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#427fed" stroke-width="15px"
+                                        fill="transparent"/>
+                                </g>
+                            </svg>
                         </span>
                     </h3>
                     <div class="content collapsible">

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -23,7 +23,7 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
-                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer">
+                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer"> <!-- UWU -->
                                 <g transform="scale(0.13 0.13)">
                                     <path d="M 10 30 l 40 40 l 40 -40" stroke="#427fed" stroke-width="15px"
                                         fill="transparent"/>

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -23,12 +23,13 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
-                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer"> <!-- Dropdown arrows are from FontAwesome under License: https://fontawesome.com/license -->
-                                <g transform="scale(0.13 0.13)">
-                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
-                                        fill="transparent"/>
-                                </g>
-                            </svg>
+                            <button>
+                                <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30"> <!-- Dropdown arrows are from FontAwesome under License: https://fontawesome.com/license -->
+                                    <g transform="scale(0.13 0.13)">
+                                        <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px" fill="transparent"/>
+                                    </g>
+                                </svg>
+                            </button>
                         </span>
                     </h3>
                     <div class="content collapsible">
@@ -54,12 +55,13 @@
                                 {% endif %}
                                 </span>
                                 <span class="slider">
-                                    <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
-                                        <g transform="scale(0.13 0.13)">
-                                            <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
-                                                fill="transparent"/>
-                                        </g>
-                                    </svg>
+                                    <button>
+                                        <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30">
+                                            <g transform="scale(0.13 0.13)">
+                                                <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px" fill="transparent"/>
+                                            </g>
+                                        </svg>
+                                    </button>
                                 </span>
                             </div>
                             <div class="message-container collapsible">
@@ -68,12 +70,13 @@
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                         <span class="slider">
-                                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
-                                                <g transform="scale(0.13 0.13)">
-                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px"
-                                                        fill="transparent"/>
-                                                </g>
-                                            </svg>
+                                            <button style="float: right;">
+                                                <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="20">
+                                                    <g transform="scale(0.13 0.13)">
+                                                        <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px" fill="transparent"/>
+                                                    </g>
+                                                </svg>
+                                            </button>
                                         </span>
                                     </h4>
                                     {% if indiv.snippet != '' %}
@@ -96,12 +99,13 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.style_err_title }}</span>
                         <span class="slider">
-                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer">
-                                <g transform="scale(0.13 0.13)">
-                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
-                                        fill="transparent"/>
-                                </g>
-                            </svg>
+                            <button>
+                                <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30">
+                                    <g transform="scale(0.13 0.13)">
+                                        <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px" fill="transparent"/>
+                                    </g>
+                                </svg>
+                            </button>
                         </span>
                     </h3>
                     <div class="content collapsible">
@@ -127,12 +131,13 @@
                                 {% endif %}
                                 </span>
                                 <span class="slider">
-                                    <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
-                                        <g transform="scale(0.13 0.13)">
-                                            <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
-                                                fill="transparent"/>
-                                        </g>
-                                    </svg>
+                                    <button>
+                                        <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30">
+                                            <g transform="scale(0.13 0.13)">
+                                                <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px" fill="transparent"/>
+                                            </g>
+                                        </svg>
+                                    </button>
                                 </span>
                             </div>
 
@@ -142,12 +147,14 @@
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                         <span class="slider">
-                                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer; float: right;">
-                                                <g transform="scale(0.13 0.13)">
-                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px"
-                                                        fill="transparent"/>
-                                                </g>
-                                            </svg>
+                                            <button style="float: right;">
+                                                <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="20">
+                                                    <g transform="scale(0.13 0.13)">
+                                                        <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px"
+                                                            fill="transparent"/>
+                                                    </g>
+                                                </svg>
+                                            </button>
                                         </span>
                                     </h4>
                                     <div class="collapsible">

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -23,9 +23,9 @@
                     <h3 class="category-heading">
                         <span>{{ reporter.code_err_title }}</span>
                         <span class="slider">
-                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer"> <!-- UWU -->
+                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer"> <!-- Dropdown arrows are from FontAwesome under License: https://fontawesome.com/license -->
                                 <g transform="scale(0.13 0.13)">
-                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#427fed" stroke-width="15px"
+                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
                                         fill="transparent"/>
                                 </g>
                             </svg>
@@ -54,7 +54,12 @@
                                 {% endif %}
                                 </span>
                                 <span class="slider">
-                                    <button> Expand/Collapse </button>
+                                    <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
+                                        <g transform="scale(0.13 0.13)">
+                                            <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
+                                                fill="transparent"/>
+                                        </g>
+                                    </svg>
                                 </span>
                             </div>
                             <div class="message-container collapsible">
@@ -65,7 +70,7 @@
                                         <span class="slider">
                                             <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
                                                 <g transform="scale(0.13 0.13)">
-                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#458B00" stroke-width="15px"
+                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px"
                                                         fill="transparent"/>
                                                 </g>
                                             </svg>
@@ -93,7 +98,7 @@
                         <span class="slider">
                             <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="30" style="cursor: pointer">
                                 <g transform="scale(0.13 0.13)">
-                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#427fed" stroke-width="15px"
+                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
                                         fill="transparent"/>
                                 </g>
                             </svg>
@@ -122,7 +127,12 @@
                                 {% endif %}
                                 </span>
                                 <span class="slider">
-                                   <button> Expand/Collapse </button>
+                                    <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer">
+                                        <g transform="scale(0.13 0.13)">
+                                            <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px"
+                                                fill="transparent"/>
+                                        </g>
+                                    </svg>
                                 </span>
                             </div>
 
@@ -132,7 +142,12 @@
                                     <h4 class="message-name">
                                         [Line {{ indiv.line }}] {{ indiv.msg }}
                                         <span class="slider">
-                                            <button style="float: right; background: #458B00;"> Expand/Collapse </button>
+                                            <svg class="collapse-trigger" viewBox="0 0 10 10" width="60" height="20" style="cursor: pointer; float: right;">
+                                                <g transform="scale(0.13 0.13)">
+                                                    <path d="M 10 30 l 40 40 l 40 -40" stroke="#777777" stroke-width="15px"
+                                                        fill="transparent"/>
+                                                </g>
+                                            </svg>
                                         </span>
                                     </h4>
                                     <div class="collapsible">


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Creates a cleaner, simpler, and more intuitive graphical way to show the expand and collapse feature of the sections.
Implements the dropdown arrows from issue #730 

## Your Changes

<!-- Describe your changes here. -->
**Description**:
Changed the expand/collapse buttons into chevron SVG graphic. In addition, added functionality so that the graphic would flip based off of its collapsed state. (Faces up when closed, faces down when content is shown below.)

before:
![image](https://user-images.githubusercontent.com/35227285/127319735-912812c4-ecf9-464c-b5f2-9f508d0ffb34.png)
 
after change:
![image](https://user-images.githubusercontent.com/35227285/127319937-6074f5f0-5ad0-4f7a-b1c9-6ef9ff33bcfe.png) ![image](https://user-images.githubusercontent.com/35227285/127320049-a112745b-2e8d-4150-82a4-2f4c006194b9.png)
![image](https://user-images.githubusercontent.com/35227285/127320470-03e7ccd4-73ea-456d-80c1-4929048fdea0.png)


**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
Tested by running `python_ta.check_all()` to see how the final template ends up rendering with a file.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
