### PR TITLE
Fix invalid-name-checker for '_' and non-astroid.Const constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Bug fixes
+
+- Fix `naming-convention-violation` bug where `_` was considered an invalid variable name.
+- Fix `naming-convention-violation` bug where top-level constants were being checked as regular variable names.
+
 ### Enhancements
 
 - Created many custom renderers to make the code snippets for `pep8-errors` easier to understand.

--- a/python_ta/checkers/invalid_name_checker.py
+++ b/python_ta/checkers/invalid_name_checker.py
@@ -170,7 +170,7 @@ def _check_function_and_variable_name(node_type: str, name: str) -> List[str]:
     Returns an empty list if `name` is a valid function or variable name."""
     error_msgs = []
 
-    if not _is_in_snake_case(name):
+    if name != "_" and not _is_in_snake_case(name):
         error_msgs.append(
             f'{node_type.capitalize()} name "{name}" should be in snake_case format. '
             f"{node_type.capitalize()} names should be lowercase, with words "
@@ -382,7 +382,7 @@ class InvalidNameChecker(BaseChecker):
                     self._check_name("class", node.name, node)
 
                 # Don't emit if the name redefines an import in an ImportError except handler.
-                elif not _redefines_import(node) and isinstance(inferred_assign_type, nodes.Const):
+                elif not _redefines_import(node):
                     self._check_name("constant", node.name, node)
                 else:
                     self._check_name("variable", node.name, node)

--- a/tests/test_custom_checkers/test_invalid_name_checker.py
+++ b/tests/test_custom_checkers/test_invalid_name_checker.py
@@ -39,6 +39,20 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_module(module_node)
 
+    def test_module_name_underscore(self) -> None:
+        """Test that the checker does not report an error when the module name starts with an
+        underscore.
+        """
+        src = """
+        i = "hi"
+        """
+        mod = astroid.parse(src)
+        module_node, *_ = mod.nodes_of_class(nodes.Module)
+        module_node.name = "_my_module"
+
+        with self.assertNoMessages():
+            self.checker.visit_module(module_node)
+
     def test_const_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid const name."""
         src = """
@@ -59,6 +73,28 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_assignname(assignname_node)
+
+    def test_const_name_underscore(self) -> None:
+        """Test that the checker does not report a const name that starts with an underscore."""
+        src = """
+        _MY_PRIVATE_CONST = "it is not"
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
+    def test_const_name_list(self) -> None:
+        """Test that the checker does not report a const name that is assigned to a list."""
+        src = """
+        MY_CONSTANT_LIST = [1, 2, 3]
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
             self.checker.visit_assignname(assignname_node)
 
     def test_class_name_violation(self) -> None:
@@ -84,6 +120,18 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_classdef(classdef_node)
 
+    def test_class_name_underscore(self) -> None:
+        """Test that the checker does not report a class name that starts with an underscore."""
+        src = """
+        class _MyClass:
+            pass
+        """
+        mod = astroid.parse(src)
+        classdef_node, *_ = mod.nodes_of_class(nodes.ClassDef)
+
+        with self.assertNoMessages():
+            self.checker.visit_classdef(classdef_node)
+
     def test_function_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid function name."""
         src = """
@@ -105,6 +153,18 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_functiondef(functiondef_node)
+
+    def test_function_name_underscore(self) -> None:
+        """Test that the checker does not report a function name that starts with an underscore."""
+        src = """
+        def _my_function():
+            pass
+        """
+        mod = astroid.parse(src)
+        functiondef_node, *_ = mod.nodes_of_class(nodes.FunctionDef)
+
+        with self.assertNoMessages():
             self.checker.visit_functiondef(functiondef_node)
 
     def test_method_name_violation(self) -> None:
@@ -132,6 +192,19 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_functiondef(functiondef_node)
 
+    def test_method_name_underscore(self) -> None:
+        """Test that the checker does not report a method name that starts with an underscore."""
+        src = """
+        class BadClass:
+            def _my_function(self):
+                pass
+        """
+        mod = astroid.parse(src)
+        functiondef_node, *_ = mod.nodes_of_class(nodes.FunctionDef)
+
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(functiondef_node)
+
     def test_attr_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid attr name."""
         src = """
@@ -156,6 +229,18 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_assignname(assignname_node)
 
+    def test_attr_name_underscore(self) -> None:
+        """Test that the checker does not report an attribute name that starts with an underscore."""
+        src = """
+        class GoodClass:
+            _attr: str
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
     def test_argument_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid argument name."""
         src = """
@@ -176,6 +261,18 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_assignname(argument_node)
+
+    def test_argument_name_underscore(self) -> None:
+        """Test that the checker does not report an argument name that starts with an underscore."""
+        src = """
+        def good(_name: str) -> None:
+            print(_name)
+        """
+        mod = astroid.parse(src)
+        argument_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
             self.checker.visit_assignname(argument_node)
 
     def test_variable_name_violation(self) -> None:
@@ -199,6 +296,31 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_assignname(assignname_node)
+
+    def test_variable_name_leading_underscore(self) -> None:
+        """Test that the checker does not report a variable name that starts with an underscore."""
+        src = """
+        def f():
+            _my_var = 10
+            print(_my_var)
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
+    def test_variable_name_underscore(self) -> None:
+        """Test that the checker does not report a variable name that is just an underscore."""
+        src = """
+        for _ in range(10):
+            print('hi')
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
             self.checker.visit_assignname(assignname_node)
 
     def test_class_attribute_name_violation(self) -> None:
@@ -227,6 +349,21 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_assignname(assignname_node)
 
+    def test_class_attribute_name_underscore(self) -> None:
+        """Test that the checker does not report a class attribute name that starts with an
+        underscore."""
+        src = """
+        from typing import ClassVar
+
+        class BadClass:
+            _snake_case: ClassVar = "CONSTANT"
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
     def test_class_const_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid class constant name."""
         src = """
@@ -253,6 +390,21 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_assignname(assignname_node)
 
+    def test_class_const_name_underscore(self) -> None:
+        """Test that the checker does not report a class constant name that starts with an
+        underscore."""
+        src = """
+        from typing import Final
+
+        class BadClass:
+            _MY_CONSTANT: Final = "CONSTANT"
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
     def test_typevar_name_violation(self) -> None:
         """Test that the checker correctly reports an invalid typevar name."""
         src = """
@@ -275,6 +427,19 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_assignname(assignname_node)
+
+    def test_typevar_name_underscore(self) -> None:
+        """Test that the checker does not report a typevar name that starts with an underscore."""
+        src = """
+        from typing import TypeVar
+
+        _MyTypeVar = TypeVar('type_var', str, float)
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
             self.checker.visit_assignname(assignname_node)
 
     @unittest.skipIf(sys.version_info < (3, 10, 0), "TypeAlias was new in version 3.10.")
@@ -300,6 +465,20 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
             ),
             ignore_position=True,
         ):
+            self.checker.visit_assignname(assignname_node)
+
+    @unittest.skipIf(sys.version_info < (3, 10, 0), "TypeAlias was new in version 3.10.")
+    def test_typealias_name_underscore(self) -> None:
+        """Test that the checker does not report a type alias name that starts with an underscore."""
+        src = """
+        from typing import TypeAlias
+
+        _MyTypeAlias: TypeAlias = dict, str
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+
+        with self.assertNoMessages():
             self.checker.visit_assignname(assignname_node)
 
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The new `invalid-name-checker` had two bugs: it didn't allow `_` as a variable name (indicating unused names) and used the wrong check for top-level constants that were assigned to objects that were not `Const` nodes (e.g., lists).

This PR fixes #955.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Fixed both of the above issues.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Added additional test cases and tested manually with various files.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
