### PR TITLE
contracts: Make contract checking work with PyCharm 'Run File in Python Console' action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed Issue #831: Contract Checker Bug. Now raises `AssertionError` when the expected type is `float` but got `int` instead.
 - PyTA contracts' type checking now raises `AssertionError` when the expected type is `int` but got `bool` instead.
+- Fixed PyTA contract checking when running modules in PyCharm using the "Run File in Python Console" action.
 
 ### New checkers
 

--- a/docs/contracts/index.md
+++ b/docs/contracts/index.md
@@ -67,10 +67,16 @@ You can set the `ENABLE_CONTRACT_CHECKING` constant to `True` to enable all cont
 .. autodata:: python_ta.contracts.ENABLE_CONTRACT_CHECKING
 ```
 
-Finally, you can set the `DEBUG_CONTRACTS` constant to `True` to enable debugging information to be printed when checking contracts.
+You can set the `DEBUG_CONTRACTS` constant to `True` to enable debugging information to be printed when checking contracts.
 
 ```{eval-rst}
 .. autodata:: python_ta.contracts.DEBUG_CONTRACTS
+```
+
+The following constant is used to make contract checking compatible with PyCharm's "Run File in Python Console" action.
+
+```{eval-rst}
+.. autodata:: python_ta.contracts.RENAME_MAIN_TO_PYDEV_UMD
 ```
 
 ## Command Line Interface


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

When we use PyCharm's 'Run File in Python Console', the current module is stored as `'pydev_umd'` rather than `'__main__'` in `sys.modules`. A few places in `python_ta.contracts` relies on accessing the module of a class/function to determine what's in scope for evaluating preconditions/representation invariants. `check_all_contracts()` by default relies on decorating all functions/classes in `__main__`.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Added a workaround to use `sys.modules['pydev_umd']` instead of `sys.modules['__main__']`, which can be turned on/off using a configuration variable.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Tested manually and by running test suite.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
