### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [2.1.0] - 2021-09-16
+
+### Enhancements
+
+- Added `line_end` and `column_end` to `JSONReporter` output.
+
 ## [2.0.0] - 2021-08-24
 
 PythonTA's adopting semantic versioning as of this release, so we've bumped the version to 2.0.

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     import python_ta
     python_ta.check_all()
 """
-__version__ = "2.1.0"  # Version number
+__version__ = "2.1.1.dev"  # Version number
 
 # First, remove underscore from builtins if it has been bound in the REPL.
 import builtins

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
     import python_ta
     python_ta.check_all()
 """
-__version__ = "2.0.1.dev"  # Version number
+__version__ = "2.1.0"  # Version number
 
 # First, remove underscore from builtins if it has been bound in the REPL.
 import builtins


### PR DESCRIPTION
This is a release for v2.1.0. The only major change is #760, mainly to be compatible with https://github.com/MarkUsProject/markus-autotesting/pull/296/.