### PR TITLE
Added docs for R1736: Unnecessary list index lookup

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -744,6 +744,7 @@ Corrected version:
 colours = ['red', 'blue', 'yellow', 'green']
 
 for index, colour in enumerate(colours):
+    print(index)
     print(colour)
 ```
 

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -728,6 +728,25 @@ for key, value in sample_dict.items():
     print(key, value)  # Direct access instead of an index lookup
 ```
 
+(R1736)=
+
+### Unnecessary list index lookup (R1736)
+
+This error occurs when iterating through a list while keeping track of both index and value using `enumerate()` but still using the index to access the value (which can be accessed directly).
+
+```{literalinclude} /../examples/pylint/r1736_unnecessary_list_index_lookup.py
+
+```
+
+Corrected version:
+
+```python
+colours = ['red', 'blue', 'yellow', 'green']
+
+for index, colour in enumerate(colours):
+    print(colour)
+```
+
 (W0107)=
 
 ### Unnecessary pass (W0107)

--- a/examples/pylint/r1736_unnecessary_list_index_lookup.py
+++ b/examples/pylint/r1736_unnecessary_list_index_lookup.py
@@ -1,4 +1,5 @@
 colours = ['red', 'blue', 'yellow', 'green']
 
 for index, colour in enumerate(colours):
+    print(index)
     print(colours[index])  # Error on this line

--- a/examples/pylint/r1736_unnecessary_list_index_lookup.py
+++ b/examples/pylint/r1736_unnecessary_list_index_lookup.py
@@ -1,0 +1,4 @@
+colours = ['red', 'blue', 'yellow', 'green']
+
+for index, colour in enumerate(colours):
+    print(colours[index])  # Error on this line


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
Added documentation for new Pylint checker R1736: Unnecessary list index lookup.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**:
Added new example file (examples/pylint/r1736_unnecessary_list_index_lookup.py) and updated PyTa checker docs (docs/pylint/index.md) to include a description and correct example under the section Code complexity.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Documentation update (change that modifies or updates documentation only)

## Testing

Generated updated PyTa checker docs page with the new checker.

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
