### PR TITLE
Fixed issue #917

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Modified configuration behaviour so when providing a config file, it only needs to contain the configuration options you want overridden.
 - Added the option `load_default_config` to `check_errors` and `check_all` to specify whether to automatically load the PythonTA default config.
 
+### Bug Fixes
+
+- Fixed bug where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`.
+
 ### New checkers
 
 Pylint checkers v2.16:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Bug Fixes
 
-- Fixed bug where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`
+- Fixed bug where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`.
 
 ### New checkers
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Bug Fixes
 
-- Fixed bug where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`.
+- Fixed bug where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`
 
 ### New checkers
 

--- a/python_ta/__main__.py
+++ b/python_ta/__main__.py
@@ -55,7 +55,7 @@ def main(
 
     # `config` is None if `-c` flag is not set
     if generate_config:
-        pylintrc_location = os.path.join(os.path.dirname(__file__), ".pylintrc")
+        pylintrc_location = os.path.join(os.path.dirname(__file__), "config/.pylintrc")
         with open(pylintrc_location, "r") as f:
             contents = f.read()
             print(contents)


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
This pull request fixed issue #917, where running `python3 -m python_ta --generate-config` yields a `FileNotFoundError`.
## Your Changes

<!-- Describe your changes here. -->

**Description**: The location of `.pylintrc` has changed from `python_ta/.pylintrc` to `python_ta/config/.pylintrc`, and this was not reflected in the `main` function in `python_ta/__main__.py`. Thus, I changed the file location from "`.pylintrc`" to "`config/.pylintrc`".

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
Checked in the Terminal and verified that a `FileNotFoundError` was not raised and the contents of the `.pylintrc` file was displayed instead.
## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Did some research into the test (3.10), and apparently error 429 is that the pull request has tried to access the PyTA project too many times. However, I don't believe that I have accessed the project since the afternoon. 
UPDATE: The error was not showing up anymore. 
## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
