### PR TITLE
Make side elements disappear when zooming in 

### DIFF
--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -21,7 +21,7 @@ header {
     grid-template-rows: min-content 1fr;
 }
 
-@media screen and (max-width: 38em) {
+@media screen and (max-width: 768px) {
     .sidebar {
         display: none;
     }

--- a/python_ta/reporters/templates/stylesheet.css
+++ b/python_ta/reporters/templates/stylesheet.css
@@ -21,6 +21,15 @@ header {
     grid-template-rows: min-content 1fr;
 }
 
+@media screen and (max-width: 38em) {
+    .sidebar {
+        display: none;
+    }
+    header {
+        display: none;
+    }
+}
+
 .sidebar {
     margin-top: 0;
     margin-left: 35px;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

When zooming in, the leftmost column consisting of the header and table of contents takes space priority over the actual reports. Users with poor eyesight may want to zoom in, but are ultimately unable to see the reports when attempting to.
This PR makes the table of contents and header disappear after zooming in a certain amount, allowing the reports to be the main content on the screen.

(Part of #730)
## Your Changes

<!-- Describe your changes here. -->
**Description**:
Added media selector to make header and table of contents not display when the screen width goes under 38em (approx 600px on standard font size). 

**Type of change** (select all that apply):
<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. --> 

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Manually created reports and observed behavior when zooming (also changed browser font size).

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
