### PR TITLE
Remove incorrect license reference

### DIFF
--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -63,7 +63,7 @@
                             <span>{{ reporter.code_err_title }}</span>
                             <span class="slider">
                                 <button>
-                                    <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30"> <!-- Dropdown arrows are from FontAwesome under License: https://fontawesome.com/license -->
+                                    <svg class="collapse-trigger" viewBox="0 1 10 10" width="60" height="30">
                                         <g transform="scale(0.13 0.13)">
                                             <path d="M 10 30 l 40 40 l 40 -40" stroke="#3669c7" stroke-width="15px" fill="transparent"/>
                                         </g>


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
Due to a misunderstanding with where the dropdown arrow we ended up using came from, font awesome was improperly credited for the dropdown arrows. @ckatsube made the SVG arrow currently in the reporter template.

## Your Changes

<!-- Describe your changes here. -->
**Description**:
Remove the reference to the font awesome license.

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 
- [x] Refactoring (internal change to codebase, without changing functionality)

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
