### PR TITLE
Improved the behavior of the contract checking new_setattr function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - When running `check_contracts` on a class with type aliases as type annotations for its attributes, the `NameError`
   that appears (which indicates that the type alias is undefined) is now resolved.
 - The default value of `pyta-number-of-messages` is now 0. This automatically displays all occurrences of the same error.
-- For the contract checking `new_setattr` function, the check for `ENABLE_CONTRACT_CHECKING` is now at the top of the
-  function body, any variables that depend only on `klass` are now defined in the outer function, the use of
-  `inspect.getouterframes` is now changed to improve efficiency, and the attribute value is now
-  restored to the original value if the `_check_invariants` call raises an error.
+- For the contract checking `new_setattr` function, any variables that depend only on `klass` are now defined in the
+  outer function, efficiency of code was improved, and the attribute value is now restored to the original value if the
+  `_check_invariants` call raises an error.
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - When running `check_contracts` on a class with type aliases as type annotations for its attributes, the `NameError`
   that appears (which indicates that the type alias is undefined) is now resolved.
 - The default value of `pyta-number-of-messages` is now 0. This automatically displays all occurrences of the same error.
+- For the contract checking `new_setattr` function, the check for `ENABLE_CONTRACT_CHECKING` is now at the top of the
+  function body, any variables that depend only on `klass` are now defined in the outer function, the use of
+  `inspect.getouterframes` is now changed to improve efficiency, and the attribute value is now
+  restored to the original value if the `_check_invariants` call raises an error.
 
 ### Bug Fixes
 

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -177,6 +177,9 @@ def add_class_invariants(klass: type) -> None:
                         f"Value {_display_value(value)} did not match type annotation for attribute "
                         f"{name}: {_display_annotation(cls_annotations[name])}"
                     ) from None
+            original_attr_value = None
+            if hasattr(super(klass, self), name):
+                original_attr_value = super(klass, self).__getattribute__(name)
             super(klass, self).__setattr__(name, value)
             frame_locals = inspect.currentframe().f_back.f_locals
             if self is not frame_locals.get("self"):
@@ -185,6 +188,10 @@ def add_class_invariants(klass: type) -> None:
                     try:
                         _check_invariants(self, klass, klass_mod.__dict__)
                     except PyTAContractError as e:
+                        if original_attr_value is None:
+                            super(klass, self).__delattr__(name)
+                        else:
+                            super(klass, self).__setattr__(name, original_attr_value)
                         raise AssertionError(str(e)) from None
 
     for attr, value in klass.__dict__.items():

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -177,7 +177,9 @@ def add_class_invariants(klass: type) -> None:
                         f"Value {_display_value(value)} did not match type annotation for attribute "
                         f"{name}: {_display_annotation(cls_annotations[name])}"
                     ) from None
-            original_attr_value = getattr(klass, name, None)
+            original_attr_value = None
+            if hasattr(super(klass, self), name):
+                original_attr_value = super(klass, self).__getattribute__(name)
             super(klass, self).__setattr__(name, value)
             frame_locals = inspect.currentframe().f_back.f_locals
             if self is not frame_locals.get("self"):
@@ -187,7 +189,7 @@ def add_class_invariants(klass: type) -> None:
                         _check_invariants(self, klass, klass_mod.__dict__)
                     except PyTAContractError as e:
                         if original_attr_value is None:
-                            delattr(klass, name)
+                            super(klass, self).__delattr__(name)
                         else:
                             super(klass, self).__setattr__(name, original_attr_value)
                         raise AssertionError(str(e)) from None

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -177,7 +177,7 @@ def add_class_invariants(klass: type) -> None:
                         f"Value {_display_value(value)} did not match type annotation for attribute "
                         f"{name}: {_display_annotation(cls_annotations[name])}"
                     ) from None
-            original_attr_value = getattr(klass, name)
+            original_attr_value = getattr(klass, name, None)
             super(klass, self).__setattr__(name, value)
             frame_locals = inspect.currentframe().f_back.f_locals
             if self is not frame_locals.get("self"):

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -176,8 +176,10 @@ def add_class_invariants(klass: type) -> None:
                     f"Value {_display_value(value)} did not match type annotation for attribute "
                     f"{name}: {_display_annotation(cls_annotations[name])}"
                 ) from None
+        original_attr_value_exists = False
         original_attr_value = None
         if hasattr(super(klass, self), name):
+            original_attr_value_exists = True
             original_attr_value = super(klass, self).__getattribute__(name)
         super(klass, self).__setattr__(name, value)
         frame_locals = inspect.currentframe().f_back.f_locals
@@ -187,10 +189,10 @@ def add_class_invariants(klass: type) -> None:
                 try:
                     _check_invariants(self, klass, klass_mod.__dict__)
                 except PyTAContractError as e:
-                    if original_attr_value is None:
-                        super(klass, self).__delattr__(name)
-                    else:
+                    if original_attr_value_exists:
                         super(klass, self).__setattr__(name, original_attr_value)
+                    else:
+                        super(klass, self).__delattr__(name)
                     raise AssertionError(str(e)) from None
 
     for attr, value in klass.__dict__.items():

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -167,32 +167,31 @@ def add_class_invariants(klass: type) -> None:
 
         Check representation invariants for this class when not within an instance method of the class.
         """
-        if ENABLE_CONTRACT_CHECKING:
-            if name in cls_annotations:
+        if name in cls_annotations:
+            try:
+                _debug(f"Checking type of attribute {attr} for {klass.__qualname__} instance")
+                check_type(name, value, cls_annotations[name])
+            except TypeError:
+                raise AssertionError(
+                    f"Value {_display_value(value)} did not match type annotation for attribute "
+                    f"{name}: {_display_annotation(cls_annotations[name])}"
+                ) from None
+        original_attr_value = None
+        if hasattr(super(klass, self), name):
+            original_attr_value = super(klass, self).__getattribute__(name)
+        super(klass, self).__setattr__(name, value)
+        frame_locals = inspect.currentframe().f_back.f_locals
+        if self is not frame_locals.get("self"):
+            # Only validating if the attribute is not being set in a instance/class method
+            if klass_mod is not None and ENABLE_CONTRACT_CHECKING:
                 try:
-                    _debug(f"Checking type of attribute {attr} for {klass.__qualname__} instance")
-                    check_type(name, value, cls_annotations[name])
-                except TypeError:
-                    raise AssertionError(
-                        f"Value {_display_value(value)} did not match type annotation for attribute "
-                        f"{name}: {_display_annotation(cls_annotations[name])}"
-                    ) from None
-            original_attr_value = None
-            if hasattr(super(klass, self), name):
-                original_attr_value = super(klass, self).__getattribute__(name)
-            super(klass, self).__setattr__(name, value)
-            frame_locals = inspect.currentframe().f_back.f_locals
-            if self is not frame_locals.get("self"):
-                # Only validating if the attribute is not being set in a instance/class method
-                if klass_mod is not None:
-                    try:
-                        _check_invariants(self, klass, klass_mod.__dict__)
-                    except PyTAContractError as e:
-                        if original_attr_value is None:
-                            super(klass, self).__delattr__(name)
-                        else:
-                            super(klass, self).__setattr__(name, original_attr_value)
-                        raise AssertionError(str(e)) from None
+                    _check_invariants(self, klass, klass_mod.__dict__)
+                except PyTAContractError as e:
+                    if original_attr_value is None:
+                        super(klass, self).__delattr__(name)
+                    else:
+                        super(klass, self).__setattr__(name, original_attr_value)
+                    raise AssertionError(str(e)) from None
 
     for attr, value in klass.__dict__.items():
         if inspect.isroutine(value):

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -177,9 +177,6 @@ def add_class_invariants(klass: type) -> None:
                         f"Value {_display_value(value)} did not match type annotation for attribute "
                         f"{name}: {_display_annotation(cls_annotations[name])}"
                     ) from None
-            original_attr_value = None
-            if hasattr(super(klass, self), name):
-                original_attr_value = super(klass, self).__getattribute__(name)
             super(klass, self).__setattr__(name, value)
             frame_locals = inspect.currentframe().f_back.f_locals
             if self is not frame_locals.get("self"):
@@ -188,10 +185,6 @@ def add_class_invariants(klass: type) -> None:
                     try:
                         _check_invariants(self, klass, klass_mod.__dict__)
                     except PyTAContractError as e:
-                        if original_attr_value is None:
-                            super(klass, self).__delattr__(name)
-                        else:
-                            super(klass, self).__setattr__(name, original_attr_value)
                         raise AssertionError(str(e)) from None
 
     for attr, value in klass.__dict__.items():

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -187,7 +187,7 @@ def add_class_invariants(klass: type) -> None:
                         _check_invariants(self, klass, klass_mod.__dict__)
                     except PyTAContractError as e:
                         if original_attr_value is None:
-                            super(klass, self).__delattr__(name)
+                            delattr(klass, name)
                         else:
                             super(klass, self).__setattr__(name, original_attr_value)
                         raise AssertionError(str(e)) from None

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -186,7 +186,10 @@ def add_class_invariants(klass: type) -> None:
                     try:
                         _check_invariants(self, klass, klass_mod.__dict__)
                     except PyTAContractError as e:
-                        super(klass, self).__setattr__(name, original_attr_value)
+                        if original_attr_value is None:
+                            super(klass, self).__delattr__(name)
+                        else:
+                            super(klass, self).__setattr__(name, original_attr_value)
                         raise AssertionError(str(e)) from None
 
     for attr, value in klass.__dict__.items():

--- a/tests/test_contracts_attr_value_restoration.py
+++ b/tests/test_contracts_attr_value_restoration.py
@@ -2,6 +2,9 @@ from python_ta.contracts import check_contracts
 
 
 def test_class_attr_value_restores_to_original_if_violates_rep_inv() -> None:
+    """Test to check whether the class attribute value is restored to the original value if a representation invariant
+    is violated."""
+
     @check_contracts
     class Person:
         """
@@ -17,3 +20,24 @@ def test_class_attr_value_restores_to_original_if_violates_rep_inv() -> None:
         my_person.age = -1
     except AssertionError:
         assert my_person.age == 0
+
+
+def test_class_attr_value_does_not_exist_if_violates_rep_inv() -> None:
+    """Test to check whether the class attribute value does not exist if a representation invariant
+    is violated."""
+
+    @check_contracts
+    class Person:
+        """
+        Representation Invariants:
+        - self.age >= 0
+        """
+
+        age: int
+
+    my_person = Person()
+
+    try:
+        my_person.age = -1
+    except AssertionError:
+        assert not hasattr(my_person, "age")

--- a/tests/test_contracts_attr_value_restoration.py
+++ b/tests/test_contracts_attr_value_restoration.py
@@ -1,0 +1,19 @@
+from python_ta.contracts import check_contracts
+
+
+def test_class_attr_value_restores_to_original_if_violates_rep_inv() -> None:
+    @check_contracts
+    class Person:
+        """
+        Representation Invariants:
+        - self.age >= 0
+        """
+
+        age: int = 0
+
+    my_person = Person()
+
+    try:
+        my_person.age = -1
+    except AssertionError:
+        assert my_person.age == 0


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
For the `new_setattr` function in `python_ta/contracts/__init__.py`, this pull request re-organizes certain variable definitions, changes the use of certain `inspect` functions, and fixes a bug with attribute value restoration when representation invariants are violated.
## Your Changes

<!-- Describe your changes here. -->

**Description**:
- Moved any variables that depend only on `klass`, but not `self/name/value`, to be defined in the outer function rather than inside `new_setattr`.
- Replaced `inspect.getouterframes` with the `f_back` to improve efficiency of code.
- The attribute value is restored to the original value if the `_check_invariants` call raises an error. 

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [X] New feature (non-breaking change which adds functionality)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
- Used an example in another file to ensure that `f_back` represents the frame that's currently being checked in the code.
- Added test case for the restoration of the attribute value to its original value if the `_check_invariants` call raises an error.
- Added test case for the attribute not existing if the `_check_invariants` call raises an error.
## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
For the 10 tests that didn't pass in `test_class_contracts`, I believe it was due to my change of moving `ENABLE_CONTRACT_CHECKING` to the top of the function body, so I don't think there's a way to make this test pass unless I don't don't move the constant. Additionally, for the 6 tests that didn't pass in `test_contracts`, the tests all passed in PyCharm when I ran them on my own branch, and I'm not too sure why that's the case because I double checked that the tests were the same both here and on my branch.
## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [X] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [X] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
