### PR TITLE
CLI for python_ta.contracts

### DIFF
--- a/python_ta/contracts/__main__.py
+++ b/python_ta/contracts/__main__.py
@@ -1,0 +1,40 @@
+from typing import TextIO, Tuple
+
+import astroid
+import click
+
+
+@click.command()
+@click.argument("main", type=click.File(mode="r"))
+@click.argument("extra-mod-names", nargs=-1)
+def run_contracts(main: TextIO, extra_mod_names: Tuple):
+    contents = main.read()
+    module_node = astroid.parse(contents)
+
+    if_main = _extract_if_main(module_node)
+    import_statement = _build_import()
+    if_main.body.insert(0, import_statement)
+    contracts_call = _build_contracts_call(extra_mod_names)
+    if_main.body.insert(1, contracts_call)
+
+    modified_main_contents = module_node.as_string()
+
+    exec(modified_main_contents)
+
+
+def _build_import() -> astroid.NodeNG:
+    return astroid.extract_node("import python_ta.contracts")
+
+
+def _build_contracts_call(mod_names: Tuple) -> astroid.NodeNG:
+    mod_names_str = ", ".join((f"'{name}'" for name in mod_names))
+    return astroid.extract_node(f"python_ta.contracts.check_all_contracts({mod_names_str})")
+
+
+def _extract_if_main(module_node: astroid.Module) -> astroid.If:
+    if_nodes = module_node.nodes_of_class(astroid.If)
+    return next(node for node in if_nodes if node.test.as_string() == "__name__ == '__main__'")
+
+
+if __name__ == "__main__":
+    run_contracts()

--- a/python_ta/contracts/__main__.py
+++ b/python_ta/contracts/__main__.py
@@ -19,7 +19,7 @@ def run_contracts(main: TextIO, extra_mod_names: Tuple):
 
     modified_main_contents = module_node.as_string()
 
-    exec(modified_main_contents)
+    exec(modified_main_contents, globals())
 
 
 def _build_import() -> astroid.NodeNG:

--- a/python_ta/contracts/__main__.py
+++ b/python_ta/contracts/__main__.py
@@ -20,10 +20,11 @@ def run_contracts(main: TextIO, extra_mod_names: Tuple, no_main: bool):
     module_node = astroid.parse(contents)
 
     if_main = _extract_if_main(module_node)
-    import_statement = _build_import()
-    if_main.body.insert(0, import_statement)
-    contracts_call = _build_contracts_call(extra_mod_names, decorate_main=no_main)
-    if_main.body.insert(1, contracts_call)
+    if if_main:
+        import_statement = _build_import()
+        if_main.body.insert(0, import_statement)
+        contracts_call = _build_contracts_call(extra_mod_names, decorate_main=no_main)
+        if_main.body.insert(1, contracts_call)
 
     modified_main_contents = module_node.as_string()
 
@@ -42,7 +43,9 @@ def _build_contracts_call(mod_names: Tuple, decorate_main: bool) -> astroid.Node
 
 def _extract_if_main(module_node: astroid.Module) -> astroid.If:
     if_nodes = module_node.nodes_of_class(astroid.If)
-    return next(node for node in if_nodes if node.test.as_string() == "__name__ == '__main__'")
+    return next(
+        (node for node in if_nodes if node.test.as_string() == "__name__ == '__main__'"), None
+    )
 
 
 if __name__ == "__main__":

--- a/python_ta/contracts/__main__.py
+++ b/python_ta/contracts/__main__.py
@@ -7,14 +7,22 @@ import click
 @click.command()
 @click.argument("main", type=click.File(mode="r"))
 @click.argument("extra-mod-names", nargs=-1)
-def run_contracts(main: TextIO, extra_mod_names: Tuple):
+@click.option("--no-main", "-n", is_flag=True, default=True)
+def run_contracts(main: TextIO, extra_mod_names: Tuple, no_main: bool):
+    """Run python_ta.contracts.check_all_contracts() using the provided arguments
+
+    MAIN the Python script as if you were to just run `python MAIN`
+    EXTRA_MOD_NAMES are the module names to also have contracts checked.
+        These are directly passed in, so the format is the module names as if you were importing
+    NO_MAIN is whether to decorate main or not. No flag defaults to True.
+    """
     contents = main.read()
     module_node = astroid.parse(contents)
 
     if_main = _extract_if_main(module_node)
     import_statement = _build_import()
     if_main.body.insert(0, import_statement)
-    contracts_call = _build_contracts_call(extra_mod_names)
+    contracts_call = _build_contracts_call(extra_mod_names, decorate_main=no_main)
     if_main.body.insert(1, contracts_call)
 
     modified_main_contents = module_node.as_string()
@@ -26,9 +34,10 @@ def _build_import() -> astroid.NodeNG:
     return astroid.extract_node("import python_ta.contracts")
 
 
-def _build_contracts_call(mod_names: Tuple) -> astroid.NodeNG:
+def _build_contracts_call(mod_names: Tuple, decorate_main: bool) -> astroid.NodeNG:
     mod_names_str = ", ".join((f"'{name}'" for name in mod_names))
-    return astroid.extract_node(f"python_ta.contracts.check_all_contracts({mod_names_str})")
+    function_args = f"{mod_names_str}{', ' if mod_names_str else ''}decorate_main={decorate_main}"
+    return astroid.extract_node(f"python_ta.contracts.check_all_contracts({function_args})")
 
 
 def _extract_if_main(module_node: astroid.Module) -> astroid.If:


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This PR introduces allowing `python_ta.contracts.check_all_contracts` to be runnable via CLI. It only provides access to this one method at the moment, and only to a limited extent.

The syntax for the command is

`python -m python_ta.contracts MAIN [EXTRA_MODS]`
where MAIN is the module being executed as if it were being ran directly (`__name__ == '__main__'`) and the EXTRA_MODS are the names of the additional modules to check, character-for-character passed into `check_all_contracts()`. 
## Your Changes

<!-- Describe your changes here. -->
**Description**:

Used the `click` module to create a command that reads in a file to be executed, but mutates it by injecting the `import python_ta.contracts` and `python_ta.contracts.check_all_contracts` into the top of the `if __name__ == '__main__'" block. The mutated script is the one executed using the main's globals so that the main module can be decorated as well.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

I programmatically wrote the executed mutated script into another file to observe the result of the mutation.
Ran test suite (but didn't add new tests).


## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

Got quite a number of things to note so even though I think it can be merged directly, I'm gonna put this up as a draft.

1) I was unsure of how to approach building Nodes so I wrote builder methods to just isolate the creation process to make it easier to change in the future. I took a look at Astroid's raw_building module that I believe is used for slight mutation testing; however, I couldn't figure out how to create the Call or Expr node with it, and the Import node ended up being an ImportFrom, which would add `contracts` into the `globals()` namespace instead of `python_ta` which I didn't like (`contracts` might end up shadowing a variable in a method that reads from the module level scope). 
2) The approach I used to extract the `if __name__ == '__main__'` block was a bit strange as well. I found it using the string representation of the if statement's tested expression because that was the simplest. Attempting to use the actual inner nodes would require type checks for a BoolOp, Name, and Const as well as more checks on their literal values. 
3) Didn't know what to do if there was no `if __name__ == '__main__'` block. I was considering adding a `python_ta.contracts.check_all(module)` under each `import` statement if that module was listed as an extra module, and then adding the `check_contracts` decorator to each of the module-level function and class objects, but I was ultimately unsure if this approach was proper. I also considered that adding this kind of functionality could be done in a new PR while leaving this one as just introducing the basic use-case for the `python_ta.contracts`.
4) Using `astroid` or `ast` or even any abstract syntax tree module removes comments and white spaces when parsing. I couldn't think of a scenario where this would affect any program (as even if you attempt to lint the main file, it would lint the original, unmutated script), but I did discover a library called `RedBaron` which creates a Full Syntax Tree that maintains whitespaces and comments. I also discovered that its tree mutation capabilities are also much more straightforward than `astroid`'s, so I was considering possibly adding this (maybe as an extra dependency such as `pip install python_ta[cli]` or something) for better dynamic script manipulation.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [ ] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
