### PR TITLE
Dynamic postconditions check

### DIFF
--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -327,7 +327,7 @@ def _check_assertions(
 
 
 def parse_assertions(obj: Any, parse_token: str = "Precondition") -> List[str]:
-    """Return a list of preconditions/representation invariants parsed from the given entity's docstring.
+    """Return a list of preconditions/postconditions/representation invariants parsed from the given entity's docstring.
 
     Uses parse_token to determine what to look for. parse_token defaults to Precondition.
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
Postconditions provide an effective method to ensure that a function behaves as expected, and are a useful way for new programmers to be sure that a piece of code they have written is correct. This change allows programmers to add a list of checks that should be verified just after the function has executed - allowing them to specify checks on the function's return values, parameters, or other variables in the function's scope.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Changes

**Description**:
For the most part I have reused the functionality present for checking function preconditions. One major difference has been an introduction of a special variable name for the function's return value, which I have called `$return_value`. Using the `$` symbol as the first character ensures that the variable name does not conflict with any other variable that might have been declared by users. 

When evaluating a postcondition check containing the `$return_value` variable - I first replace the assertion string containing this variable with the actual return value of the function. This is because assertions are evaluated in the `_check_assertions` function (present in the `__init__.py` file of `python_ta.contracts`) using the `eval` function. Thus, using the illegal variable name `$return_value` in this expression caused an exception, which is why the replacement was needed.

**Type of change**:

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing
I have added added 2 unit tests for each of the 3 categories below. The 2 tests check an erroneous and a correct implementation of a function - the former causes the postcondition check to fail, while the latter results in the check passing:

- Expression containing the `$return_value` variable
- Expression containing function's parameters
- Expressions using functions defined by the user that should be in scope for the function

These unit tests passed, along with the unit tests already present.

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
