### PR TITLE
Adding example and documentation for W1310 (Format string without interpolation)

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -1829,6 +1829,30 @@ s = "{} and {}".format("first", "second")
 
 **See also**: [E1120](#E1120)
 
+### F-string without interpolation (W1309) [](#W1309)
+
+This error occurs when there are no interpolation variables present in an f-string. This might indicate that there is
+either a bug in the code (that is, there should be an interpolation variable in the f-string) or the f-string can be a
+normal string.
+
+```{literalinclude} /../examples/pylint/W1309_f_string_without_interpolation.py
+
+```
+
+The issue above can be resolved in 2 ways - either the f-string can be converted into a normal string, or the missing
+interpolation variable can be added to the f-string. The snippet below shows both these solutions.
+
+```python
+# Using a normal string instead of an f-string
+print('Hello World!')
+
+# Adding an interpolation to the f-string
+entity = "World"
+print(f'Hello {entity}!')
+```
+
+**See also**: [W1310](#W1310)
+
 ### Format string without interpolation (W1310) [](#W1310)
 
 This error occurs when a format string does not have **any** interpolation variables. This can be an issue as it can
@@ -1844,6 +1868,8 @@ The error above can be resolved as follows:
 ```python
 greeting = 'Hello There, {name}'.format(name='person')
 ```
+
+**See also**: [W1309](#W1309)
 
 ### Missing format argument key (W1303) [](#W1303)
 

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -1829,6 +1829,22 @@ s = "{} and {}".format("first", "second")
 
 **See also**: [E1120](#E1120)
 
+### Format string without interpolation (W1310) [](#W1310)
+
+This error occurs when a format string does not have **any** interpolation variables. This can be an issue as it can
+mean that either the string can be a normal string which does not need any formatting, or there is a bug in the code
+and there should be interpolation variables in the string.
+
+```{literalinclude} /../examples/pylint/W1310_format_string_without_interpolation.py
+
+```
+
+The error above can be resolved as follows:
+
+```python
+greeting = 'Hello There, {name}'.format(name='person')
+```
+
 ### Missing format argument key (W1303) [](#W1303)
 
 This error occurs when a format string that uses named fields does not receive the required

--- a/examples/pylint/W1310_format_string_without_interpolation.py
+++ b/examples/pylint/W1310_format_string_without_interpolation.py
@@ -1,0 +1,1 @@
+greeting = 'Hello There, '.format(name='person')  # Error on this line


### PR DESCRIPTION
## Changes
**Description**:
Adding a short example which contains the W1310 error along with supporting documentation which explains the error and contains a code sample that resolves W1310. The example can be found in the *Miscellaneous* section of `index.md`, where documentation for some other format string related pylint errors are located as well.


**Type of change**:
- [x] Documentation update (change that modifies or updates documentation only)

## Testing
- Manually verified that the W1310 error occurs in the example file documenting this error through pylint.
- Ran `python -m pytest tests/test_examples.py` after creating the W1310 example file, which succeeded as well.
- Verified through pylint that the corrected example mentioned in documentation does not include the W1310 error.
- Ran `make html` in the `docs` directory, verifying that the documentation is created for W1310.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
