### PR TITLE
Added Hyperlinks to Table of Contents

### DIFF
--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -79,7 +79,7 @@ class HTMLReporter(PythonTaReporter):
         # Render the jinja template
         rendered_template = template.render(date_time=dt, reporter=self,
                                             grouped_messages=grouped_messages,
-                                            os=os)
+                                            os=os, enumerate=enumerate)
 
         # If a filepath was specified, write to the file
         if self.out is not sys.stdout:

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -36,6 +36,15 @@ header {
     overscroll-behavior-y: contain;
 }
 
+.sidebar a:link, a:visited {
+    color: inherit;
+    text-decoration: none;
+}
+
+.sidebar a:hover {
+    text-decoration: underline;
+}
+
 code {
     white-space: pre;
     font-size: 120%;

--- a/python_ta/reporters/templates/template.html
+++ b/python_ta/reporters/templates/template.html
@@ -16,10 +16,12 @@
             <section class="sidebar">
                 <h2>Table of Contents</h2>
                 <ul>
-                    {% for filename, messages in grouped_messages.items() %}
+                    {% for filenum, (filename, messages) in enumerate(grouped_messages.items()) %}
                     <li>
                         <span>
-                            {{os.path.basename(filename)}}
+                            <a href={{'#{}'.format(filenum)}}>
+                                {{os.path.basename(filename)}}
+                            </a>
                         </span>
                         <ul>
                             <li>
@@ -29,7 +31,9 @@
                                 <ul>
                                     {% for message_id in messages[0] %}
                                     <li>
-                                        {{'{} - {}'.format(message_id, messages[0][message_id][0].symbol)}}
+                                        <a href={{'#{}-{}'.format(filenum, message_id)}}>
+                                            {{'{} - {}'.format(message_id, messages[0][message_id][0].symbol)}}
+                                        </a>
                                     </li>
                                     {% endfor %}
                                 </ul>
@@ -41,7 +45,9 @@
                                 <ul>
                                     {% for message_id in messages[1] %}
                                     <li>
-                                        {{'{} - {}'.format(message_id, messages[1][message_id][0].symbol)}}
+                                        <a href={{'#{}-{}'.format(filenum, message_id)}}>
+                                            {{'{} - {}'.format(message_id, messages[1][message_id][0].symbol)}}
+                                        </a>
                                     </li>
                                     {% endfor %}
                                 </ul>
@@ -53,8 +59,8 @@
             </section>
             <main>
                 {% set limit = reporter.linter.config.pyta_number_of_messages %}
-                {% for filename, messages in grouped_messages.items() %}
-                <section>
+                {% for filenum, (filename, messages) in enumerate(grouped_messages.items()) %}
+                <section id={{filenum}}>
                     <article class="file-name">
                         <h2> {{ filename }} </h2>
                     </article>
@@ -74,7 +80,7 @@
                         <div class="content collapsible">
                             {% for message_id in messages[0] %}
                                 {% set occurrences = messages[0][message_id] %}
-                            <div class="error-instance">
+                            <div class="error-instance" id={{'{}-{}'.format(filenum, message_id)}}>
                                 <div class="info">
                                     <span class="error-link code-error-id">
                                         <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message_id}}" target="_blank">&#10064; {{ message_id }} ({{ occurrences[0].symbol }})</a>
@@ -149,7 +155,7 @@
                         </h3>
                         <div class="content collapsible">
                             {% for message_id, occurrences in messages[1].items() %}
-                            <div class="error-instance">
+                            <div class="error-instance" id={{'{}-{}'.format(filenum, message_id)}}>
                                 <div class="info">
                                     <span class="error-link style-error-id">
                                         <a href="http://www.cs.toronto.edu/~david/pyta/&#35;{{message_id}}" target="_blank">&#10064; {{ message_id }} ({{ occurrences[0].symbol }})</a>


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Added internal hyperlinks to table of contents to navigate through large reports more quickly. (Part of #730)

## Your Changes

<!-- Describe your changes here. -->
**Description**:
Added ids to each file's report section and to each error instance. The naming scheme for each file is just the report # and the error instance is the report # followed by the error message's id.
Wrapped file name and error name in toc with an anchor tag with its associated href.
Added `enumerate` to the Pythonic objects passed into the template as using `{%set count = 0%}` and its increment in the loop seemed excessive. 

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Manually created reports with multiple files and observed hyperlink behavior.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
