### PR TITLE
html-reporter: Display file even when no errors detected

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix HTML report to display file even when no errors are found.
+
 ## [2.1.0] - 2021-09-16
 
 ### Enhancements

--- a/python_ta/reporters/core.py
+++ b/python_ta/reporters/core.py
@@ -195,6 +195,9 @@ class PythonTaReporter(BaseReporter):
         self.module_name = module
         self.current_file = filepath
 
+        if self.current_file not in self.messages:
+            self.messages[self.current_file] = []
+
         with open(filepath, encoding="utf-8") as f:
             self.source_lines = [line.rstrip() for line in f.readlines()]
 

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -43,8 +43,8 @@ class HTMLReporter(PythonTaReporter):
     }
     _PRE_LINE_NUM_SPACES = 0
 
-    no_err_message = "None!"
-    no_snippet = "Nothing here."
+    no_err_message = "No problems detected, good job!"
+    no_snippet = "No code to display for this message."
     code_err_title = "Code Errors or Forbidden Usage (fix: high priority)"
     style_err_title = "Style or Convention Errors (fix: before submission)"
     OUTPUT_FILENAME = "pyta_report.html"

--- a/python_ta/reporters/plain_reporter.py
+++ b/python_ta/reporters/plain_reporter.py
@@ -19,8 +19,8 @@ class PlainReporter(PythonTaReporter):
     _COLOURING = {}
     code_err_title = "=== Code errors/forbidden usage (fix: high priority) ==="
     style_err_title = "=== Style/convention errors (fix: before submission) ==="
-    no_err_message = "None!" + _BREAK * 2
-    no_snippet = "Nothing here." + _BREAK * 2
+    no_err_message = "No problems detected, good job!" + _BREAK * 2
+    no_snippet = "No code to display for this message." + _BREAK * 2
 
     def print_messages(self, level: str = "all") -> None:
         """Print messages for the current file.


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

When PythonTA is run on a file with no errors, the HTML reporter does not display the file, which is confusing (students aren't sure whether their file was checked). This is a regression from #727.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Update reporters so that they always register a file, even when there are no error messages for that file. Also updated the strings displayed to the user in this case, and a related string (`no_snippet`).

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Verified that the HTML report now displays files with no errors. Also ran the other reporters to verify that they print out information for files with no errors.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
