### PR TITLE
Add command line interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improve error message of `unncessary-indexing` checker.
 - Added CLI for `python_ta.contracts` module for executing a file with contract checking
   (`$ python -m python_ta.contracts FILE`)
+- Added two new command line interfaces. User can print out the default PythonTA configuration file in the command line using `python -m python_ta -g` and can specify the output format of the reporter using `python -m python_ta --output-format FILE`.
 
 ### Bug fixes
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

To add two command-line options, `--generate-config` which prints out the default PythonTA configuration, and `--output-format` which accepts the specific configuration for which reporter to use.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**: Added two command-line interface options in the `python_ta/__main__.py` file using the Click module.
For the `--generate-config option`, I used the classic open and read function to print the `.pylintrc` file.
For the `--output-format option`, I added `config={"output-format": output_format}` argument when calling `checker()`.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing

The following command-line calls have been made to test the changes.
`python3 __main__.py -g`
`python3 __main__.py`
`python3 __main__.py --output-format python_ta.reporters.PlainReporter`
`python3 __main__.py ../examples/pylint/C0103_invalid_name.py --output-format` `python_ta.reporters.ColorReporter`

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
