### PR TITLE
add type annotations for checkers files

### DIFF
--- a/python_ta/checkers/forbidden_import_checker.py
+++ b/python_ta/checkers/forbidden_import_checker.py
@@ -3,6 +3,7 @@ import inspect
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class ForbiddenImportChecker(BaseChecker):
@@ -39,7 +40,7 @@ class ForbiddenImportChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-import")
-    def visit_import(self, node):
+    def visit_import(self, node: nodes.Import):
         """visit an Import node"""
         temp = [
             name
@@ -56,7 +57,7 @@ class ForbiddenImportChecker(BaseChecker):
             )
 
     @only_required_for_messages("forbidden-import")
-    def visit_importfrom(self, node):
+    def visit_importfrom(self, node: nodes.ImportFrom):
         """visit an ImportFrom node"""
         if (
             node.modname not in self.linter.config.allowed_import_modules
@@ -65,7 +66,7 @@ class ForbiddenImportChecker(BaseChecker):
             self.add_message("forbidden-import", node=node, args=(node.modname, node.lineno))
 
     @only_required_for_messages("forbidden-import")
-    def visit_call(self, node):
+    def visit_call(self, node: nodes.Call):
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -81,6 +82,6 @@ class ForbiddenImportChecker(BaseChecker):
                         self.add_message("forbidden-import", node=node, args=args)
 
 
-def register(linter):
+def register(linter: PyLinter):
     """required method to auto register this checker"""
     linter.register_checker(ForbiddenImportChecker(linter))

--- a/python_ta/checkers/forbidden_import_checker.py
+++ b/python_ta/checkers/forbidden_import_checker.py
@@ -40,7 +40,7 @@ class ForbiddenImportChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-import")
-    def visit_import(self, node: nodes.Import):
+    def visit_import(self, node: nodes.Import) -> None:
         """visit an Import node"""
         temp = [
             name
@@ -57,7 +57,7 @@ class ForbiddenImportChecker(BaseChecker):
             )
 
     @only_required_for_messages("forbidden-import")
-    def visit_importfrom(self, node: nodes.ImportFrom):
+    def visit_importfrom(self, node: nodes.ImportFrom) -> None:
         """visit an ImportFrom node"""
         if (
             node.modname not in self.linter.config.allowed_import_modules
@@ -66,7 +66,7 @@ class ForbiddenImportChecker(BaseChecker):
             self.add_message("forbidden-import", node=node, args=(node.modname, node.lineno))
 
     @only_required_for_messages("forbidden-import")
-    def visit_call(self, node: nodes.Call):
+    def visit_call(self, node: nodes.Call) -> None:
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -82,6 +82,6 @@ class ForbiddenImportChecker(BaseChecker):
                         self.add_message("forbidden-import", node=node, args=args)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     """required method to auto register this checker"""
     linter.register_checker(ForbiddenImportChecker(linter))

--- a/python_ta/checkers/forbidden_io_function_checker.py
+++ b/python_ta/checkers/forbidden_io_function_checker.py
@@ -46,7 +46,7 @@ class IOFunctionChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-IO-function")
-    def visit_call(self, node: nodes.Call):
+    def visit_call(self, node: nodes.Call) -> None:
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -74,5 +74,5 @@ class IOFunctionChecker(BaseChecker):
                         self.add_message("forbidden-IO-function", node=node, args=name)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(IOFunctionChecker(linter))

--- a/python_ta/checkers/forbidden_io_function_checker.py
+++ b/python_ta/checkers/forbidden_io_function_checker.py
@@ -4,6 +4,7 @@
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 from python_ta.utils import _is_in_main
 
@@ -45,7 +46,7 @@ class IOFunctionChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-IO-function")
-    def visit_call(self, node):
+    def visit_call(self, node: nodes.Call):
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -73,5 +74,5 @@ class IOFunctionChecker(BaseChecker):
                         self.add_message("forbidden-IO-function", node=node, args=name)
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(IOFunctionChecker(linter))

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -1,6 +1,7 @@
 """checker for global variables
 """
 import re
+from typing import List
 
 from astroid import nodes
 from pylint.checkers import BaseChecker
@@ -25,42 +26,42 @@ class GlobalVariablesChecker(BaseChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def __init__(self, linter=None):
+    def __init__(self, linter=None) -> None:
         super().__init__(linter)
         self.import_names = []
 
-    def visit_global(self, node: nodes.Global):
+    def visit_global(self, node: nodes.Global) -> None:
         args = "the keyword 'global' is used on line {}".format(node.lineno)
         self.add_message("forbidden-global-variables", node=node, args=args)
 
-    def visit_assignname(self, node: nodes.AssignName):
+    def visit_assignname(self, node: nodes.AssignName) -> None:
         """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
-    def visit_name(self, node: nodes.Name):
+    def visit_name(self, node: nodes.Name) -> None:
         """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
-    def visit_import(self, node: nodes.Import):
+    def visit_import(self, node: nodes.Import) -> None:
         """Save the names of imports, to prevent mistaking for global vars."""
         self._store_name_or_alias(node)
 
-    def visit_importfrom(self, node: nodes.ImportFrom):
+    def visit_importfrom(self, node: nodes.ImportFrom) -> None:
         """Save the names of imports, to prevent mistaking for global vars."""
         self._store_name_or_alias(node)
 
-    def _store_name_or_alias(self, node: nodes.NodeNG):
+    def _store_name_or_alias(self, node: nodes.NodeNG) -> None:
         for name_tuple in node.names:
             if name_tuple[1] is not None:
                 self.import_names.append(name_tuple[1])  # aliased names
             else:
                 self.import_names.append(name_tuple[0])  # no alias
 
-    def _inspect_vars(self, node: nodes.NodeNG):
+    def _inspect_vars(self, node: nodes.NodeNG) -> None:
         """Allows constant, global variables (i.e. uppercase) and type aliases (i.e. type alias pattern), but issue
         messages for all other global variables.
         """
@@ -80,7 +81,7 @@ class GlobalVariablesChecker(BaseChecker):
                 self.add_message("forbidden-global-variables", node=node, args=args)
 
 
-def _get_child_disallowed_global_var_nodes(node: nodes.NodeNG):
+def _get_child_disallowed_global_var_nodes(node: nodes.NodeNG) -> List[nodes.NodeNG]:
     """Return a list of all top-level Name or AssignName nodes for a given
     global, non-constant and non-type alias variable.
     """
@@ -104,6 +105,6 @@ def _get_child_disallowed_global_var_nodes(node: nodes.NodeNG):
     return node_list
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     """required method to auto register this checker"""
     linter.register_checker(GlobalVariablesChecker(linter))

--- a/python_ta/checkers/global_variables_checker.py
+++ b/python_ta/checkers/global_variables_checker.py
@@ -7,6 +7,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.base import UpperCaseStyle
 from pylint.checkers.base.name_checker.checker import DEFAULT_PATTERNS
 from pylint.checkers.utils import is_builtin
+from pylint.lint import PyLinter
 
 from python_ta.utils import _is_in_main
 
@@ -28,38 +29,38 @@ class GlobalVariablesChecker(BaseChecker):
         super().__init__(linter)
         self.import_names = []
 
-    def visit_global(self, node):
+    def visit_global(self, node: nodes.Global):
         args = "the keyword 'global' is used on line {}".format(node.lineno)
         self.add_message("forbidden-global-variables", node=node, args=args)
 
-    def visit_assignname(self, node):
+    def visit_assignname(self, node: nodes.AssignName):
         """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
-    def visit_name(self, node):
+    def visit_name(self, node: nodes.Name):
         """Allow global constant variables (uppercase) and type aliases (type alias pattern), but issue messages for
         all other globals.
         """
         self._inspect_vars(node)
 
-    def visit_import(self, node):
+    def visit_import(self, node: nodes.Import):
         """Save the names of imports, to prevent mistaking for global vars."""
         self._store_name_or_alias(node)
 
-    def visit_importfrom(self, node):
+    def visit_importfrom(self, node: nodes.ImportFrom):
         """Save the names of imports, to prevent mistaking for global vars."""
         self._store_name_or_alias(node)
 
-    def _store_name_or_alias(self, node):
+    def _store_name_or_alias(self, node: nodes.NodeNG):
         for name_tuple in node.names:
             if name_tuple[1] is not None:
                 self.import_names.append(name_tuple[1])  # aliased names
             else:
                 self.import_names.append(name_tuple[0])  # no alias
 
-    def _inspect_vars(self, node):
+    def _inspect_vars(self, node: nodes.NodeNG):
         """Allows constant, global variables (i.e. uppercase) and type aliases (i.e. type alias pattern), but issue
         messages for all other global variables.
         """
@@ -79,7 +80,7 @@ class GlobalVariablesChecker(BaseChecker):
                 self.add_message("forbidden-global-variables", node=node, args=args)
 
 
-def _get_child_disallowed_global_var_nodes(node):
+def _get_child_disallowed_global_var_nodes(node: nodes.NodeNG):
     """Return a list of all top-level Name or AssignName nodes for a given
     global, non-constant and non-type alias variable.
     """
@@ -103,6 +104,6 @@ def _get_child_disallowed_global_var_nodes(node):
     return node_list
 
 
-def register(linter):
+def register(linter: PyLinter):
     """required method to auto register this checker"""
     linter.register_checker(GlobalVariablesChecker(linter))

--- a/python_ta/checkers/invalid_for_target_checker.py
+++ b/python_ta/checkers/invalid_for_target_checker.py
@@ -38,5 +38,5 @@ class InvalidForTargetChecker(BaseChecker):
             self.add_message("invalid-for-target", node=target, args=target.as_string())
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(InvalidForTargetChecker(linter))

--- a/python_ta/checkers/invalid_for_target_checker.py
+++ b/python_ta/checkers/invalid_for_target_checker.py
@@ -5,6 +5,7 @@ from typing import List, Union
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class InvalidForTargetChecker(BaseChecker):
@@ -37,5 +38,5 @@ class InvalidForTargetChecker(BaseChecker):
             self.add_message("invalid-for-target", node=target, args=target.as_string())
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(InvalidForTargetChecker(linter))

--- a/python_ta/checkers/invalid_name_checker.py
+++ b/python_ta/checkers/invalid_name_checker.py
@@ -305,7 +305,7 @@ class InvalidNameChecker(BaseChecker):
         self._check_name("module", node.name.split(".")[-1], node)
 
     @only_required_for_messages("naming-convention-violation")
-    def visit_classdef(self, node: nodes.ClassDef):
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
         """Visit a Class node to check for any name violations.
 
         Taken from pylint.checkers.base.name_checker.checker."""
@@ -325,7 +325,7 @@ class InvalidNameChecker(BaseChecker):
     visit_asyncfunctiondef = visit_functiondef
 
     @only_required_for_messages("naming-convention-violation")
-    def visit_assignname(self, node: nodes.AssignName):
+    def visit_assignname(self, node: nodes.AssignName) -> None:
         """Visit an AssignName node to check for any name violations.
 
         Taken from pylint.checkers.base.name_checker.checker."""

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -19,7 +19,7 @@ class InvalidRangeIndexChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("invalid-range-index")
-    def visit_call(self, node: nodes.Call):
+    def visit_call(self, node: nodes.Call) -> None:
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -52,6 +52,6 @@ class InvalidRangeIndexChecker(BaseChecker):
                         self.add_message("invalid-range-index", node=node, args=args)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     """required method to auto register this checker"""
     linter.register_checker(InvalidRangeIndexChecker(linter))

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -3,6 +3,7 @@ from ast import literal_eval
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class InvalidRangeIndexChecker(BaseChecker):
@@ -18,7 +19,7 @@ class InvalidRangeIndexChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("invalid-range-index")
-    def visit_call(self, node):
+    def visit_call(self, node: nodes.Call):
         if isinstance(node.func, nodes.Name):
             name = node.func.name
             # ignore the name if it's not a builtin (i.e. not defined in the
@@ -51,6 +52,6 @@ class InvalidRangeIndexChecker(BaseChecker):
                         self.add_message("invalid-range-index", node=node, args=args)
 
 
-def register(linter):
+def register(linter: PyLinter):
     """required method to auto register this checker"""
     linter.register_checker(InvalidRangeIndexChecker(linter))

--- a/python_ta/checkers/missing_space_in_doctest_checker.py
+++ b/python_ta/checkers/missing_space_in_doctest_checker.py
@@ -5,6 +5,7 @@ from typing import Match, Optional, Union
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 DOCTEST = ">>>"
 
@@ -37,7 +38,7 @@ class MissingSpaceInDoctestChecker(BaseChecker):
         self._check_docstring(node)
 
     # Helper Functions
-    def _check_docstring(self, node) -> None:
+    def _check_docstring(self, node: nodes.NodeNG) -> None:
         """Go through the docstring of the respective node type"""
         if node.doc_node is not None:
             docstring = node.doc_node.value or ""
@@ -63,6 +64,6 @@ class MissingSpaceInDoctestChecker(BaseChecker):
         return match
 
 
-def register(linter):
+def register(linter: PyLinter):
     """Required method to auto register this checker"""
     linter.register_checker(MissingSpaceInDoctestChecker(linter))

--- a/python_ta/checkers/missing_space_in_doctest_checker.py
+++ b/python_ta/checkers/missing_space_in_doctest_checker.py
@@ -64,6 +64,6 @@ class MissingSpaceInDoctestChecker(BaseChecker):
         return match
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     """Required method to auto register this checker"""
     linter.register_checker(MissingSpaceInDoctestChecker(linter))

--- a/python_ta/checkers/one_iteration_checker.py
+++ b/python_ta/checkers/one_iteration_checker.py
@@ -5,6 +5,7 @@ from typing import Union
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class OneIterationChecker(BaseChecker):
@@ -25,12 +26,12 @@ class OneIterationChecker(BaseChecker):
 
     # pass in message symbol as a parameter of only_required_for_messages
     @only_required_for_messages("one-iteration")
-    def visit_for(self, node):
+    def visit_for(self, node: nodes.For):
         if self._check_one_iteration(node):
             self.add_message("one-iteration", node=node)
 
     @only_required_for_messages("one-iteration")
-    def visit_while(self, node):
+    def visit_while(self, node: nodes.While):
         if self._check_one_iteration(node):
             self.add_message("one-iteration", node=node)
 
@@ -64,5 +65,5 @@ class OneIterationChecker(BaseChecker):
         return True
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(OneIterationChecker(linter))

--- a/python_ta/checkers/one_iteration_checker.py
+++ b/python_ta/checkers/one_iteration_checker.py
@@ -26,12 +26,12 @@ class OneIterationChecker(BaseChecker):
 
     # pass in message symbol as a parameter of only_required_for_messages
     @only_required_for_messages("one-iteration")
-    def visit_for(self, node: nodes.For):
+    def visit_for(self, node: nodes.For) -> None:
         if self._check_one_iteration(node):
             self.add_message("one-iteration", node=node)
 
     @only_required_for_messages("one-iteration")
-    def visit_while(self, node: nodes.While):
+    def visit_while(self, node: nodes.While) -> None:
         if self._check_one_iteration(node):
             self.add_message("one-iteration", node=node)
 
@@ -65,5 +65,5 @@ class OneIterationChecker(BaseChecker):
         return True
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(OneIterationChecker(linter))

--- a/python_ta/checkers/possibly_undefined_checker.py
+++ b/python_ta/checkers/possibly_undefined_checker.py
@@ -26,21 +26,21 @@ class PossiblyUndefinedChecker(BaseChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def __init__(self, linter=None):
+    def __init__(self, linter=None) -> None:
         super().__init__(linter=linter)
         self._possibly_undefined: Set[nodes.Name] = set()
 
     @only_required_for_messages("possibly-undefined")
-    def visit_name(self, node: nodes.Name):
+    def visit_name(self, node: nodes.Name) -> None:
         """Adds message if there exists a path from the start block to node where
         a variable used by node might not be defined."""
         if node in self._possibly_undefined:
             self.add_message("possibly-undefined", node=node)
 
-    def visit_module(self, node: nodes.Module):
+    def visit_module(self, node: nodes.Module) -> None:
         self._analyze(node)
 
-    def visit_functiondef(self, node: nodes.FunctionDef):
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         self._analyze(node)
 
     def _analyze(self, node: Union[nodes.Module, nodes.FunctionDef]) -> None:
@@ -148,5 +148,5 @@ class PossiblyUndefinedChecker(BaseChecker):
             yield from multiple_nodes(statement.get_children())
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(PossiblyUndefinedChecker(linter))

--- a/python_ta/checkers/possibly_undefined_checker.py
+++ b/python_ta/checkers/possibly_undefined_checker.py
@@ -6,6 +6,7 @@ from typing import Generator, Set, Union
 from astroid import nodes
 from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 from python_ta.cfg.graph import CFGBlock, ControlFlowGraph
 
@@ -30,16 +31,16 @@ class PossiblyUndefinedChecker(BaseChecker):
         self._possibly_undefined: Set[nodes.Name] = set()
 
     @only_required_for_messages("possibly-undefined")
-    def visit_name(self, node):
+    def visit_name(self, node: nodes.Name):
         """Adds message if there exists a path from the start block to node where
         a variable used by node might not be defined."""
         if node in self._possibly_undefined:
             self.add_message("possibly-undefined", node=node)
 
-    def visit_module(self, node):
+    def visit_module(self, node: nodes.Module):
         self._analyze(node)
 
-    def visit_functiondef(self, node):
+    def visit_functiondef(self, node: nodes.FunctionDef):
         self._analyze(node)
 
     def _analyze(self, node: Union[nodes.Module, nodes.FunctionDef]) -> None:
@@ -147,5 +148,5 @@ class PossiblyUndefinedChecker(BaseChecker):
             yield from multiple_nodes(statement.get_children())
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(PossiblyUndefinedChecker(linter))

--- a/python_ta/checkers/pycodestyle_checker.py
+++ b/python_ta/checkers/pycodestyle_checker.py
@@ -1,3 +1,5 @@
+from typing import List, Tuple
+
 import pycodestyle
 from astroid import nodes
 from pylint.checkers import BaseRawFileChecker
@@ -23,7 +25,7 @@ class PycodestyleChecker(BaseRawFileChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def process_module(self, node: nodes.NodeNG):
+    def process_module(self, node: nodes.NodeNG) -> None:
         style_guide = pycodestyle.StyleGuide(
             paths=[node.stream().name],
             reporter=JSONReport,
@@ -36,7 +38,7 @@ class PycodestyleChecker(BaseRawFileChecker):
 
 
 class JSONReport(pycodestyle.StandardReport):
-    def get_file_results(self):
+    def get_file_results(self) -> List[Tuple]:
         self._deferred_print.sort()
         return [
             (line_number, f"line {line_number}, column {offset}: {text}")
@@ -44,6 +46,6 @@ class JSONReport(pycodestyle.StandardReport):
         ]
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     """required method to auto register this checker"""
     linter.register_checker(PycodestyleChecker(linter))

--- a/python_ta/checkers/pycodestyle_checker.py
+++ b/python_ta/checkers/pycodestyle_checker.py
@@ -1,5 +1,7 @@
 import pycodestyle
+from astroid import nodes
 from pylint.checkers import BaseRawFileChecker
+from pylint.lint import PyLinter
 
 
 class PycodestyleChecker(BaseRawFileChecker):
@@ -21,7 +23,7 @@ class PycodestyleChecker(BaseRawFileChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def process_module(self, node):
+    def process_module(self, node: nodes.NodeNG):
         style_guide = pycodestyle.StyleGuide(
             paths=[node.stream().name],
             reporter=JSONReport,
@@ -42,6 +44,6 @@ class JSONReport(pycodestyle.StandardReport):
         ]
 
 
-def register(linter):
+def register(linter: PyLinter):
     """required method to auto register this checker"""
     linter.register_checker(PycodestyleChecker(linter))

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -13,6 +13,7 @@ from typing import List, Set, Union
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 from python_ta.cfg.graph import CFGBlock, ControlFlowGraph
 
@@ -139,5 +140,5 @@ class RedundantAssignmentChecker(BaseChecker):
         return assigns.difference(kills)
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(RedundantAssignmentChecker(linter))

--- a/python_ta/checkers/redundant_assignment_checker.py
+++ b/python_ta/checkers/redundant_assignment_checker.py
@@ -33,24 +33,24 @@ class RedundantAssignmentChecker(BaseChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def __init__(self, linter=None):
+    def __init__(self, linter=None) -> None:
         super().__init__(linter=linter)
         self._redundant_assignment: Set[nodes.Assign] = set()
 
     @only_required_for_messages("redundant-assignment")
-    def visit_assign(self, node: nodes.Assign):
+    def visit_assign(self, node: nodes.Assign) -> None:
         if node in self._redundant_assignment:
             self.add_message("redundant-assignment", node=node)
 
     @only_required_for_messages("redundant-assignment")
-    def visit_augassign(self, node: nodes.AugAssign):
+    def visit_augassign(self, node: nodes.AugAssign) -> None:
         if node in self._redundant_assignment:
             self.add_message("redundant-assignment", node=node)
 
-    def visit_module(self, node: nodes.Module):
+    def visit_module(self, node: nodes.Module) -> None:
         self._analyze(node)
 
-    def visit_functiondef(self, node: nodes.FunctionDef):
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         self._analyze(node)
 
     def _analyze(self, node: Union[nodes.Module, nodes.FunctionDef]) -> None:
@@ -140,5 +140,5 @@ class RedundantAssignmentChecker(BaseChecker):
         return assigns.difference(kills)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(RedundantAssignmentChecker(linter))

--- a/python_ta/checkers/shadowing_in_comprehension_checker.py
+++ b/python_ta/checkers/shadowing_in_comprehension_checker.py
@@ -3,6 +3,7 @@
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class ShadowingInComprehensionChecker(BaseChecker):
@@ -31,5 +32,5 @@ class ShadowingInComprehensionChecker(BaseChecker):
                 self.add_message("shadowing-in-comprehension", node=node.target, args=args)
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(ShadowingInComprehensionChecker(linter))

--- a/python_ta/checkers/shadowing_in_comprehension_checker.py
+++ b/python_ta/checkers/shadowing_in_comprehension_checker.py
@@ -20,7 +20,7 @@ class ShadowingInComprehensionChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("shadowing-in-comprehension")
-    def visit_comprehension(self, node: nodes.Comprehension):
+    def visit_comprehension(self, node: nodes.Comprehension) -> None:
         if isinstance(node.target, nodes.Tuple):
             for target in node.target.elts:
                 if target.name in node.parent.frame().locals and target.name != "_":
@@ -32,5 +32,5 @@ class ShadowingInComprehensionChecker(BaseChecker):
                 self.add_message("shadowing-in-comprehension", node=node.target, args=args)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(ShadowingInComprehensionChecker(linter))

--- a/python_ta/checkers/top_level_code_checker.py
+++ b/python_ta/checkers/top_level_code_checker.py
@@ -5,6 +5,7 @@ from pylint.checkers import BaseChecker
 from pylint.checkers.base import UpperCaseStyle
 from pylint.checkers.base.name_checker.checker import DEFAULT_PATTERNS
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class TopLevelCodeChecker(BaseChecker):
@@ -22,7 +23,7 @@ class TopLevelCodeChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-top-level-code")
-    def visit_module(self, node):
+    def visit_module(self, node: nodes.Module):
         for statement in node.body:
             if not (
                 _is_import(statement)
@@ -34,21 +35,21 @@ class TopLevelCodeChecker(BaseChecker):
 
 
 # Helper functions
-def _is_import(statement) -> bool:
+def _is_import(statement: nodes.NodeNG) -> bool:
     """
     Return whether or not <statement> is an Import or an ImportFrom.
     """
     return isinstance(statement, (nodes.Import, nodes.ImportFrom))
 
 
-def _is_definition(statement) -> bool:
+def _is_definition(statement: nodes.NodeNG) -> bool:
     """
     Return whether or not <statement> is a function definition or a class definition.
     """
     return isinstance(statement, (nodes.FunctionDef, nodes.ClassDef))
 
 
-def _is_allowed_assignment(statement) -> bool:
+def _is_allowed_assignment(statement: nodes.NodeNG) -> bool:
     """
     Return whether or not <statement> is a constant assignment or type alias assignment.
     """
@@ -66,7 +67,7 @@ def _is_allowed_assignment(statement) -> bool:
     )
 
 
-def _is_main_block(statement) -> bool:
+def _is_main_block(statement: nodes.NodeNG) -> bool:
     """
     Return whether or not <statement> is the main block.
     """
@@ -83,5 +84,5 @@ def _is_main_block(statement) -> bool:
     )
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(TopLevelCodeChecker(linter))

--- a/python_ta/checkers/top_level_code_checker.py
+++ b/python_ta/checkers/top_level_code_checker.py
@@ -23,7 +23,7 @@ class TopLevelCodeChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("forbidden-top-level-code")
-    def visit_module(self, node: nodes.Module):
+    def visit_module(self, node: nodes.Module) -> None:
         for statement in node.body:
             if not (
                 _is_import(statement)
@@ -84,5 +84,5 @@ def _is_main_block(statement: nodes.NodeNG) -> bool:
     )
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(TopLevelCodeChecker(linter))

--- a/python_ta/checkers/type_annotation_checker.py
+++ b/python_ta/checkers/type_annotation_checker.py
@@ -36,7 +36,7 @@ class TypeAnnotationChecker(BaseChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def is_type(self, node: nodes.NodeNG):
+    def is_type(self, node: nodes.NodeNG) -> bool:
         """Check if nodes such as <Name.int ...> represent builtin types."""
         inferred = node.inferred()
         if len(inferred) > 0 and inferred[0] is not Uninferable:
@@ -45,7 +45,7 @@ class TypeAnnotationChecker(BaseChecker):
         return False
 
     @only_required_for_messages("missing-param-type", "missing-return-type", "type-is-assigned")
-    def visit_functiondef(self, node: nodes.FunctionDef):
+    def visit_functiondef(self, node: nodes.FunctionDef) -> None:
         arguments = node.args.args
         names = [argument.name for argument in arguments]
         annotations = node.args.annotations
@@ -69,7 +69,7 @@ class TypeAnnotationChecker(BaseChecker):
             self.add_message("missing-return-type", node=node.args)
 
     @only_required_for_messages("missing-attribute-type", "type-is-assigned")
-    def visit_classdef(self, node: nodes.ClassDef):
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
         for attr_key in node.instance_attrs:
             attr_node = node.instance_attrs[attr_key][0]
             if isinstance(attr_node, nodes.AssignAttr):
@@ -89,5 +89,5 @@ class TypeAnnotationChecker(BaseChecker):
                     self.add_message("type-is-assigned", node=attr_node)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(TypeAnnotationChecker(linter))

--- a/python_ta/checkers/type_annotation_checker.py
+++ b/python_ta/checkers/type_annotation_checker.py
@@ -5,6 +5,7 @@ from astroid import Uninferable, nodes
 from astroid.exceptions import NoDefault
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class TypeAnnotationChecker(BaseChecker):
@@ -35,7 +36,7 @@ class TypeAnnotationChecker(BaseChecker):
     # this is important so that your checker is executed before others
     priority = -1
 
-    def is_type(self, node):
+    def is_type(self, node: nodes.NodeNG):
         """Check if nodes such as <Name.int ...> represent builtin types."""
         inferred = node.inferred()
         if len(inferred) > 0 and inferred[0] is not Uninferable:
@@ -44,7 +45,7 @@ class TypeAnnotationChecker(BaseChecker):
         return False
 
     @only_required_for_messages("missing-param-type", "missing-return-type", "type-is-assigned")
-    def visit_functiondef(self, node):
+    def visit_functiondef(self, node: nodes.FunctionDef):
         arguments = node.args.args
         names = [argument.name for argument in arguments]
         annotations = node.args.annotations
@@ -68,7 +69,7 @@ class TypeAnnotationChecker(BaseChecker):
             self.add_message("missing-return-type", node=node.args)
 
     @only_required_for_messages("missing-attribute-type", "type-is-assigned")
-    def visit_classdef(self, node):
+    def visit_classdef(self, node: nodes.ClassDef):
         for attr_key in node.instance_attrs:
             attr_node = node.instance_attrs[attr_key][0]
             if isinstance(attr_node, nodes.AssignAttr):
@@ -88,5 +89,5 @@ class TypeAnnotationChecker(BaseChecker):
                     self.add_message("type-is-assigned", node=attr_node)
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(TypeAnnotationChecker(linter))

--- a/python_ta/checkers/type_inference_checker.py
+++ b/python_ta/checkers/type_inference_checker.py
@@ -1,8 +1,10 @@
 """checker for type inference errors.
 """
 
+from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 from python_ta.typecheck.base import TypeFail
 
@@ -21,7 +23,7 @@ class TypeInferenceChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("type-error")
-    def visit_default(self, node):
+    def visit_default(self, node: nodes.NodeNG):
         if hasattr(node, "inf_type"):
             x = node.inf_type
             if isinstance(x, TypeFail):
@@ -35,5 +37,5 @@ class TypeInferenceChecker(BaseChecker):
                 self.add_message("type-error", args=x.msg, node=node)
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(TypeInferenceChecker(linter))

--- a/python_ta/checkers/type_inference_checker.py
+++ b/python_ta/checkers/type_inference_checker.py
@@ -23,7 +23,7 @@ class TypeInferenceChecker(BaseChecker):
     priority = -1
 
     @only_required_for_messages("type-error")
-    def visit_default(self, node: nodes.NodeNG):
+    def visit_default(self, node: nodes.NodeNG) -> None:
         if hasattr(node, "inf_type"):
             x = node.inf_type
             if isinstance(x, TypeFail):
@@ -37,5 +37,5 @@ class TypeInferenceChecker(BaseChecker):
                 self.add_message("type-error", args=x.msg, node=node)
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(TypeInferenceChecker(linter))

--- a/python_ta/checkers/unnecessary_indexing_checker.py
+++ b/python_ta/checkers/unnecessary_indexing_checker.py
@@ -169,5 +169,5 @@ def _index_name_nodes(
     ]
 
 
-def register(linter: PyLinter):
+def register(linter: PyLinter) -> None:
     linter.register_checker(UnnecessaryIndexingChecker(linter))

--- a/python_ta/checkers/unnecessary_indexing_checker.py
+++ b/python_ta/checkers/unnecessary_indexing_checker.py
@@ -6,6 +6,7 @@ import astroid
 from astroid import nodes
 from pylint.checkers import BaseChecker
 from pylint.checkers.utils import only_required_for_messages
+from pylint.lint import PyLinter
 
 
 class UnnecessaryIndexingChecker(BaseChecker):
@@ -168,5 +169,5 @@ def _index_name_nodes(
     ]
 
 
-def register(linter):
+def register(linter: PyLinter):
     linter.register_checker(UnnecessaryIndexingChecker(linter))


### PR DESCRIPTION
## Motivation and Context

The functions in the custom checkers files do not have type annotations which can make it difficult to understand the purpose of the function's parameters and what theur 

## Your Changes

**Description**:
Added type annotations for all of the parameters for the functions in the files under the 'checkers' folder.

**Type of change** (select all that apply):

- [x] Refactoring (internal change to codebase, without changing functionality)


## Testing
I ensured the code still functioned after making my changes by calling python_ta.check_all locally using the checkers that had the type annotations added.


## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
