### PR TITLE
Added example and documentation for W3601 bad-chained-comparison

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -2969,8 +2969,14 @@ for all lines is 80 characters.
 
 ### Bad chained comparison (W3601)
 
-This error occurs when a chained comparison uses semantically incompatible operators. For example,
-"<" has a different meaning than "is".
+This error occurs when a chained comparison uses incompatible comparison operators, i.e. operators that perform a different kind of test. For example,
+`<` has a different meaning than `is` and `in`.
+
+The different types of comparison operators can be classified in the following categories:
+
+- [Value comparisons][value comparisons] which compares values
+- [Membership tests][membership test operations] which checks whether a value is present in some other object
+- [Identity comparisons][identity comparisons] which checks whether two variables or values represent the same object
 
 ```{literalinclude} /../examples/pylint/w3601_bad_chained_comparison.py
 
@@ -3160,6 +3166,9 @@ function and method calls or definitions.
 [python documentation: staticmethod]: https://docs.python.org/3/library/functions.html#staticmethod
 [string and bytes literals]: https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
 [unary arithmetic and bitwise operations]: https://docs.python.org/3/reference/expressions.html#unary-arithmetic-and-bitwise-operations
+[value comparisons]: https://docs.python.org/3/reference/expressions.html#value-comparisons
+[membership test operations]: https://docs.python.org/3/reference/expressions.html#membership-test-operations
+[identity comparisons]: https://docs.python.org/3/reference/expressions.html#is-not
 
 <!-- PEP8 -->
 

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -2965,6 +2965,17 @@ for all lines is 80 characters.
 
 ```
 
+(W3601)=
+
+### Bad chained comparison (W3601)
+
+This error occurs when a chained comparison uses semantically incompatible operators. For example,
+"<" has a different meaning than "is".
+
+```{literalinclude} /../examples/pylint/w3601_bad_chained_comparison.py
+
+```
+
 ## Syntax errors
 
 (E0001)=

--- a/examples/pylint/w3601_bad_chained_comparison.py
+++ b/examples/pylint/w3601_bad_chained_comparison.py
@@ -2,14 +2,14 @@
 
 x = 5
 
-if 0 < x is 5:  # bad-chained-comparison
+if 0 < x is 5:  # Error on this line
     print("hi")
 
 a = 1
-lis = [1, 2, 3, 4]
+my_list = [1, 2, 3, 4]
 
-if a > 0 not in lis:  # bad-chained-comparison
+if a > 0 not in my_list:  # Error on this line
     print("whee")
 
-if a == x is 1 in lis:  # bad-chained-comparison
+if a == x is 1 in my_list:  # Error on this line
     print("yikes")

--- a/examples/pylint/w3601_bad_chained_comparison.py
+++ b/examples/pylint/w3601_bad_chained_comparison.py
@@ -2,5 +2,14 @@
 
 x = 5
 
-if 0 < x is 5:
+if 0 < x is 5:  # bad-chained-comparison
     print("hi")
+
+a = 1
+lis = [1, 2, 3, 4]
+
+if a > 0 not in lis:  # bad-chained-comparison
+    print("whee")
+
+if a == x is 1 in lis:  # bad-chained-comparison
+    print("yikes")

--- a/examples/pylint/w3601_bad_chained_comparison.py
+++ b/examples/pylint/w3601_bad_chained_comparison.py
@@ -1,0 +1,6 @@
+"""Examples for W3601 bad-chained-comparison"""
+
+x = 5
+
+if 0 < x is 5:
+    print("hi")


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The `bad-chained-comparison` error is not documented in the pyta docs nor does it have an example showing what may cause this error. This PR aims to fix both of these things.

## Your Changes

<!-- Describe your changes here. -->

**Description**:

- Created an example that causes the `bad-chained-comparison` error
- Updated the `docs/checkers/index.md` file to document this error

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Documentation update (change that modifies or updates documentation only)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran python_ta on the example file to ensure that the intended error was being reported
- Ran python_ta on the corrected version of the example to ensure that it fixes the error
- Generated the docs to verify that the documentation was properly updated

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
