### PR TITLE
seperate __init__.py for handling config related functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Simeon Krastnikov,
 Ryan Lee,
 Hayley Lin,
 Bruce Liu,
-Merrick Liu
+Merrick Liu,
 Wendy Liu,
 Yibing (Amy) Lu,
 Shweta Mogalapalli,

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Simeon Krastnikov,
 Ryan Lee,
 Hayley Lin,
 Bruce Liu,
-Merrick Liu,
+Merrick Liu
 Wendy Liu,
 Yibing (Amy) Lu,
 Shweta Mogalapalli,

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -22,10 +22,10 @@ import builtins
 from pylint.lint import PyLinter
 
 from python_ta.config import (
-    _find_local_config,
-    _load_config,
-    _load_messages_config,
-    _override_config,
+    find_local_config,
+    load_config,
+    load_messages_config,
+    override_config,
 )
 
 from .reporters.core import PythonTaReporter

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -40,6 +40,7 @@ import os
 import sys
 import tokenize
 import webbrowser
+from builtins import FileNotFoundError
 from os import listdir
 from typing import AnyStr, Generator, List, Optional, TextIO, Union
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -121,7 +121,7 @@ def _check(
     current_reporter.set_output(output)
     messages_config_path = linter.config.messages_config_path
     messages_config_default_path = linter._option_dicts["messages-config-path"]["default"]
-    messages_config = _load_messages_config(messages_config_path, messages_config_default_path)
+    messages_config = load_messages_config(messages_config_path, messages_config_default_path)
 
     global PYLINT_PATCHED
     if not PYLINT_PATCHED:
@@ -304,13 +304,13 @@ def reset_linter(
     linter.load_plugin_modules(custom_checkers)
     linter.load_plugin_modules(["python_ta.transforms.setendings"])
 
-    default_config_path = _find_local_config(os.path.dirname(__file__))
-    set_config = _load_config
+    default_config_path = find_local_config(os.path.dirname(__file__))
+    set_config = load_config
 
     if load_default_config:
-        _load_config(linter, default_config_path)
+        load_config(linter, default_config_path)
         # If we do specify to load the default config, we just need to override the options later.
-        set_config = _override_config
+        set_config = override_config
 
     if isinstance(config, str) and config != "":
         set_config(linter, config)
@@ -318,7 +318,7 @@ def reset_linter(
         # If available, use config file at directory of the file being linted.
         pylintrc_location = None
         if file_linted:
-            pylintrc_location = _find_local_config(file_linted)
+            pylintrc_location = find_local_config(file_linted)
 
         # Load or override the options if there is a config file in the current directory.
         if pylintrc_location:

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -19,9 +19,14 @@ __version__ = "2.6.2.dev"  # Version number
 # First, remove underscore from builtins if it has been bound in the REPL.
 import builtins
 
-from pylint.config.config_file_parser import _ConfigurationFileParser
-from pylint.config.exceptions import _UnrecognizedOptionError
 from pylint.lint import PyLinter
+
+from python_ta.config import (
+    _find_local_config,
+    _load_config,
+    _load_messages_config,
+    _override_config,
+)
 
 from .reporters.core import PythonTaReporter
 
@@ -35,17 +40,13 @@ import os
 import sys
 import tokenize
 import webbrowser
-from builtins import FileNotFoundError
 from os import listdir
-from pathlib import Path
 from typing import AnyStr, Generator, List, Optional, TextIO, Union
 
 import pylint.config
 import pylint.lint
 import pylint.utils
-import toml
 from astroid import MANAGER, modutils
-from pylint.config.config_initialization import _config_initialization
 from pylint.utils.pragma_parser import OPTION_PO
 
 from .patches import patch_all
@@ -206,84 +207,6 @@ def _check(
         )
         print('[ERROR] Error message: "{}"'.format(e))
         raise e
-
-
-def _find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
-    """Search for a `.pylintrc` configuration file provided in same (user)
-    location as the source file to check.
-    Return absolute path to the file, or None.
-    `curr_dir` is an absolute path to a directory, containing a file to check.
-    For more info see, pylint.config.find_pylintrc
-    """
-    if curr_dir.endswith(".py"):
-        curr_dir = os.path.dirname(curr_dir)
-    if os.path.exists(os.path.join(curr_dir, "config", ".pylintrc")):
-        return os.path.join(curr_dir, "config", ".pylintrc")
-    elif os.path.exists(os.path.join(curr_dir, "config", "pylintrc")):
-        return os.path.join(curr_dir, "config", "pylintrc")
-
-
-def _load_config(linter: PyLinter, config_location: AnyStr) -> None:
-    """Load configuration into the linter."""
-    _config_initialization(linter, args_list=[], config_file=config_location)
-    linter.config_file = config_location
-
-
-def _override_config(linter: PyLinter, config_location: AnyStr) -> None:
-    """Override the default linter configuration options (if possible).
-
-    Snippets taken from pylint.config.config_initialization.
-    """
-    linter.set_current_module(config_location)
-
-    # Read the configuration file.
-    config_file_parser = _ConfigurationFileParser(verbose=True, linter=linter)
-    try:
-        _, config_args = config_file_parser.parse_config_file(file_path=config_location)
-    except OSError as ex:
-        print(ex, file=sys.stderr)
-        sys.exit(32)
-
-    # Override the config options by parsing the provided file.
-    try:
-        linter._parse_configuration_file(config_args)
-    except _UnrecognizedOptionError as exc:
-        unrecognized_options_message = ", ".join(exc.options)
-        linter.add_message("unrecognized-option", args=unrecognized_options_message, line=0)
-
-    # Everything has been set up already so emit any stashed messages.
-    linter._emit_stashed_messages()
-
-    linter.config_file = config_location
-
-
-def _load_messages_config(path: str, default_path: str) -> dict:
-    """Given path (potentially) specified by user and default default_path
-    of messages config file, merge the config files."""
-    merge_into = toml.load(default_path)
-
-    if Path(default_path).resolve() == Path(path).resolve():
-        return merge_into
-
-    try:
-        merge_from = toml.load(path)
-    except FileNotFoundError:
-        print(
-            f"[WARNING] Could not find messages config file at {str(Path(path).resolve())}. Using default messages config file at {str(Path(default_path).resolve())}."
-        )
-        return merge_into
-
-    for category in merge_from:
-        if category not in merge_into:
-            merge_into[category] = {}
-        for checker in merge_from[category]:
-            if checker not in merge_into[category]:
-                merge_into[category][checker] = {}
-            for error_code in merge_from[category][checker]:
-                merge_into[category][checker][error_code] = merge_from[category][checker][
-                    error_code
-                ]
-    return merge_into
 
 
 def reset_linter(
@@ -456,11 +379,11 @@ def _verify_pre_check(filepath: AnyStr) -> bool:
         print(
             "[ERROR] python_ta could not check your code due to an "
             + "invalid character. Please check the following lines "
-            "in your file and all characters that are marked with a �."
+            "in your file and all characters that are marked with a  ."
         )
         with open(os.path.expanduser(filepath), encoding="utf-8", errors="replace") as f:
             for i, line in enumerate(f):
-                if "�" in line:
+                if " " in line:
                     print(f"  Line {i}: {line}", end="")
         return False
     return True

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -21,13 +21,12 @@ import builtins
 
 from pylint.lint import PyLinter
 
-from python_ta.config import (
+from .config import (
     find_local_config,
     load_config,
     load_messages_config,
     override_config,
 )
-
 from .reporters.core import PythonTaReporter
 
 try:

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -380,11 +380,11 @@ def _verify_pre_check(filepath: AnyStr) -> bool:
         print(
             "[ERROR] python_ta could not check your code due to an "
             + "invalid character. Please check the following lines "
-            "in your file and all characters that are marked with a  ."
+            "in your file and all characters that are marked with a �."
         )
         with open(os.path.expanduser(filepath), encoding="utf-8", errors="replace") as f:
             for i, line in enumerate(f):
-                if " " in line:
+                if "�" in line:
                     print(f"  Line {i}: {line}", end="")
         return False
     return True

--- a/python_ta/config/__init__.py
+++ b/python_ta/config/__init__.py
@@ -1,0 +1,101 @@
+""" Python Teaching Assistant - Configuration
+
+Within the config submodule, this .py file encompasses functions responsible
+ for managing all configuration-related tasks.
+"""
+__version__ = "2.6.2.dev"  # Version number
+
+import os
+import sys
+from pathlib import Path
+from typing import AnyStr, Optional
+
+import toml
+from pylint.config.config_file_parser import _ConfigurationFileParser
+from pylint.config.config_initialization import _config_initialization
+from pylint.config.exceptions import _UnrecognizedOptionError
+from pylint.lint import PyLinter
+
+HELP_URL = "http://www.cs.toronto.edu/~david/pyta/checkers/index.html"
+
+# check the python version
+if sys.version_info < (3, 7, 0):
+    print("[WARNING] You need Python 3.7 or later to run PythonTA.")
+
+
+def _find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
+    """Search for a `.pylintrc` configuration file provided in same (user)
+    location as the source file to check.
+    Return absolute path to the file, or None.
+    `curr_dir` is an absolute path to a directory, containing a file to check.
+    For more info see, pylint.config.find_pylintrc
+    """
+    if curr_dir.endswith(".py"):
+        curr_dir = os.path.dirname(curr_dir)
+    if os.path.exists(os.path.join(curr_dir, "config", ".pylintrc")):
+        return os.path.join(curr_dir, "config", ".pylintrc")
+    elif os.path.exists(os.path.join(curr_dir, "config", "pylintrc")):
+        return os.path.join(curr_dir, "config", "pylintrc")
+
+
+def _load_config(linter: PyLinter, config_location: AnyStr) -> None:
+    """Load configuration into the linter."""
+    _config_initialization(linter, args_list=[], config_file=config_location)
+    linter.config_file = config_location
+
+
+def _override_config(linter: PyLinter, config_location: AnyStr) -> None:
+    """Override the default linter configuration options (if possible).
+
+    Snippets taken from pylint.config.config_initialization.
+    """
+    linter.set_current_module(config_location)
+
+    # Read the configuration file.
+    config_file_parser = _ConfigurationFileParser(verbose=True, linter=linter)
+    try:
+        _, config_args = config_file_parser.parse_config_file(file_path=config_location)
+    except OSError as ex:
+        print(ex, file=sys.stderr)
+        sys.exit(32)
+
+    # Override the config options by parsing the provided file.
+    try:
+        linter._parse_configuration_file(config_args)
+    except _UnrecognizedOptionError as exc:
+        unrecognized_options_message = ", ".join(exc.options)
+        linter.add_message("unrecognized-option", args=unrecognized_options_message, line=0)
+
+    # Everything has been set up already so emit any stashed messages.
+    linter._emit_stashed_messages()
+
+    linter.config_file = config_location
+
+
+def _load_messages_config(path: str, default_path: str) -> dict:
+    """Given path (potentially) specified by user and default default_path
+    of messages config file, merge the config files."""
+    merge_into = toml.load(default_path)
+
+    if Path(default_path).resolve() == Path(path).resolve():
+        return merge_into
+
+    try:
+        merge_from = toml.load(path)
+    except FileNotFoundError:
+        print(
+            f"[WARNING] Could not find messages config file at {str(Path(path).resolve())}. Using default messages config file at {str(Path(default_path).resolve())}."
+        )
+        return merge_into
+
+    for category in merge_from:
+        if category not in merge_into:
+            merge_into[category] = {}
+        for checker in merge_from[category]:
+            if checker not in merge_into[category]:
+                merge_into[category][checker] = {}
+            for error_code in merge_from[category][checker]:
+                merge_into[category][checker][error_code] = merge_from[category][checker][
+                    error_code
+                ]
+    return merge_into

--- a/python_ta/config/__init__.py
+++ b/python_ta/config/__init__.py
@@ -1,9 +1,7 @@
-""" Python Teaching Assistant - Configuration
-
+"""
 Within the config submodule, this .py file encompasses functions responsible
  for managing all configuration-related tasks.
 """
-__version__ = "2.6.2.dev"  # Version number
 
 import os
 import sys
@@ -16,14 +14,8 @@ from pylint.config.config_initialization import _config_initialization
 from pylint.config.exceptions import _UnrecognizedOptionError
 from pylint.lint import PyLinter
 
-HELP_URL = "http://www.cs.toronto.edu/~david/pyta/checkers/index.html"
 
-# check the python version
-if sys.version_info < (3, 7, 0):
-    print("[WARNING] You need Python 3.7 or later to run PythonTA.")
-
-
-def _find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
+def find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
     """Search for a `.pylintrc` configuration file provided in same (user)
     location as the source file to check.
     Return absolute path to the file, or None.
@@ -38,13 +30,13 @@ def _find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
         return os.path.join(curr_dir, "config", "pylintrc")
 
 
-def _load_config(linter: PyLinter, config_location: AnyStr) -> None:
+def load_config(linter: PyLinter, config_location: AnyStr) -> None:
     """Load configuration into the linter."""
     _config_initialization(linter, args_list=[], config_file=config_location)
     linter.config_file = config_location
 
 
-def _override_config(linter: PyLinter, config_location: AnyStr) -> None:
+def override_config(linter: PyLinter, config_location: AnyStr) -> None:
     """Override the default linter configuration options (if possible).
 
     Snippets taken from pylint.config.config_initialization.
@@ -72,7 +64,7 @@ def _override_config(linter: PyLinter, config_location: AnyStr) -> None:
     linter.config_file = config_location
 
 
-def _load_messages_config(path: str, default_path: str) -> dict:
+def load_messages_config(path: str, default_path: str) -> dict:
     """Given path (potentially) specified by user and default default_path
     of messages config file, merge the config files."""
     merge_into = toml.load(default_path)


### PR DESCRIPTION
## Motivation and Context

In the `python_ta/__init__.py` file, we currently have functions that handle configuration-related tasks. However, we also have a dedicated `config` file within the `python_ta` directory, specifically designed for managing configuration-related features in PythonTA. It would be beneficial to organize our code in a more structured manner by placing a `__init__.py` file under the proper submodule (`python_ta.config`). This `__init__.py` file would encapsulate all configuration-related functions for PythonTA, enhancing code organization and clarity.

## Your Changes

**Description**:

Firstly, I created a new `.py` file under the submodule `python_ta.config` named `__init__.py`. Subsequently, I transferred all configuration-related functions, **along with the required import statements**, from `python_ta/__init__.py` to this new file. I also removed the unused import statements from `python_ta/__init__.py`, which were previously utilized by the aforementioned functions. Additionally, I noticed a minor typo in the `README.md` file and promptly corrected it.

**Type of change** (select all that apply):

- [X] New feature (non-breaking change which adds functionality)
- [X] Refactoring (internal change to codebase, without changing functionality)
- [X] Documentation update (change that modifies or updates documentation only)

## Testing

After applying these changes, I imported `python_ta` and called its user-utilized functions (e.g., `python_ta.check_all`) on multiple examples. Everything seems to be working smoothly!

## Questions and Comments (if applicable)

I have two specific questions related to the code-base:

1. I'm curious about our approach to accessing protected members of certain modules (e.g., `pylint`). While Python allows flexibility in terms of "privacy", is this considered a best practice?
2. I've observed that our import statements are organized and ordered in a specific manner. Is there a particular convention that we are adhering to?

## Checklist

- [X] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
