### PR TITLE
Fix `check_contracts` typings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Bug fixes
 
 - Ensure pycodestyle W503, line break before binary operator, is disabled (regression from 2.6.2).
+- Fix `check_contracts` typings so PyCharm static checking will work
 
 ## [2.6.2] - 2023-09-22
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Christopher Koehler,
 David Kim,
 Simeon Krastnikov,
 Ryan Lee,
+Christopher Li,
 Hayley Lin,
 Bruce Liu,
 Merrick Liu

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -13,7 +13,7 @@ import inspect
 import sys
 import typing
 from types import CodeType, FunctionType, ModuleType
-from typing import Any, Callable, List, Optional, Set, Tuple
+from typing import Any, Callable, List, Optional, Set, Tuple, TypeVar, Union, overload
 
 import wrapt
 from typeguard import CollectionCheckStrategy, TypeCheckError, check_type
@@ -95,7 +95,23 @@ def _enable_function_contracts(wrapped, instance, args, kwargs):
         raise AssertionError(str(e)) from None
 
 
-def check_contracts(func_or_class: Any, module_names: Optional[Set[str]] = None) -> Callable:
+# Wildcard Type Variable
+Class = TypeVar("Class", bound=type)
+
+
+@overload
+def check_contracts(func: FunctionType, module_names: Optional[Set[str]] = None) -> FunctionType:
+    ...
+
+
+@overload
+def check_contracts(func: Class, module_names: Optional[Set[str]] = None) -> Class:
+    ...
+
+
+def check_contracts(
+    func_or_class: Union[Class, FunctionType], module_names: Optional[Set[str]] = None
+) -> Union[Class, FunctionType]:
     """A decorator to enable contract checking for a function or class.
 
     When used with a class, all methods defined within the class have contract checking enabled.


### PR DESCRIPTION
## Motivation and Context

Addresses #961 

## Your Changes

**Description**:

- I added `Class = TypeVar("Class", bound=type)` as a wildcard to match classes
- I created 2 overload methods for `check_contracts` that better reflects how the function works

**Type of change** (select all that apply):

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

I tested the following code and PyCharm doesn't show `Cannot find reference '__init__' in '(...)->Any'`

```python
from python_ta.contracts import check_contracts


@check_contracts
class Foo:
    def __init__(self):
        self.a = 5


@check_contracts
class Bar(Foo):
    def __init__(self):
        Foo.__init__(self)


```

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
