### PR TITLE
Highlighted blank lines in between functions for the message display of E9989 pep8-errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - For the message display of C0303 `trailing-whitespace`, trailing whitespaces are now appearing in the reporters,
   and only those spaces are highlighted rather than the entire line of code.
 - The `UnnecessaryIndexingChecker` now checks for a greater variety of loop/comprehension indexes.
-- For the message display of E9989 `pep8-errors`, all "blank line" messages are now custom-rendered, i.e., blank lines
-  are now highlighted instead of function signatures and instruction strings are added for required blank lines that
-  are missing.
 
 ### New checkers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - For the message display of C0303 `trailing-whitespace`, trailing whitespaces are now appearing in the reporters,
   and only those spaces are highlighted rather than the entire line of code.
 - The `UnnecessaryIndexingChecker` now checks for a greater variety of loop/comprehension indexes.
+- For the message display of E9989 `pep8-errors`, the blank lines in between functions are now highlighted instead of
+  the line that the second function starts on.
 
 ### New checkers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - The `UnnecessaryIndexingChecker` now checks for a greater variety of loop/comprehension indexes.
 - Modified configuration behaviour so when providing a config file, it only needs to contain the configuration options you want overridden.
 - Added the option `load_default_config` to `check_errors` and `check_all` to specify whether to automatically load the PythonTA default config.
+- For the message display of E9989 `pep8-errors`, all "blank line" messages are now custom-rendered, i.e., blank lines
+  are now highlighted instead of function signatures and instruction strings are added for required blank lines that
+  are missing.
 
 ### New checkers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - For the message display of C0303 `trailing-whitespace`, trailing whitespaces are now appearing in the reporters,
   and only those spaces are highlighted rather than the entire line of code.
 - The `UnnecessaryIndexingChecker` now checks for a greater variety of loop/comprehension indexes.
-- For the message display of E9989 `pep8-errors`, the blank lines in between functions are now highlighted instead of
-  the line that the second function starts on.
+- For the message display of E9989 `pep8-errors`, all "blank line" messages are now custom-rendered, i.e., blank lines
+  are now highlighted instead of function signatures and instruction strings are added for required blank lines that
+  are missing.
 
 ### New checkers
 

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -141,7 +141,7 @@ def render_pep8_blank_lines_in_between_functions(msg, _node, source_lines=None):
         )
         yield from render_context(msg.line, msg.line + 2, source_lines)
     else:
-        render_generic(msg, _node, source_lines)
+        yield from render_generic(msg, _node, source_lines)
 
 
 CUSTOM_MESSAGES = {

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -157,13 +157,12 @@ def render_pep8_blank_lines(msg, _node, source_lines=None):
                 )
                 for _ in range(0, 2)
             )
-            yield from render_context(msg.line, msg.line + 2, source_lines)
         else:
             line -= 1
             yield from render_context(line - 1, line + 1, source_lines)
             yield (line + 1, slice(None, None), LineType.ERROR, " " * 32)
             yield (None, slice(None, None), LineType.ERROR, '"""INSERT NEW BLANK LINE HERE"""')
-            yield from render_context(msg.line, msg.line + 2, source_lines)
+        yield from render_context(msg.line, msg.line + 2, source_lines)
     elif "too many blank lines" in msg.msg:
         line = msg.line - 1
         while source_lines[line - 1] == "\n":

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -130,15 +130,18 @@ def render_missing_space_in_doctest(msg, _node, source_lines=None):
 
 def render_pep8_blank_lines_in_between_functions(msg, _node, source_lines=None):
     """Render a PEP8 blank lines in between functions message."""
-    line = msg.line - 1
-    while source_lines[line - 1] == "\n":
-        line -= 1
-    yield from render_context(line - 1, line + 1, source_lines)
-    yield from (
-        (curr_line, slice(None, None), LineType.ERROR, " ")
-        for curr_line in range(line + 1, msg.line)
-    )
-    yield from render_context(msg.line, msg.line + 2, source_lines)
+    if "blank line" in msg.msg:
+        line = msg.line - 1
+        while source_lines[line - 1] == "\n":
+            line -= 1
+        yield from render_context(line - 1, line + 1, source_lines)
+        yield from (
+            (curr_line, slice(None, None), LineType.ERROR, " " * 20)
+            for curr_line in range(line + 1, msg.line)
+        )
+        yield from render_context(msg.line, msg.line + 2, source_lines)
+    else:
+        render_generic(msg, _node, source_lines)
 
 
 CUSTOM_MESSAGES = {

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -193,7 +193,7 @@ def render_pep8_errors_e302(msg, _node, source_lines=None):
 def render_pep8_errors_e303(msg, _node, source_lines=None):
     """Render a PEP8 too many blank lines message."""
     line = msg.line - 1
-    while source_lines[line - 1] == "\n":
+    while source_lines[line - 1].strip() == "":
         line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
     body = source_lines[msg.line - 1]
@@ -208,7 +208,7 @@ def render_pep8_errors_e303(msg, _node, source_lines=None):
 def render_pep8_errors_e304(msg, _node, source_lines=None):
     """Render a PEP8 blank lines found after function decorator message."""
     line = msg.line - 1
-    while source_lines[line - 1] == "\n":
+    while source_lines[line - 1].strip() == "":
         line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
     yield from (

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -128,6 +128,19 @@ def render_missing_space_in_doctest(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
+def render_pep8_blank_lines_in_between_functions(msg, _node, source_lines=None):
+    """Render a PEP8 blank lines in between functions message."""
+    line = msg.line - 1
+    while source_lines[line - 1] == "\n":
+        line -= 1
+    yield from render_context(line - 1, line + 1, source_lines)
+    yield from (
+        (curr_line, slice(None, None), LineType.ERROR, " ")
+        for curr_line in range(line + 1, msg.line)
+    )
+    yield from render_context(msg.line, msg.line + 2, source_lines)
+
+
 CUSTOM_MESSAGES = {
     "missing-module-docstring": render_missing_docstring,
     "missing-class-docstring": render_missing_docstring,
@@ -137,6 +150,7 @@ CUSTOM_MESSAGES = {
     "missing-return-type": render_missing_return_type,
     "too-many-arguments": render_too_many_arguments,
     "missing-space-in-doctest": render_missing_space_in_doctest,
+    "pep8-errors": render_pep8_blank_lines_in_between_functions,
 }
 
 

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -131,7 +131,7 @@ def render_missing_space_in_doctest(msg, _node, source_lines=None):
 
 
 def render_pep8_errors(msg, _node, source_lines=None):
-    """Render a PEP8 blank lines message."""
+    """Render a PEP8 error message."""
     if "expected 1 blank line," in msg.msg:
         yield from render_pep8_errors_e301(msg, _node, source_lines)
     elif "expected 2 blank lines," in msg.msg:
@@ -149,7 +149,7 @@ def render_pep8_errors(msg, _node, source_lines=None):
 
 
 def render_blank_line(line):
-    """Render a blank line."""
+    """Render a blank line for a PEP8 error message."""
     yield (line + 1, slice(None, None), LineType.ERROR, " " * 28)
 
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
In the PEP8 error check for the number of blank lines in between functions, the highlighted line is the line that the second function starts on, rather than the blank lines that precede it, which can be misleading. This pull request solves this problem by creating a new custom renderer that will highlight the blank lines in between functions to make it clear what the error is referring to.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Created a new custom renderer that will highlight the blank lines in between functions to make it clear what the error is referring to.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)
- [X] Other (please specify): Since this renderer is for all pep-8 error checkers, this change may modify the highlighting for other error messages in the reporters.

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
I have ran my code through PythonTA to ensure the HTML Report produces the desired outcome.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
I know that the specific PEP8 error checker for this situation is E302, but I believe that there is only one single PythonTA checker for all PEP8 errors. Thus, I wasn't sure how to customize this rendering function for only E302 because the 'msg' parameter only referred to a general PEP8 message (i.e., it's 'msg_id' attribute being E9989).
## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [X] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
