### PR TITLE
Fixed bug where webpage opens on bad paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-## [2.4.3] - 2023-02-13
-
 ### Bug fixes
 
-- Fixed bug where `check_errors` and `check_all` open a webpage when a undefined or unreadable path is passed as an argument.
+- Fixed bug where `check_errors` and `check_all` opens a webpage when a undefined or unreadable path is passed as an argument.
 
 ## [2.4.2] - 2023-1-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [2.4.3] - 2023-02-13
+
+### Bug fixes
+
+- Fixed bug where `check_errors` and `check_all` open a webpage when a undefined or unreadable path is passed as an argument.
+
 ## [2.4.2] - 2023-1-31
 
 ### Bug fixes

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -109,15 +109,18 @@ def _check(
 
     # Try to check file, issue error message for invalid files.
     try:
-        files_to_check = list(_get_valid_files_to_check(module_name))
+        # Flag indicating whether at least one file has been checked
+        is_any_file_checked = False
 
-        for locations in files_to_check:
+        for locations in _get_valid_files_to_check(module_name):
             f_paths = []  # Paths to files for data submission
             errs = []  # Errors caught in files for data submission
             config = {}  # Configuration settings for data submission
             for file_py in get_file_paths(locations):
                 if not _verify_pre_check(file_py):
                     continue  # Check the other files
+                # The current file can actually be checked so update the flag
+                is_any_file_checked = True
                 # Load config file in user location. Construct new linter each
                 # time, so config options don't bleed to unintended files.
                 # Reuse the same reporter each time to accumulate the results across different files.
@@ -158,7 +161,7 @@ def _check(
                     version=__version__,
                 )
         # Only generate reports (display the webpage) if there were valid files to check
-        if len(files_to_check) != 0:
+        if is_any_file_checked:
             linter.generate_reports()
         return current_reporter
     except Exception as e:

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -109,7 +109,9 @@ def _check(
 
     # Try to check file, issue error message for invalid files.
     try:
-        for locations in _get_valid_files_to_check(module_name):
+        files_to_check = list(_get_valid_files_to_check(module_name))
+
+        for locations in files_to_check:
             f_paths = []  # Paths to files for data submission
             errs = []  # Errors caught in files for data submission
             config = {}  # Configuration settings for data submission
@@ -155,7 +157,9 @@ def _check(
                     url=linter.config.pyta_server_address,
                     version=__version__,
                 )
-        linter.generate_reports()
+        # Only generate reports (display the webpage) if there were valid files to check
+        if len(files_to_check) != 0:
+            linter.generate_reports()
         return current_reporter
     except Exception as e:
         print(


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Calls to `check_all` and `check_errors` generate an error report when we pass in a path that doesn't exist or is unreadable. 

## Your Changes

<!-- Describe your changes here. -->

**Description**:
- PythonTA no longer opens a webpage under these conditions but still prints the error message to the console.
- Added some logic to ensure at least one file has been checked before generating reports.
- Updated `CHANGELOG.md` to document this bug fix.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran the tests in the test suite and verified they passed.
- Ran `python` in `pyta` repository and called `check_all` and `check_errors` (in reality, they both use the same helper method) with erroneous inputs (both files and directories) and verified that an error message was displayed but no webpage opened. Also tested with different PythonTA reporters.
- Also tested the `check_all` and `check_errors` methods with valid inputs and verified this change did not affect the messages being displayed (e.g. removing some by accident).
- Previewed the `CHANGELOG.md` file to verify it now includes information related to this bug fix.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

- As of now, the PR for the `ForbiddenPythonSyntaxChecker` hasn't been merged so once it does, there will might be a merge conflict with the `CHANGELOG.md` files so that needs to be dealt with

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
