### PR TITLE
Add config option to choose whether to overwrite Pylint error messages

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -94,6 +94,19 @@ python_ta.check_all(..., output='pyta_output.txt')
 This options is compatible with all of PythonTA's reporter types, but we do not recommend its use with ColorReporter,
 as this reporter uses terminal-specific characters to colourize text displayed on your screen.
 
+## Overwrite Error Messages
+
+By default, PythonTA overwrites Pylint's error messages with its own to make them more reader-friendly. You can specify whether
+you want Pylint's default error messages instead using the `overwrite-error-messages` option. For example, use the following configuration to
+see Pylint's error messages:
+
+```python
+import python_ta
+python_ta.check_all(config={
+    "overwrite-error-messages": False
+})
+```
+
 ## Forbidden Imports
 
 By default, PythonTA has a list of modules that are allowed to be imported. You can specify any additional modules using the `extra-imports` configuration option, which you can set in a call to `python_ta.check_all` or in a configuration file.

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -120,10 +120,12 @@ def _check(
     messages_config_path = linter.config.messages_config_path
     messages_config_default_path = linter._option_dicts["messages-config-path"]["default"]
     messages_config = _load_messages_config(messages_config_path, messages_config_default_path)
-
+    overwrite_error_messages = linter.config.overwrite_error_messages
     global PYLINT_PATCHED
     if not PYLINT_PATCHED:
-        patch_all(messages_config)  # Monkeypatch pylint (override certain methods)
+        patch_all(
+            messages_config, overwrite_error_messages
+        )  # Monkeypatch pylint (override certain methods)
         PYLINT_PATCHED = True
 
     # Try to check file, issue error message for invalid files.
@@ -361,6 +363,15 @@ def reset_linter(
                 "type": "string",
                 "metavar": "<messages_config>",
                 "help": "Path to patch config toml file.",
+            },
+        ),
+        (
+            "overwrite-error-messages",
+            {
+                "default": True,
+                "type": "yn",
+                "metavar": "<yn>",
+                "help": "Overwrite the default pylint error messages",
             },
         ),
     )

--- a/python_ta/config/.pylintrc
+++ b/python_ta/config/.pylintrc
@@ -23,6 +23,9 @@ pyta-server-address = http://127.0.0.1:5000
 # Path to messages_config toml file
 # messages-config-path = messages.toml
 
+# Set whether the default error messages by pylint should be overwritten by python TA's custom messages
+overwrite-error-messages = yes
+
 [REPORTS]
 # The type of reporter to use to display results. Available PyTA classes are
 # PlainReporter, ColorReporter, HTMLReporter, JSONReporter.

--- a/python_ta/patches/__init__.py
+++ b/python_ta/patches/__init__.py
@@ -6,9 +6,10 @@ from .messages import patch_messages
 from .transforms import patch_ast_transforms
 
 
-def patch_all(messages_config: dict):
+def patch_all(messages_config: dict, overwrite_error_messages: bool):
     """Execute all patches defined in this module."""
     patch_checkers()
     patch_ast_transforms()
     patch_messages()
-    patch_error_messages(messages_config)
+    if overwrite_error_messages:
+        patch_error_messages(messages_config)


### PR DESCRIPTION
## Motivation and Context

Currently, all Pylint error messages are overwritten by custom Python TA error messages to make them more reader-friendly. However, in case the user wants to see the default Pylint messages instead, they have no flexibility. Now, users can simply add a config option if they don't want the Pylint messages to be overwritten.

## Your Changes

<!-- Describe your changes here. -->

**Description**:
Added a new custom configuration option representing whether the Pylint error messages should be overwritten (default is True). Add logic to only overwrite the error messages when the config option is True. Also added documentation specifying the purpose and usage of  the new config option.

**Type of change** (select all that apply):

- [x] New feature (non-breaking change which adds functionality)


## Testing

I ran python_ta.check_all without the config option, with the config option as True, and with it as False. In all cases, the expected output was received. This was also to make sure that the checkers still worked and that the new changes didn't create bugs. I ran the test cases for pyta as well to ensure everything was working as expected.

## Questions and Comments (if applicable)

If I have a pending pull request and made new changes to my fork, should I also pull in those changes when making a second pull request?

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->

