### PR TITLE
Fixed bug where comprehension variable was falsely flagged as being undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Bug fixes
+
+- Fixed bug in possibly-undefined checker where a comprehension variable is falsely flagged as possibly undefined.
+
 ## [2.4.2] - 2023-1-31
 
 ### Bug fixes

--- a/python_ta/checkers/possibly_undefined_checker.py
+++ b/python_ta/checkers/possibly_undefined_checker.py
@@ -142,10 +142,10 @@ class PossiblyUndefinedChecker(BaseChecker):
                 yield from self.get_nodes(statement.value)
             else:
                 yield from self.get_nodes(statement.elt)
-        else:
-            yield from statement.nodes_of_class(
-                (nodes.AssignName, nodes.DelName, nodes.Name), nodes.FunctionDef
-            )
+        elif isinstance(statement, (nodes.AssignName, nodes.DelName, nodes.Name)):
+            yield statement
+        elif not isinstance(statement, nodes.FunctionDef):
+            yield from multiple_nodes(statement.get_children())
 
 
 def register(linter):


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

The `possibly_undefined_checker` was flagging comprehension variables as being possibly undefined when it shadows another variable later on in the program.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**:

- Updated the `get_nodes` helper method in `possibly_undefined_checker.py` to fix the order of nodes being checked in the checker.
- Updated `CHANGELOG.md` to include this bug fix.
- Added the previously buggy code snippet as a test case.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran the test suite and verified all tests passed.
- Ran `pyta` on the buggy code and verified that the variables are no longer flagged as being possibly undefined.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

- Turns out `get_nodes` never actually checked the generator expression in the given buggy code snippet. The entire print call was treated as one `Expr` node so when it was passed to `get_nodes`, it went straight to the else branch instead.
```python
# The buggy code
def f() -> None:
    """Test"""
    if True:
        print(x for x in range(20))
    else:
        for x in range(10):
            pass
```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes.
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
