### PR TITLE
Space doctest change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added new command line argument `-v/--version`. User can print out current PythonTA version using `python -m python_ta -v`.
 - Preconditions, postconditions, and representation invariants are now parsed only once and compiled.
 - Can configure custom error messages for pylint in a toml file.
+- `missing_space_in_doctest_checker` is now able to check doctests in python modules and classes.
 
 ### Bug fixes
 

--- a/python_ta/checkers/missing_space_in_doctest_checker.py
+++ b/python_ta/checkers/missing_space_in_doctest_checker.py
@@ -16,7 +16,7 @@ class MissingSpaceInDoctestChecker(BaseChecker):
     name = "missing_space_in_doctest"
     msgs = {
         "E9973": (
-            'Space missing after >>> in the docstring of function "%s."',
+            'Space missing after >>> in the docstring of "%s."',
             "missing-space-in-doctest",
             "Used when a doctest is missing a space before the code to be executed",
         )
@@ -28,11 +28,44 @@ class MissingSpaceInDoctestChecker(BaseChecker):
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Visit a function definition"""
 
-        if node.doc_node is not None:
-            docstring = node.doc_node.value
+        if node.doc is not None:
+            docstring = node.doc
             start_line = node.lineno + 1
             lines = docstring.split("\n")
+            for line_no, line in enumerate(lines):
+                if self._has_invalid_doctest(line):
+                    self.add_message(
+                        "missing-space-in-doctest",
+                        node=node,
+                        args=node.name,
+                        line=line_no + start_line,
+                    )
 
+    @check_messages("missing-space-in-doctest")
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
+        """Visit a Class definition"""
+
+        if node.doc is not None:
+            docstring = node.doc
+            start_line = node.lineno + 1
+            lines = docstring.split("\n")
+            for line_no, line in enumerate(lines):
+                if self._has_invalid_doctest(line):
+                    self.add_message(
+                        "missing-space-in-doctest",
+                        node=node,
+                        args=node.name,
+                        line=line_no + start_line,
+                    )
+
+    @check_messages("missing-space-in-doctest")
+    def visit_module(self, node: nodes.Module) -> None:
+        """Visit a Module definition"""
+
+        if node.doc is not None:
+            docstring = node.doc
+            start_line = node.lineno + 1
+            lines = docstring.split("\n")
             for line_no, line in enumerate(lines):
                 if self._has_invalid_doctest(line):
                     self.add_message(

--- a/python_ta/checkers/missing_space_in_doctest_checker.py
+++ b/python_ta/checkers/missing_space_in_doctest_checker.py
@@ -32,6 +32,7 @@ class MissingSpaceInDoctestChecker(BaseChecker):
             docstring = node.doc
             start_line = node.lineno + 1
             lines = docstring.split("\n")
+
             for line_no, line in enumerate(lines):
                 if self._has_invalid_doctest(line):
                     self.add_message(
@@ -49,6 +50,7 @@ class MissingSpaceInDoctestChecker(BaseChecker):
             docstring = node.doc
             start_line = node.lineno + 1
             lines = docstring.split("\n")
+
             for line_no, line in enumerate(lines):
                 if self._has_invalid_doctest(line):
                     self.add_message(
@@ -66,6 +68,7 @@ class MissingSpaceInDoctestChecker(BaseChecker):
             docstring = node.doc
             start_line = node.lineno + 1
             lines = docstring.split("\n")
+            
             for line_no, line in enumerate(lines):
                 if self._has_invalid_doctest(line):
                     self.add_message(

--- a/python_ta/checkers/missing_space_in_doctest_checker.py
+++ b/python_ta/checkers/missing_space_in_doctest_checker.py
@@ -27,48 +27,26 @@ class MissingSpaceInDoctestChecker(BaseChecker):
     @check_messages("missing-space-in-doctest")
     def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         """Visit a function definition"""
-
-        if node.doc is not None:
-            docstring = node.doc
-            start_line = node.lineno + 1
-            lines = docstring.split("\n")
-
-            for line_no, line in enumerate(lines):
-                if self._has_invalid_doctest(line):
-                    self.add_message(
-                        "missing-space-in-doctest",
-                        node=node,
-                        args=node.name,
-                        line=line_no + start_line,
-                    )
+        self._check_docstring(node)
 
     @check_messages("missing-space-in-doctest")
     def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Visit a Class definition"""
-
-        if node.doc is not None:
-            docstring = node.doc
-            start_line = node.lineno + 1
-            lines = docstring.split("\n")
-
-            for line_no, line in enumerate(lines):
-                if self._has_invalid_doctest(line):
-                    self.add_message(
-                        "missing-space-in-doctest",
-                        node=node,
-                        args=node.name,
-                        line=line_no + start_line,
-                    )
+        self._check_docstring(node)
 
     @check_messages("missing-space-in-doctest")
     def visit_module(self, node: nodes.Module) -> None:
         """Visit a Module definition"""
+        self._check_docstring(node)
 
+    # Helper Functions
+    def _check_docstring(self, node) -> None:
+        """Go through the docstring of the respective node type"""
         if node.doc is not None:
             docstring = node.doc
             start_line = node.lineno + 1
             lines = docstring.split("\n")
-            
+
             for line_no, line in enumerate(lines):
                 if self._has_invalid_doctest(line):
                     self.add_message(
@@ -78,7 +56,6 @@ class MissingSpaceInDoctestChecker(BaseChecker):
                         line=line_no + start_line,
                     )
 
-    # Helper Function
     def _has_invalid_doctest(self, doc: str) -> Union[bool, Optional[Match[str]]]:
         """Return whether the docstring line contains an invalid doctest"""
         start_index = doc.find(DOCTEST)

--- a/tests/test_custom_checkers/test_missing_space_in_doctest_checker.py
+++ b/tests/test_custom_checkers/test_missing_space_in_doctest_checker.py
@@ -191,6 +191,127 @@ class TestMissingSpaceInDoctestChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
+    def test_missing_space_class(self) -> None:
+        """Test the checker on a doctest missing a space"""
+        src = '''
+        class ClassA:
+            """
+            >>>var = 2 #@
+            """
+            var1: int
+        '''
+        mod = astroid.parse(src)
+        class_node, *_ = mod.nodes_of_class(nodes.ClassDef)
+
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="missing-space-in-doctest",
+                node=class_node,
+                args=class_node.name,
+                line=4,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_classdef(class_node)
+
+    def test_no_missing_space_class(self) -> None:
+        """Test the checker on a doctest not missing the space"""
+        src = '''
+        class ClassA:
+            """
+            >>> var = 2
+            9
+            """
+            var1: int
+        '''
+        mod = astroid.parse(src)
+        class_node, *_ = mod.nodes_of_class(nodes.ClassDef)
+
+        with self.assertNoMessages():
+            self.checker.visit_classdef(class_node)
+
+    def test_missing_space_mixed_class(self) -> None:
+        """Test the checker on multiple doctests"""
+        src = '''
+        class ClassA:
+            """
+            >>> var = 2
+            >>>var + 7
+            9
+            """
+            var1: int
+        '''
+        mod = astroid.parse(src)
+        class_node, *_ = mod.nodes_of_class(nodes.ClassDef)
+
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="missing-space-in-doctest",
+                node=class_node,
+                args=class_node.name,
+                line=5,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_classdef(class_node)
+
+    def test_missing_space_module(self) -> None:
+        """Test the checker on a doctest missing a space"""
+        src = '''
+        """This is the module header
+        >>>var = 2
+        """
+        '''
+        mod = astroid.parse(src)
+        module_node, *_ = mod.nodes_of_class(nodes.Module)
+
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="missing-space-in-doctest",
+                node=module_node,
+                args=module_node.name,
+                line=2,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_module(module_node)
+
+    def test_no_missing_space_module(self) -> None:
+        """Test the checker on a doctest not missing the space"""
+        src = '''
+        """This is the module header
+        >>> var = 2
+        """
+        '''
+        mod = astroid.parse(src)
+        module_node, *_ = mod.nodes_of_class(nodes.Module)
+
+        with self.assertNoMessages():
+            self.checker.visit_module(module_node)
+
+    def test_missing_space_mixed_module(self) -> None:
+        """Test the checker on multiple doctests"""
+        src = '''
+        """This is the module header
+        >>>var = 2
+        >>> print(var + 7)
+        9
+        """
+        '''
+        mod = astroid.parse(src)
+        module_node, *_ = mod.nodes_of_class(nodes.Module)
+
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="missing-space-in-doctest",
+                node=module_node,
+                args=module_node.name,
+                line=2,
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_module(module_node)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->


This pull request has two major changes. One was a fix with a potential bug as the FunctionDef node did not have an attribute doc_node, and that was changed to just doc. Another change was that the custom checker is now able to check for a space in the doctests in class and module docstring.

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

This pull request was required to allow the custom checker missing_space_in_doctest to be able to work again as well as it improves it by allowing for the checker to check module and class docstrings.

## Your Changes

<!-- Describe your changes here. -->

**Description**:  The first change associated with the bug was simply altering the property of the node so it would actually read the docstring with the correct attribute from the specific node. The next thing that was added was the ability for the checker to check class and module docstrings, which was coded almost identically to the already written code for the function_def section. Finally tests were added to ensure the code runs properly in different scenarios.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

The important tests were added to the test_missing_space_in_doctest file. I also did testing externally on a test file and tested even more situations, but as many of those were redundant, they were not included in the test_missing_space_in_doctest file. 

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

This might be a potential bug, but in the file that contains the test suite, every test that is supposed to fail has a line "ignore_position = True". When I commented the line the test worked the way it should, but the moment I uncommented it, it ran into an error. I am assuming the line is supposed to be there for a reason as it is there for all of the tests that are supposed to fail; however, I believe it is supposed to run and not produce an error.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
