### PR TITLE
Fix double-spacing in PlainReporter and ColorReporter code snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed bug where the HTML reporter would display all error occurrences of the same type despite stating that only a limited number was being shown.
 - Fixed bug where the JSON reporter was not limiting the number of error occurrences displayed with respect to `pyta-number-of-messages`.
 - Ensured some config file parsing errors no longer display incorrect lines of code as the source of the error.
+- Remove line double-spacing in PlainReporter and ColorReporter output code snippets.
 
 ### New checkers
 

--- a/python_ta/reporters/core.py
+++ b/python_ta/reporters/core.py
@@ -241,7 +241,7 @@ class PythonTaReporter(BaseReporter):
             self.messages[self.current_file] = []
 
         with open(filepath, encoding="utf-8") as f:
-            self.source_lines = [line for line in f.readlines()]
+            self.source_lines = [line.rstrip("\r\n") for line in f.readlines()]
 
     def on_close(self, stats, previous_stats):
         """Hook called when a module finished analyzing.


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

An earlier change accidentally introduced extra newline characters in the reporter `source_lines`, which caused the code snippets to be displayed as "double-spaced" rather than the previous single spacing.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Removed the extra new lines.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Tested manually both the PlainReporter and ColorReporter. The HTML reporter was unaffected because the newline characters weren't rendered in HTML.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
