### PR TITLE
Added example and documentation for W3301 nested-min-max

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -906,6 +906,24 @@ for student in students_info:
         cs_student_dict[student[0]] = student[1]
 ```
 
+(W3301)=
+
+### Nested min-max (W3301)
+
+This error occurs when there are nested calls of min or max instead of using a single min/max call.
+
+```{literalinclude} /../examples/pylint/w3301_nested_min_max.py
+
+```
+
+Corrected version:
+
+```python
+smallest = min(12, 1, 2)
+
+largest = max(12, 1, 2)
+```
+
 ## Documentation and naming
 
 Good documentation and identifiers are essential for writing software. PyTA helps check to make sure

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -910,7 +910,9 @@ for student in students_info:
 
 ### Nested min-max (W3301)
 
-This error occurs when there are nested calls of min or max instead of using a single min/max call.
+This error occurs when there are nested calls of `min` or `max` instead of using a single `min`/`max` call.
+
+Note that using a single `min`/`max` call is perfectly fine since you can pass in an arbitrary number of arguments.
 
 ```{literalinclude} /../examples/pylint/w3301_nested_min_max.py
 

--- a/examples/pylint/w3301_nested_min_max.py
+++ b/examples/pylint/w3301_nested_min_max.py
@@ -1,0 +1,5 @@
+"""Examples for W3301 nested-min-max"""
+
+smallest = min(12, min(1, 2))
+
+largest = max(12, max(1, 2))


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The `nested-min-max` error is not documented in the pyta docs nor does it have an example showing what may cause this error. This PR aims to fix that.

## Your Changes

<!-- Describe your changes here. -->

**Description**:

- Created an example that causes the `nested-min-max` error
- Updated the `docs/checkers/index.md` file to document this error

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Documentation update (change that modifies or updates documentation only)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran python_ta on the example file to ensure that the intended error was being reported
- Ran python_ta on the corrected version of the example to ensure that it fixes the error
- Generated the docs to verify that the documentation was properly updated

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
