### PR TITLE
Added instance attributes to rep invariant error message 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - `unnecessary_indexing_checker` has now been extended to check comprehensions in addition to for loops.
 - `invalid_for_target_checker` has now been extended to check comprehensions in addition to for loops.
-- Violated representation invariant error message now includes the current values of the instance attributes.
+- Violated representation invariant error message now includes the class name and current values of the instance attributes.
 
 ### Bug Fixes
 

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -345,7 +345,12 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
             _debug(f"Warning: could not evaluate representation invariant: {invariant}")
         else:
             if not check:
-                raise PyTAContractError(f'Representation invariant "{invariant}" was violated')
+                arg_string = instance.__dict__
+
+                raise PyTAContractError(
+                    f'Representation invariant "{invariant}" was violated for'
+                    f" arguments {arg_string}"
+                )
 
 
 def _get_legal_return_val_var_name(var_dict: dict) -> str:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -352,11 +352,15 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
             _debug(f"Warning: could not evaluate representation invariant: {invariant}")
         else:
             if not check:
-                arg_string = instance.__dict__
+                curr_attributes = ", ".join(
+                    f"{k}: {_display_value(v)}" for k, v in vars(instance).items()
+                )
+
+                curr_attributes = "{" + curr_attributes + "}"
 
                 raise PyTAContractError(
                     f'Representation invariant "{invariant}" was violated for'
-                    f" arguments {arg_string}"
+                    f" instance attributes {curr_attributes}"
                 )
 
 

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -359,7 +359,7 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
                 curr_attributes = "{" + curr_attributes + "}"
 
                 raise PyTAContractError(
-                    f'Representation invariant "{invariant}" was violated for'
+                    f'"{instance.__class__.__name__}" representation invariant "{invariant}" was violated for'
                     f" instance attributes {curr_attributes}"
                 )
 

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -108,7 +108,7 @@ def person():
 
 def test_change_age_invalid_over(person) -> None:
     """
-    Change the age to larger than 100. Expect an exception.
+    Change the age to larger than 150. Expect an exception.
     """
     with pytest.raises(AssertionError) as excinfo:
         person.change_age(200)
@@ -217,6 +217,27 @@ def test_circle_area_invalid() -> None:
     assert "r > 0" in msg
 
 
+def test_pizza_valid() -> None:
+    """
+    Test the Pizza representation invariant on a valid instance.
+    """
+    pizza = Pizza(radius=5, ingredients=["cheese", "pepperoni"])
+    assert pizza.radius == 5 and pizza.ingredients == ["cheese", "pepperoni"]
+
+
+def test_pizza_invalid() -> None:
+    """
+    Test the Pizza representation invariant on an invalid instance.
+    """
+    with pytest.raises(AssertionError) as excinfo:
+        Pizza(radius=10, ingredients=[])
+    msg = str(excinfo.value)
+    assert (
+        "\"len(self.ingredients) > 0\" was violated for arguments {'radius': 10, 'ingredients': []}"
+        in msg
+    )
+
+
 def test_set_wrapper_valid() -> None:
     """
     Test the SetWrapper representation invariant on a valid instance.
@@ -227,12 +248,15 @@ def test_set_wrapper_valid() -> None:
 
 def test_set_wrapper_invalid() -> None:
     """
-    Test the SetWrapper representation invariant on a valid instance.
+    Test the SetWrapper representation invariant on an invalid instance.
     """
     with pytest.raises(AssertionError) as excinfo:
         SetWrapper(set={1, 2, -3})
     msg = str(excinfo.value)
-    assert "all(x in self.set for x in {1, 2, 3})" in msg
+    assert (
+        "\"all(x in self.set for x in {1, 2, 3})\" was violated for arguments {'set': {1, 2, -3}}"
+        in msg
+    )
 
 
 class NoInit:

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -233,7 +233,8 @@ def test_pizza_invalid() -> None:
         Pizza(radius=10, ingredients=[])
     msg = str(excinfo.value)
     assert (
-        'Representation invariant "len(self.ingredients) > 0" was violated for instance attributes {radius: 10, '
+        '"Pizza" representation invariant "len(self.ingredients) > 0" was violated for instance attributes {'
+        "radius: 10, "
         "ingredients: []}" == msg
     )
 
@@ -254,7 +255,8 @@ def test_set_wrapper_invalid() -> None:
         SetWrapper(set={1, 2, -3})
     msg = str(excinfo.value)
     assert (
-        'Representation invariant "all(x in self.set for x in {1, 2, 3})" was violated for instance attributes {'
+        '"SetWrapper" representation invariant "all(x in self.set for x in {1, 2, 3})" was violated for instance '
+        "attributes {"
         "set: {1, 2, -3}}" == msg
     )
 

--- a/tests/test_class_contracts.py
+++ b/tests/test_class_contracts.py
@@ -233,8 +233,8 @@ def test_pizza_invalid() -> None:
         Pizza(radius=10, ingredients=[])
     msg = str(excinfo.value)
     assert (
-        "\"len(self.ingredients) > 0\" was violated for arguments {'radius': 10, 'ingredients': []}"
-        in msg
+        'Representation invariant "len(self.ingredients) > 0" was violated for instance attributes {radius: 10, '
+        "ingredients: []}" == msg
     )
 
 
@@ -254,8 +254,8 @@ def test_set_wrapper_invalid() -> None:
         SetWrapper(set={1, 2, -3})
     msg = str(excinfo.value)
     assert (
-        "\"all(x in self.set for x in {1, 2, 3})\" was violated for arguments {'set': {1, 2, -3}}"
-        in msg
+        'Representation invariant "all(x in self.set for x in {1, 2, 3})" was violated for instance attributes {'
+        "set: {1, 2, -3}}" == msg
     )
 
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The motivation for this pull request was to modify the error message for a violated representation invariant to include the instance attributes' current values.

## Your Changes

<!-- Describe your changes here. -->

**Description**:

In `python_ta/contracts/__init__.py`, I modified the check so that after the check returns false (invariant was violated), it would then access the current instance attributes and include those in the error message raised. I also fixed two typos in the test file. One that said "valid" when it was testing for an invalid instance and another whose docstring value for an attribute didn't match up with what was in the precondition (100 instead of 150).

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Because this change only affected the error message that was produced I just modified the existing representation invariant test for `SetWrapper` to check if the arguments were included as well in the assertion. I did add two more tests that were also checking for this with the `Pizza` class, one for valid and one for invalid. The `Pizza` tests included two invariants and it should raise an error when one of them is violated.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
