### PR TITLE
Fix custom message formats and shadowing-in-comprehension bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Bug fixes
 
 - Fixed custom message formats based on Pylint 2.15 updates.
+- Fixed bug in shadowing-in-comprehension checker when target is a subscript node.
 
 ## [2.4.1] - 2023-1-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Bug fixes
+
+- Fixed custom message formats based on Pylint 2.15 updates.
+
 ## [2.4.1] - 2023-1-13
 
 ### Bug fixes

--- a/python_ta/checkers/shadowing_in_comprehension_checker.py
+++ b/python_ta/checkers/shadowing_in_comprehension_checker.py
@@ -26,7 +26,7 @@ class ShadowingInComprehensionChecker(BaseChecker):
                 if target.name in node.parent.frame().locals and target.name != "_":
                     args = target.name
                     self.add_message("shadowing-in-comprehension", node=target, args=args)
-        else:  # isinstance(node.target, nodes.AssignName)
+        elif isinstance(node.target, nodes.AssignName):
             if node.target.name in node.parent.frame().locals and node.target.name != "_":
                 args = node.target.name
                 self.add_message("shadowing-in-comprehension", node=node.target, args=args)

--- a/python_ta/config/messages_config.toml
+++ b/python_ta/config/messages_config.toml
@@ -12,7 +12,6 @@ W0126 = "This if condition references a function but is missing the parentheses 
 W0199 = "Calling assert on a tuple will only evaluate to False if it is empty. It's likely you intended 'assert x, y' rather than 'assert (x,y)'."
 
 ["pylint.checkers.base".ComparisonChecker]
-R0123 = "When performing a comparison with a literal, use '==' instead of 'is'. Exceptions: use 'is' when comparing to None."
 C0123 = "You should use 'isinstance(x, my_type)' instead of 'type(x) == my_type' to check the type of a value."
 
 ["pylint.checkers.base".NameChecker]
@@ -42,7 +41,7 @@ R1710 = """This function has at least one case where the function body will exec
     """
 R1712 = "Use parallel assignment to swap the values of variables. For example: to swap variables 'a' and 'b', simply do 'a, b = b, a'."
 R1713 = "If you want to concatenate a sequence of strings, use the str.join method."
-R1714 = "To check whether this variable is equal to one of many values, merge the comparisons into a single check: %r."
+R1714 = "To check whether this variable is equal to one of many values, use the in operator with a set or list, for example: '%s %sin {%s}'."
 R1715 = "To lookup a value from a dictionary if a key is present and use a default value if the key is not, use the built-in dict.get method."
 R1716 = "You can simplify this boolean operation into a chained comparison. Instead of 'a < b and b < c', use 'a < b < c'."
 R1721 = "When you want to convert a collection from one type into another, use the appropriate type constructor instead of a comprehension. Here, use %s instead."
@@ -65,8 +64,8 @@ R0916 = "This if condition contains too many boolean expressions (%s, exceeding 
 
 ["pylint.checkers.classes".ClassChecker]
 E0203 = "You can't use instance attribute %r prior to its assignment on line %s."
-E0211 = "Every instance method requires at least one parameter 'self', referring to the object on which this method is called. "
-E0213 = "The first parameter of a method should always be called 'self'. "
+E0211 = "Every instance method (including %r) requires at least one parameter 'self', referring to the object on which this method is called. "
+E0213 = "The first parameter of every instance method (including %r) should always be called 'self'. "
 E0241 = "This class %r should not inherit from the same class multiple times."
 R0205 = "All classes inherit from object by default, so you do not need to specify this in the header for %r."
 W0211 = "The static method %r should not have 'self' as the first parameter."

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -6,23 +6,23 @@ import sys
 from os import path, remove
 from unittest.mock import Mock
 
-from pytest import skip
-
 import python_ta
 
 
 def test_check_on_dir():
     """The function, check_all() should handle a top-level dir as input."""
-    _inputs = [["nodes"], ["examples"]]
-    for item in _inputs:
-        python_ta.check_all(
-            item,
-            config={
-                "output-format": "python_ta.reporters.PlainReporter",
-                "pyta-error-permission": "no",
-                "pyta-file-permission": "no",
-            },
-        )
+    reporter = python_ta.check_all(
+        "examples",
+        config={
+            "output-format": "python_ta.reporters.JSONReporter",
+            "pyta-error-permission": "no",
+            "pyta-file-permission": "no",
+        },
+    )
+    for filename, messages in reporter.messages.items():
+        assert "astroid-error" not in {
+            msg.message.symbol for msg in messages
+        }, f"astroid-error encountered for {filename}"
 
 
 def test_check_on_file():


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Improved `tests/test_check.py` to detect fatal `astroid-error`s. This investigation was a result of some reported errors when PythonTA 2.4.1 detected certain messages.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Updated custom messages to be consistent with expected formats in Pylint 2.15. Also updated the `shadowing-in-comprehension` checker to explicitly handle non-standard target types.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Ran test suite and manually ran PYthonTA on the example inputs for the changed messages.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
