### PR TITLE
Modified GlobalVariablesChecker to allow for type alias assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Can now create control flow graphs to visualize the execution of your program.
 - The `TopLevelCodeChecker` now allows type alias assignment statements at the top level, i.e., doesn't flag such lines
   of code as an error.
+- The `GlobalVariablesChecker` now allows type alias assignment statements at the top level, i.e., doesn't flag such
+  lines of code as an error.
 
 ### New checkers
 

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -80,9 +80,6 @@ class GlobalVariablesChecker(BaseChecker):
 def _get_child_disallowed_global_var_nodes(node):
     """Return a list of all top-level Name or AssignName nodes for a given
     global, non-constant variable.
-
-    TODO: use the configured NamingStyle instead of hard-coded SnakeCaseStyle
-    for the CONST_NAME_RGX value.
     """
     node_list = []
     if (

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -5,6 +5,8 @@ import re
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.base import UpperCaseStyle
+from pylint.checkers.base.name_checker.checker import DEFAULT_PATTERNS
+from pylint.checkers.utils import is_builtin
 
 from python_ta.utils import _is_in_main
 
@@ -13,7 +15,7 @@ class GlobalVariablesChecker(BaseChecker):
     name = "global_variables"
     msgs = {
         "E9997": (
-            "Global variables must be constants in CSC108/CSC148: " "%s",
+            "Global variables must be constants or type aliases in CSC108/CSC148: " "%s",
             "forbidden-global-variables",
             "",
         )
@@ -31,13 +33,13 @@ class GlobalVariablesChecker(BaseChecker):
         self.add_message("forbidden-global-variables", node=node, args=args)
 
     def visit_assignname(self, node):
-        """Allow global constant variables (uppercase), but issue messages for
+        """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
     def visit_name(self, node):
-        """Allow global constant variables (uppercase), but issue messages for
+        """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
@@ -58,7 +60,7 @@ class GlobalVariablesChecker(BaseChecker):
                 self.import_names.append(name_tuple[0])  # no alias
 
     def _inspect_vars(self, node):
-        """Allows constant, global variables (i.e. uppercase), but issue
+        """Allows constant, global variables (i.e. uppercase) and type aliases (i.e. type alias pattern), but issue
         messages for all other global variables.
         """
         if hasattr(node, "name") and node.name in self.import_names:
@@ -79,7 +81,7 @@ class GlobalVariablesChecker(BaseChecker):
 
 def _get_child_disallowed_global_var_nodes(node):
     """Return a list of all top-level Name or AssignName nodes for a given
-    global, non-constant variable.
+    global, non-constant and non-type alias variable.
     """
     node_list = []
     if (
@@ -87,7 +89,11 @@ def _get_child_disallowed_global_var_nodes(node):
             isinstance(node, (nodes.AssignName, nodes.Name))
             and not isinstance(node.parent, nodes.Call)
         )
-        and not re.match(UpperCaseStyle.CONST_NAME_RGX, node.name)
+        and not (
+            re.match(UpperCaseStyle.CONST_NAME_RGX, node.name)
+            or re.match(DEFAULT_PATTERNS["typealias"], node.name)
+        )
+        and not is_builtin(node.name)
         and node.scope() is node.root()
     ):
         return [node]

--- a/tests/test_custom_checkers/test_global_variables_checker.py
+++ b/tests/test_custom_checkers/test_global_variables_checker.py
@@ -1,0 +1,33 @@
+import astroid
+import pylint.testutils
+
+from python_ta.checkers.global_variables_checker import GlobalVariablesChecker
+
+
+class TestGlobalVariablesChecker(pylint.testutils.CheckerTestCase):
+    CHECKER_CLASS = GlobalVariablesChecker
+
+    def test_no_message_global_type_alias_assignment(self):
+        """Global type alias assignment allowed, no message."""
+        src = """
+        MyType = list[list[list[int]]]
+        """
+        mod = astroid.parse(src)
+        with self.assertNoMessages():
+            self.checker.visit_assignname(mod)
+
+    def test_message_global_type_alias_assignment(self):
+        """Global type alias assignment not allowed, raises a message."""
+        src = """
+        TypeName = list[int]
+        """
+        mod = astroid.parse(src)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="forbidden-global-variables",
+                node=mod.globals["TypeName"][0],
+                args="a global variable 'TypeName' is assigned to on line 2",
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_assignname(mod)

--- a/tests/test_custom_checkers/test_global_variables_checker.py
+++ b/tests/test_custom_checkers/test_global_variables_checker.py
@@ -7,7 +7,7 @@ from python_ta.checkers.global_variables_checker import GlobalVariablesChecker
 class TestGlobalVariablesChecker(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = GlobalVariablesChecker
 
-    def test_no_message_global_type_alias_assignment(self):
+    def test_no_message_global_type_alias_assignment_builtin(self):
         """Global type alias assignment allowed, no message."""
         src = """
         MyType = list[list[list[int]]]
@@ -16,7 +16,7 @@ class TestGlobalVariablesChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_assignname(mod)
 
-    def test_message_global_type_alias_assignment(self):
+    def test_message_global_type_alias_assignment_builtin(self):
         """Global type alias assignment not allowed, raises a message."""
         src = """
         TypeName = list[int]
@@ -31,3 +31,16 @@ class TestGlobalVariablesChecker(pylint.testutils.CheckerTestCase):
             ignore_position=True,
         ):
             self.checker.visit_assignname(mod)
+
+    def test_no_message_global_type_alias_assignment_import(self):
+        """Global type alias assignment allowed, no message."""
+        src = """
+        import datetime
+        MyType = datetime.date
+        """
+        mod = astroid.parse(src)
+        attribute_node = [child for child in mod.body[1].get_children()][1]
+        attribute_name_node = [child for child in attribute_node.get_children()][0]
+        with self.assertNoMessages():
+            self.checker.visit_import(mod.body[0])
+            self.checker.visit_assignname(attribute_name_node)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
This pull request extends the GlobalVariablesChecker functionality to allow not just assignment to "constant" variables like MY_CONST, but also to type aliases like MyType = list[int].
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

**Description**: In the global_variables_checker.py file, added extra import statements to access the default pattern for the naming convention of type aliases as well as a pylint function to determine if a name is a python built-in name, and modified the _get_child_disallowed_global_var_nodes function to ignore type alias Name and AssignName nodes.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)


## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
-Ran PythonTA on sample lines of code, which were global variable assignment statements.
-Added test cases to check that GlobalVariablesChecker detects valid and invalid type alias assignments.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [X] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [X] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
