### PR TITLE
accumulation table: Improve formatting of None and float, and improve documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Bug fixes
 
 - Add missing `toml` package to library dependencies.
+- Improve formatting of `None` and `float`s in `AccumulationTable` display.
+  Also make minor improvements to the documentation.
 
 ## [2.3.0] - 2022-08-08
 

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -22,7 +22,7 @@ def calculate_sum_and_averages(numbers: list) -> list:
     with AccumulationTable(["sum_so_far", "avg_so_far", "list_so_far"]):
         for number in numbers:
             sum_so_far = sum_so_far + number
-            avg_so_far = sum(list_so_far) / len(list_so_far)
+            avg_so_far = sum_so_far / (len(list_so_far) + 1)
             list_so_far.append((sum_so_far, avg_so_far))
 
     return list_so_far
@@ -38,13 +38,13 @@ When this file is run, we get the following output:
 $ python demo.py
 iteration    loop variable (number)    sum_so_far    avg_so_far    list_so_far
 -----------  ------------------------  ------------  ------------  ---------------------------------------------------------------------------
-0            N/A                       0                           []
-1            10                        10            10            [(10, 10.0)]
-2            20                        30            15            [(10, 10.0), (30, 15.0)]
-3            30                        60            20            [(10, 10.0), (30, 15.0), (60, 20.0)]
-4            40                        100           25            [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0)]
-5            50                        150           30            [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0), (150, 30.0)]
-6            60                        210           35            [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0), (150, 30.0), (210, 35.0)]
+0            N/A                       0             None          []
+1            10                        10            10.0          [(10, 10.0)]
+2            20                        30            15.0          [(10, 10.0), (30, 15.0)]
+3            30                        60            20.0          [(10, 10.0), (30, 15.0), (60, 20.0)]
+4            40                        100           25.0          [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0)]
+5            50                        150           30.0          [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0), (150, 30.0)]
+6            60                        210           35.0          [(10, 10.0), (30, 15.0), (60, 20.0), (100, 25.0), (150, 30.0), (210, 35.0)]
 ```
 
 ## API
@@ -78,7 +78,7 @@ def calculate_sum_and_averages(numbers: list) -> list:
     with AccumulationTable(["sum_so_far", "avg_so_far", "list_so_far"]) as table:
         for number in numbers:
             sum_so_far = sum_so_far + number
-            avg_so_far = sum(list_so_far) / len(list_so_far)
+            avg_so_far = sum_so_far / (len(list_so_far) + 1)
             list_so_far.append((sum_so_far, avg_so_far))
 
     print(table.loop_accumulators)
@@ -91,18 +91,30 @@ def calculate_sum_and_averages(numbers: list) -> list:
 The `AccumulationTable` is a new PythonTA feature and currently has the following known limitations:
 
 1. `AccumulationTable` uses [`sys.settrace`] to update variable state, and so is not compatible with other libraries (e.g. debuggers, code coverage tools).
-2. Only supports for loops with one target. E.g. loops like `for i, item in enumerate(my_list)` are not supported.
+
+2. Only supports for loops with one target.
+
+   - For loops like `for i, item in enumerate(my_list)` are not supported.
+   - While loops are not supported.
+
 3. Only supports loop accumulation variables, but not accumulators as part of an object.
    For example, instance attribute accumulators are not supported:
 
    ```python
-   def update_my_sum(self, numbers):
-       for number in numbers:
-           self.sum_so_far = self.sum_so_far + number
+   class MyClass:
+       def update_my_sum(self, numbers):
+           for number in numbers:
+               self.sum_so_far = self.sum_so_far + number
    ```
 
 4. Loop variable state is stored by creating shallow copies of the objects.
    Loops that mutate a nested part of an object will not have their state displayed properly.
+
+5. All tracked loop variables other than the for loop target must be initialized before the loop,
+   even when the variables are guaranteed to be initialized before use inside the loop body.
+
+6. The `AccumulatorTable` context manager can only log the execution of one for loop.
+   To log the state of multiple for loops, each must be wrapped in a separate `with` statement and fresh `AccumulatorTable` instance.
 
 [tabulate]: https://github.com/astanin/python-tabulate
 [`sys.settrace`]: https://docs.python.org/3/library/sys.html#sys.settrace

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -112,7 +112,11 @@ class AccumulationTable:
         iteration_dict = self._create_iteration_dict()
         print(
             tabulate.tabulate(
-                iteration_dict, headers="keys", colalign=(*["left"] * len(iteration_dict),)
+                iteration_dict,
+                headers="keys",
+                colalign=(*["left"] * len(iteration_dict),),
+                disable_numparse=True,
+                missingval="None",
             )
         )
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Instructor feedback on the `AccumulationTable` class!

## Your Changes

<!-- Describe your changes here. -->

**Description**: Based on initial instructor feedback, we've changed the display of `None` from an empty cell to a cell containing the text `None`. We've also disabled tabulate's automatic number parsing to preserve trailing `.0`, e.g. so that `14.0` is displayed as `14.0` rather than `14`. 

We also updated the `AccumulationTable` documentation based on initial feedback, including fixing the example provided.


**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (change that modifies or updates documentation only)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Ran test suite and built documentation.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
