### PR TITLE
Adding example and documentation for R1733 (Unnecessary dict index lookup)

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -605,6 +605,24 @@ for strings.
 
 ```
 
+### Unnecessary dict index lookup (R1733) [](#R1733)
+
+This error occurs when values for a dictionary are accessed using an index lookup (that is, through
+`dictionary_name[key]`) instead of directly while iterating over key-value pairs of the dictionary.
+
+```{literalinclude} /../examples/pylint/R1733_unnecessary_dict_index_lookup.py
+
+```
+
+The code above can be fixed by accessing the dictionary values directly:
+
+```python
+sample_dict = {"key_one": "value_one", "key_two": "value_two"}
+
+for key, value in sample_dict.items():
+    print(key, value)  # Direct access instead of an index lookup
+```
+
 ### Unnecessary pass (W0107) [](#W0107)
 
 This error occurs when a [`pass` statement][`pass` statements] is used that can be avoided (or has

--- a/examples/pylint/R1733_unnecessary_dict_index_lookup.py
+++ b/examples/pylint/R1733_unnecessary_dict_index_lookup.py
@@ -1,0 +1,4 @@
+sample_dict = {"key_one": "value_one", "key_two": "value_two"}
+
+for key, value in sample_dict.items():
+    print(key, sample_dict[key])  # Error on this line


### PR DESCRIPTION
## Changes

**Description**:
Adding a short example which contains the R1733 error along with supporting documentation which explains the error and also provides an example correcting R1733. The example for R1733 is present under *Code Complexity* in `index.md`, because I believe this error makes Python code less readable and thereby results in increased complexity.

**Type of change**:
- [x] Documentation update (change that modifies or updates documentation only)

## Testing
- Manually verified that the R1733 error occurs in the example file documenting this error through `pylint`.
- Ran `python -m pytest tests/test_examples.py` after creating the R1733 example file, which succeeded as well.
- Verified through `pylint` that the corrected example mentioned in documentation does not include the R1733 error.
- Ran `make html` in the `docs` directory, verifying that the documentation is created for R1733. 

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
