### PR TITLE
moved R1734 doc location

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -400,25 +400,6 @@ if True:  # Error was on this line
   pass
 ```
 
-### Use list literal (R1734) [](#R1734)
-
-This error occurs when `list()` is used instead of `[]` to create an empty list.
-
-```{literalinclude} /../examples/pylint/r1734_use_list_literal.py
-
-```
-
-The above can be modified to:
-
-```python
-lst = [1, 2, 3, 4]
-even_lst = []  # This is a fixed version.
-
-for x in lst:
-    if x % 2 == 0:
-        even_lst.append(x)
-```
-
 ### Singleton comparison (C0121) [](#C0121)
 
 This error occurs when an expression is compared to a singleton value like `True`, `False` or `None`
@@ -693,6 +674,25 @@ Corrected version:
 ```python
 with open('my_file.txt', 'r') as file:
     ... # No need to manually close the file
+```
+
+### Use list literal (R1734) [](#R1734)
+
+This error occurs when `list()` is used instead of `[]` to create an empty list.
+
+```{literalinclude} /../examples/pylint/r1734_use_list_literal.py
+
+```
+
+The above can be modified to:
+
+```python
+lst = [1, 2, 3, 4]
+even_lst = []  # This is a fixed version.
+
+for x in lst:
+    if x % 2 == 0:
+        even_lst.append(x)
 ```
 
 ### Use dict literal (R1735) [](#R1735)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

Documentation for the checkers R1734 and R1735 were located in two completely separate locations.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**:

I moved the documentation for R1734 to a location in between the documentation for R1732 and R1735.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->


- [x] Documentation update (change that modifies or updates documentation only)


## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
