### PR TITLE
Added documentation and example of W0133 Pointless Exception Statement Checker

### DIFF
--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -743,6 +743,24 @@ for strings.
 
 ```
 
+(W0133)=
+
+### Pointless exception statement (W0133)
+
+This error occurs when an exception is created but never assigned, raised or returned for use anywhere in the code.
+
+```{literalinclude} /../examples/pylint/w0105_pointless_string_statement.py
+
+```
+
+This error can be resolved by assigning, raising or returning the exception as demonstrated below:
+
+**Note** : NameError is a subclass of Exception (It is a more specific type of exception in Python).
+
+```python
+raise NameError("This is not a pointless exception anymore.")
+```
+
 (R1733)=
 
 ### Unnecessary dict index lookup (R1733)

--- a/examples/pylint/w0133_pointless_exception_statement.py
+++ b/examples/pylint/w0133_pointless_exception_statement.py
@@ -1,0 +1,4 @@
+"""Pointless Exception Statement Example"""
+# The exception statement below is not raised, assigned,
+# or returned for use anywhere in this file.
+Exception("This is a pointless exception statement.")  # Error on this line


### PR DESCRIPTION
Added documentation and example of W0133 Pointless Exception Statement Checker

<!-- Provide a summary of your changes in the Pull Request Title above. --> 
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!-- Why is this pull request required? What problem does it solve? --> 
W0133 (pointless-exception-statement) is a new checker that got incorporated into PythonTA. This pull request adds a description for this new checker to ensure proper usage.
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**: Added documentation for checker W0133 (pointless-exception-statement), an example of a pointless exception statement that triggers the error, and a correction to the example that demonstrates proper usage.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Documentation update (change that modifies or updates documentation only)


## Testing

<!-- Please describe in detail how you tested this pull request. --> 
Used pylint scans to ensure the example evokes and the correction resolves the error W0133. Also did manual proofreading.
<!-- This can include tests you added and manual testing. -->

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
