### PR TITLE
pylint: Manually create pylint cache directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Bug fixes
 
 - Fix HTML report to display file even when no errors are found.
+- Fix pylint cache directory creation (backport of change from pylint 2.11)
 
 ## [2.1.0] - 2021-09-16
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -31,6 +31,7 @@ import tokenize
 import webbrowser
 from typing import Generator
 
+import pylint.config
 import pylint.lint
 import pylint.utils
 from astroid import MANAGER, modutils
@@ -72,6 +73,15 @@ def _check(module_name="", level="all", local_config="", output=None):
     `local_config` is a dict of config options or string (config file name).
     `output` is an absolute or relative path to capture pyta data output. Default std out.
     """
+    # Manually create pylint cache directory if it doesn't exist.
+    # This is a backport of https://github.com/PyCQA/pylint/pull/4988,
+    # and should be removed once we update to pylint 2.11.
+    if not os.path.exists(pylint.config.PYLINT_HOME):
+        try:
+            os.makedirs(pylint.config.PYLINT_HOME)
+        except OSError:
+            pass
+
     linter = reset_linter(config=local_config)
     current_reporter = linter.reporter
     current_reporter.set_output(output)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Pylint version 2.10 has a bug when trying to create its cache directory: https://github.com/PyCQA/pylint/issues/4900. This causes an error message to be displayed to students, which is confusing. 

## Your Changes

<!-- Describe your changes here. -->

**Description**: While this was fixed in Pylint version 2.11, we're currently pinned to Pylint 2.10, so I backported the fix directly into our code for now. (It will be removed at the next major release of PythonTA.)

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Verified that the pylint cache directory gets created, even when its parent directory doesn't exist.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->