### PR TITLE
Ending locations fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   2. False negative when the loop variable can be simplified, but is also shadowed in the
      the loop body.
 - Fix HTML report to link correctly to specific errors on the PythonTA documentation website.
+- Fix bug when setting ending locations for `ClassDef`s that have no decorators.
 
 ### New checkers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   (`$ python -m python_ta.contracts FILE`)
 - Added two new command line interfaces. User can print out the default PythonTA configuration file in the command line using `python -m python_ta -g` and can specify the output format of the reporter using `python -m python_ta --output-format FILE`.
 - Updated to Pylint v2.12. See "New checks" below for the new checkers enabled by default.
+- Register ending location setter as pylint plugin.
 
 ### Bug fixes
 

--- a/examples/ending_locations/class_def.py
+++ b/examples/ending_locations/class_def.py
@@ -1,3 +1,8 @@
 @wrapper
 class Foo(base1, base2):
     pass
+
+
+class Bar:
+    def __init__(self):
+        pass

--- a/examples/ending_locations/function_def.py
+++ b/examples/ending_locations/function_def.py
@@ -5,3 +5,11 @@ def fun(arg) -> str:
     """
     return_annotation = "cool!"
     return return_annotation
+
+
+def fun2(arg) -> str:
+    """
+    This is a function fun2.
+    """
+    return_annotation = "cool!"
+    return return_annotation

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -242,6 +242,7 @@ def reset_linter(config=None, file_linted=None):
     linter = pylint.lint.PyLinter(options=new_checker_options)
     linter.load_default_plugins()  # Load checkers, reporters
     linter.load_plugin_modules(custom_checkers)
+    linter.load_plugin_modules(["python_ta.transforms.setendings"])
 
     if isinstance(config, str) and config != "":
         # Use config file at the specified path instead of the default.

--- a/python_ta/patches/__init__.py
+++ b/python_ta/patches/__init__.py
@@ -2,7 +2,7 @@
 """
 from .checkers import patch_checkers
 from .error_messages import patch_error_messages
-from .messages import patch_linter_transform, patch_messages
+from .messages import patch_messages
 from .transforms import patch_ast_transforms
 
 
@@ -11,5 +11,4 @@ def patch_all():
     patch_checkers()
     patch_ast_transforms()
     patch_messages()
-    patch_linter_transform()
     patch_error_messages()

--- a/python_ta/patches/messages.py
+++ b/python_ta/patches/messages.py
@@ -1,9 +1,6 @@
 """Patch pylint message-handling behaviour."""
-from astroid.transforms import TransformVisitor
 from pylint.interfaces import UNDEFINED
 from pylint.lint import PyLinter
-
-from python_ta.transforms.setendings import register_transforms
 
 
 def patch_messages():
@@ -30,20 +27,3 @@ def patch_messages():
             self.reporter.handle_node(msg_info, node)
 
     PyLinter.add_message = new_add_message
-
-
-def patch_linter_transform():
-    """Patch PyLinter class to apply message transform with source code."""
-    old_get_ast = PyLinter.get_ast
-
-    def new_get_ast(self, filepath, modname):
-        ast = old_get_ast(self, filepath, modname)
-        if ast is not None:
-            with open(filepath, encoding="utf-8") as f:
-                source_code = f.readlines()
-            ending_transformer = TransformVisitor()
-            register_transforms(source_code, ending_transformer)
-            ending_transformer.visit(ast)
-        return ast
-
-    PyLinter.get_ast = new_get_ast

--- a/python_ta/transforms/setendings.py
+++ b/python_ta/transforms/setendings.py
@@ -203,8 +203,8 @@ def init_register_ending_setters(source_code):
 
     # Ad hoc transformations
     ending_transformer.register_transform(nodes.BinOp, _set_start_from_first_child)
-    ending_transformer.register_transform(nodes.ClassDef, _set_start_from_first_child)
-    ending_transformer.register_transform(nodes.FunctionDef, _set_start_from_first_child)
+    ending_transformer.register_transform(nodes.ClassDef, _set_start_from_first_decorator)
+    ending_transformer.register_transform(nodes.FunctionDef, _set_start_from_first_decorator)
     ending_transformer.register_transform(nodes.Tuple, _set_start_from_first_child)
     ending_transformer.register_transform(nodes.Arguments, fix_arguments(source_code))
     ending_transformer.register_transform(nodes.Slice, fix_slice(source_code))
@@ -401,6 +401,15 @@ def _set_start_from_first_child(node):
     except StopIteration:
         pass
     else:
+        node.fromlineno = first_child.fromlineno
+        node.col_offset = first_child.col_offset
+    return node
+
+
+def _set_start_from_first_decorator(node):
+    """Set the start attributes of this node from its first child, if that child is a decorator."""
+    if getattr(node, "decorators"):
+        first_child = node.decorators
         node.fromlineno = first_child.fromlineno
         node.col_offset = first_child.col_offset
     return node

--- a/tests/test_setendings.py
+++ b/tests/test_setendings.py
@@ -144,7 +144,7 @@ class TestEndingLocations(unittest.TestCase):
         self.set_and_check(module, nodes.Call, expected)
 
     def test_classdef(self):
-        expected = [(1, 3, 0, 8)]
+        expected = [(1, 3, 0, 8), (6, 8, 0, 12)]
         module = self.get_file_as_module("class_def.py")
         self.set_and_check(module, nodes.ClassDef, expected)
 
@@ -257,8 +257,8 @@ class TestEndingLocations(unittest.TestCase):
         self.set_and_check(module, nodes.For, expected)
 
     def test_functiondef(self):
-        """Note: this node includes the decorator."""
-        expected = [(1, 7, 0, 28)]
+        """Note: this node includes the decorator, if applicable."""
+        expected = [(1, 7, 0, 28), (10, 15, 0, 28)]
         module = self.get_file_as_module("function_def.py")
         self.set_and_check(module, nodes.FunctionDef, expected)
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This PR includes two fixes for the ending locations transformer. The first is to register the transform using a pylint plugin rather than through monkey-patching, and then to make the module's `register` function use `init_register_ending_setters` rather than `register_transforms`, as the latter was out of date. (This was causing PythonTA to have inconsistent ending location behaviour between running its checks and the ending location test cases.)

The second fix is for `ClassDef` and `FunctionDef` nodes to only override their `fromlineno` attribute if they have decorators. Previously, in the case that they didn't have decorators, their `fromlineno` was set to be the same as that of their first child, which for `ClassDef`s could be the first statement in the class definition body.

## Your Changes

<!-- Describe your changes here. -->

**Description**: See above description.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Ran tests and manual run of PythonTA, and added an additional test for `ClassDef`s and `FunctionDef`s with no decorators.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
