### PR TITLE
Added example and documentation for W0644 unbalanced-dict-unpacking

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -410,10 +410,22 @@ SCORES = {
     "billy": (2, 2, 2, 2),
 }
 
-a, b, c = SCORES
+a, b, c = SCORES  # unpacking the dictionary keys
 
-for d, e, f in SCORES.values():
+for d, e, f in SCORES.values():  # unpacking the dictionary values
     print(d)
+```
+
+Note that when using unpacking with a dictionary on the right-hand side of an `=`, the variables on the left-hand side gets assigned the keys of the dictionary. For example,
+
+```python
+test = {
+  "hi": 0,
+  "bye": 1,
+}
+
+# `a` gets assigned "hi", `b` gets assigned "bye"
+a, b = test
 ```
 
 (E0633)=

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -390,6 +390,32 @@ too few or too many values in the sequence.
 
 ```
 
+(W0644)=
+
+### Unbalanced dict unpacking (W0644)
+
+This error occurs when we are trying to assign dictionary keys or values to multiple variables at
+once, but the right side has too few or too many values.
+
+```{literalinclude} /../examples/pylint/w0644_unbalanced_dict_unpacking.py
+
+```
+
+Corrected version:
+
+```python
+SCORES = {
+    "bob": (1, 1, 3, 2),
+    "joe": (4, 3, 1, 2),
+    "billy": (2, 2, 2, 2),
+}
+
+a, b, c = SCORES
+
+for d, e, f in SCORES.values():
+    print(d)
+```
+
 (E0633)=
 
 ### Unpacking non-sequence (E0633)

--- a/examples/pylint/w0644_unbalanced_dict_unpacking.py
+++ b/examples/pylint/w0644_unbalanced_dict_unpacking.py
@@ -1,0 +1,10 @@
+"""Examples for W0644 unbalanced-dict-unpacking"""
+
+SCORES = {
+    "bob": (1, 1, 3, 2),
+    "joe": (4, 3, 1, 2),
+    "billy": (2, 2, 2, 2),
+}
+
+for a, b, c, d in SCORES.values():  # unbalanced-dict-unpacking
+    print(a)

--- a/examples/pylint/w0644_unbalanced_dict_unpacking.py
+++ b/examples/pylint/w0644_unbalanced_dict_unpacking.py
@@ -6,7 +6,7 @@ SCORES = {
     "billy": (2, 2, 2, 2),
 }
 
-a, b = SCORES   # unbalanced-dict-unpacking
+a, b = SCORES  # Error on this line
 
-for d, e in SCORES.values():  # unbalanced-dict-unpacking
+for d, e in SCORES.values():  # Error on this line
     print(d)

--- a/examples/pylint/w0644_unbalanced_dict_unpacking.py
+++ b/examples/pylint/w0644_unbalanced_dict_unpacking.py
@@ -6,5 +6,7 @@ SCORES = {
     "billy": (2, 2, 2, 2),
 }
 
-for a, b, c, d in SCORES.values():  # unbalanced-dict-unpacking
+c, d = SCORES   # unbalanced-dict-unpacking
+
+for a, b in SCORES.values():  # unbalanced-dict-unpacking
     print(a)

--- a/examples/pylint/w0644_unbalanced_dict_unpacking.py
+++ b/examples/pylint/w0644_unbalanced_dict_unpacking.py
@@ -6,7 +6,7 @@ SCORES = {
     "billy": (2, 2, 2, 2),
 }
 
-c, d = SCORES   # unbalanced-dict-unpacking
+a, b = SCORES   # unbalanced-dict-unpacking
 
-for a, b in SCORES.values():  # unbalanced-dict-unpacking
-    print(a)
+for d, e in SCORES.values():  # unbalanced-dict-unpacking
+    print(d)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The `unbalanced-dict-unpacking` error is not documented in the pyta docs nor does it have an example showing what may cause this error. This PR serves to fix both these problems.

## Your Changes

<!-- Describe your changes here. -->

**Description**:

- Created an example that causes the `unbalanced-dict-unpacking` error
- Updated the `docs/checkers/index.md` file to document this error

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Documentation update (change that modifies or updates documentation only)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran python_ta on the example file to ensure that the intended error was being reported
- Ran python_ta on the corrected version of the example to ensure that it fixes the error
- Generated the docs to verify that the documentation was properly updated

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

- ~~I was looking online and there doesn't seem to be much on dictionary unpacking so I'm unsure if the example provided for the "assignment" source of the error is correct. The snippet is included below:~~
```python
SCORES = {
    "bob": (1, 1, 3, 2),
    "joe": (4, 3, 1, 2),
    "billy": (2, 2, 2, 2),
}

c, d = SCORES
```
~~It seems to assign the variables the dictionary keys. Is this what is meant by "unbalanced dict unpacking in assignment"?~~

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
