### PR TITLE
Fixed bug related to missing raise handling in CFG implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed bug in possibly-undefined checker where a comprehension variable is falsely flagged as possibly undefined.
 - Fixed bug where `check_errors` and `check_all` opens a webpage when a nonexistent or unreadable path is passed as an argument.
+- Fixed the CFG implementation of pyta to resolve a bug in the possibly-undefined checker where variables were falsely flagged as possibly undefined when the code conditionally raises an exception and the variable was referenced afterwards.
 
 ### New checkers
 

--- a/python_ta/cfg/graph.py
+++ b/python_ta/cfg/graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Generator, List, Optional, Set, Tuple, Union
 
-from astroid import Break, Continue, NodeNG, Return
+from astroid import Break, Continue, NodeNG, Raise, Return
 
 
 class ControlFlowGraph:
@@ -180,7 +180,7 @@ class CFGBlock:
     def is_jump(self) -> bool:
         """Returns True if the block has a statement that branches
         the control flow (ex: `break`)"""
-        return isinstance(self.jump, (Break, Continue, Return))
+        return isinstance(self.jump, (Break, Continue, Return, Raise))
 
 
 class CFGEdge:

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -61,7 +61,15 @@ class CFGVisitor:
         self.cfgs[func] = ControlFlowGraph()
         self._current_cfg = self.cfgs[func]
 
-        self._control_boundaries.append((func, {nodes.Return.__name__: self._current_cfg.end}))
+        self._control_boundaries.append(
+            (
+                func,
+                {
+                    nodes.Return.__name__: self._current_cfg.end,
+                    nodes.Raise.__name__: self._current_cfg.end,
+                },
+            )
+        )
 
         self._current_cfg.start.add_statement(func.args)
         func.cfg_block = self._current_cfg.start
@@ -200,8 +208,6 @@ class CFGVisitor:
         self._visit_jump(node)
 
     def visit_raise(self, node: nodes.Raise) -> None:
-        # Raise acts like a return so it jumps to the end
-        self._control_boundaries.append((node, {nodes.Raise.__name__: self._current_cfg.end}))
         self._visit_jump(node)
 
     def _visit_jump(

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -199,7 +199,14 @@ class CFGVisitor:
     def visit_return(self, node: nodes.Return) -> None:
         self._visit_jump(node)
 
-    def _visit_jump(self, node: Union[nodes.Break, nodes.Continue, nodes.Return]) -> None:
+    def visit_raise(self, node: nodes.Raise) -> None:
+        # Raise acts like a return so it jumps to the end
+        self._control_boundaries.append((node, {nodes.Raise.__name__: self._current_cfg.end}))
+        self._visit_jump(node)
+
+    def _visit_jump(
+        self, node: Union[nodes.Break, nodes.Continue, nodes.Return, nodes.Raise]
+    ) -> None:
         old_curr = self._current_block
         for boundary, exits in reversed(self._control_boundaries):
             if type(node).__name__ in exits:

--- a/tests/test_cfg/test_jump.py
+++ b/tests/test_cfg/test_jump.py
@@ -63,3 +63,19 @@ def test_link_return_to_block() -> None:
 
     new_block = cfg.create_block(return_block)
     assert new_block.predecessors == []
+
+
+def test_link_raise_to_block() -> None:
+    src = """
+    def func():
+        raise NotImplementedError
+    """
+    cfgs = build_cfgs(src)
+    keys = list(cfgs)
+    cfg = cfgs[keys[1]]
+
+    raise_block = cfg.start.successors[0].target
+    assert raise_block.statements[0].as_string() == "raise NotImplementedError"
+
+    new_block = cfg.create_block(raise_block)
+    assert new_block.predecessors == []

--- a/tests/test_custom_checkers/test_possibly_undefined_checker.py
+++ b/tests/test_custom_checkers/test_possibly_undefined_checker.py
@@ -448,3 +448,24 @@ class TestPossiblyUndefinedChecker(pylint.testutils.CheckerTestCase):
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(func_node)
+
+    def test_prev_incorrect_raise_handling(self) -> None:
+        """Test that this checker no longer falsely flags a variable as being possibly undefined
+        when it conditionally raises an exception."""
+        src = """
+        def g(a: int) -> int:
+            if a % 3 == 0:
+                result = 3
+            elif a % 2 == 0:
+                result = 2
+            else:
+                raise NotImplementedError
+
+            return result
+        """
+        mod = astroid.parse(src)
+        mod.accept(CFGVisitor())
+        func_node = mod.body[0]
+
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(func_node)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

These changes aim to fix the bug introduced in this issue's [comment](https://github.com/pyta-uoft/pyta/issues/882#issuecomment-1476670044). In addition, the current CFG implementation does not seem to handle `raise` statements (which should be similar to `return` statements) so these changes also fix this gap in the implementation.

## Your Changes

<!-- Describe your changes here. -->

**Description**:
- `raise` statements are now being handled as if they were jumps (because they are very similar to a `return` statement).
- Added the [bug](https://github.com/pyta-uoft/pyta/issues/882#issuecomment-1476670044) as a test case.
- Added a new test case to ensure that `raise` statements are correctly being handled as a jump.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactoring (internal change to codebase, without changing functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran the test suite and verified that they all passed.
- Added the bug as a test case and ensured that the previously buggy code is no longer flagged by the `possibly-undefined` checker.
- Added a new test case to verify that `raise` statements are now being handled as a jump. Verified that this new test passes.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

- This bug was not the fault of the `possibly-undefined-checker`, but rather, the current CFG implementation did not support and handle `raise` statements correctly. Since they are very similar to `return` statements, I handled them in a similar manner and considered them a jump in these changes.
- Although this change fixes the original bug, there is a new bug involving `raise` statements inside `tryexcept` blocks. For example, the following snippet:
```
def f() -> None:
    try:
        raise NotImplementedError
    except NotImplementedError:  # CFG indicates it is unreachable
        pass
```
With this new change, the code above connected the `raise` statement directly to the end but in actuality, it should connect to the `ExceptHandler` block.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
