### PR TITLE
Removed code snippet in the error message for config file parsing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed bug in how PythonTA reports error messages that occur when parsing configuration files.
 - Fixed bug where the HTML reporter would display all error occurrences of the same type despite stating that only a limited number was being shown.
 - Fixed bug where the JSON reporter was not limiting the number of error occurrences displayed with respect to `pyta-number-of-messages`.
+- Ensured some config file parsing errors no longer display incorrect lines of code as the source of the error.
 
 ### New checkers
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -248,7 +248,8 @@ def _override_config(linter: PyLinter, config_location: AnyStr) -> None:
     try:
         linter._parse_configuration_file(config_args)
     except _UnrecognizedOptionError as exc:
-        print(f"Unrecognized options: {', '.join(exc.options)}", file=sys.stderr)
+        unrecognized_options_message = ", ".join(exc.options)
+        linter.add_message("unrecognized-option", args=unrecognized_options_message, line=0)
 
     # Everything has been set up already so emit any stashed messages.
     linter._emit_stashed_messages()

--- a/python_ta/reporters/core.py
+++ b/python_ta/reporters/core.py
@@ -46,6 +46,7 @@ NO_SNIPPET = {
     "unknown-option-value",
     "config-parse-error",
     "useless-option-value",
+    "unrecognized-option",
 }
 
 

--- a/python_ta/reporters/core.py
+++ b/python_ta/reporters/core.py
@@ -44,6 +44,8 @@ class NewMessage:
 NO_SNIPPET = {
     "invalid-name",
     "unknown-option-value",
+    "config-parse-error",
+    "useless-option-value",
 }
 
 

--- a/tests/test_config/file_fixtures/test_f0011.pylintrc
+++ b/tests/test_config/file_fixtures/test_f0011.pylintrc
@@ -11,10 +11,5 @@ ignore-long-lines = ^\s*((# )?<?https?://\S+>?)|(>>>.*)$
 [FORBIDDEN IMPORT]
 extra-imports = math, tkinter
 
-[MESSAGES CONTROL]
-# To trigger W0012, R0022
-disable =
-    ooga, bad-continuation
-
-# To trigger E0015
-no-space-check =
+# To trigger F0011
+bad

--- a/tests/test_config/file_fixtures/test_with_errors.pylintrc
+++ b/tests/test_config/file_fixtures/test_with_errors.pylintrc
@@ -12,5 +12,6 @@ ignore-long-lines = ^\s*((# )?<?https?://\S+>?)|(>>>.*)$
 extra-imports = math, tkinter
 
 [MESSAGES CONTROL]
+# To trigger W0012, R0022
 disable =
-    ooga
+    ooga, bad-continuation

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -14,9 +14,11 @@ TEST_CONFIG = {
     "max-line-length": 120,
 }
 
+# Non-fatal config errors. Fatal errors will be checked individually.
 CONFIG_ERRORS_TO_CHECK = {
     "W0012",
     "R0022",
+    "E0015",
 }
 
 
@@ -131,7 +133,9 @@ def test_default_pylint_checks_in_no_default(configure_linter_no_default) -> Non
 
 def test_config_parsing_errors() -> None:
     """Test that the configuration options gets overridden without error when there are errors
-    parsing the config files."""
+    parsing the config files.
+
+    This checks the non-fatal errors from parsing the config file."""
     curr_dir = os.path.dirname(__file__)
     config = os.path.join(curr_dir, "file_fixtures", "test_with_errors.pylintrc")
     reporter = python_ta.reset_linter(config=config).reporter
@@ -145,6 +149,8 @@ def test_config_parsing_errors() -> None:
 def test_config_parsing_errors_no_default() -> None:
     """Test that the configuration options gets loaded without error when there are errors
     parsing the config files.
+
+    This checks the non-fatal errors from parsing the config file.
 
     The default options are not loaded from the PythonTA default config."""
     curr_dir = os.path.dirname(__file__)
@@ -198,3 +204,25 @@ def test_no_snippet_for_config_parsing_errors() -> None:
     ]
 
     assert all(snippet == "" for snippet in snippets)
+
+
+def test_config_parse_error(capsys) -> None:
+    """Test that F0011 (config-parse-error) correctly gets reported."""
+    curr_dir = os.path.dirname(__file__)
+    config = os.path.join(curr_dir, "file_fixtures", "test_f0011.pylintrc")
+    reporter = python_ta.check_all(module_name="examples/nodes/name.py", config=config)
+
+    msg_id = reporter.messages[config][0].msg_id
+
+    assert msg_id == "F0011"
+
+
+def test_config_parse_error_has_no_snippet() -> None:
+    """Test that F0011 (config-parse-error) correctly gets reported with no code snippet."""
+    curr_dir = os.path.dirname(__file__)
+    config = os.path.join(curr_dir, "file_fixtures", "test_f0011.pylintrc")
+    reporter = python_ta.check_all(module_name="examples/nodes/name.py", config=config)
+
+    snippet = reporter.messages[config][0].snippet
+
+    assert snippet == ""


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

From #920, it is apparent that pylint does not accurately display the lines containing the error for config file parsing errors. This PR aims to prevent the reporter from displaying the incorrect lines as the source of the error and simply show no code instead.

## Your Changes

<!-- Describe your changes here. -->

**Description**:

- Added certain config file parsing error ids to `NO_SNIPPET` which prevents the reporter from displaying incorrect lines as the sources of error.
- Generalized some test cases to include the newly blacklisted config file parsing errors.
- Added a new test case to verify that no snippet was built for the blacklisted config file parsing errors.
- Updated `_override_config` to add E0015 to the reporter instead of printing to `stderr`.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

- Ran the test suite and verified they all passed.
- Ran the modified and new tests and verified they passed.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

- ~~Did not include the `F0011` error in the updated tests since it seems to cause all other config file errors to be excluded. I ran the updated `test_config_parsing_errors` but included `F0011` in `CONFIG_ERRORS_TO_CHECK`, but after debugging, it seems to not report the `W0012` and `R0022` even though those errors are in the config file. Maybe since it's a "fatal" error, it stops pylint from checking for other errors?~~
- ~~`F0011` and `R0022` were the only errors that I was able to reproduce. The other errors whose id started with "00" were probably either command line or inline errors.~~
- `E0015` was not showing up in the reporter because the message was being printed to `stderr` instead inside of `_override_config`. I've updated it to now add the message to the reporter.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
