### PR TITLE
Fix bug in invalid_range_checker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix `naming-convention-violation` bug where `_` was considered an invalid variable name.
 - Fix `naming-convention-violation` bug where top-level constants were being checked as regular variable names.
+- Fix `invalid-range-index` bug where `range(1, 5, 3)` would not pass the check
 
 ### Enhancements
 

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -26,7 +26,12 @@ class InvalidRangeIndexChecker(BaseChecker):
             if not (name in node.frame() or name in node.root()) and name == "range":
                 arg = node.args  # the arguments of 'range' call
                 # guard nodes (e.g. Name) not properly handled by literal_eval.
-                if any([not isinstance(item, nodes.Const) for item in arg]):
+                if any(
+                    [
+                        not isinstance(item, nodes.Const) and not isinstance(item, nodes.UnaryOp)
+                        for item in arg
+                    ]
+                ):
                     return
                 eval_parm = list(map(lambda z: literal_eval(z.as_string()), arg))
 
@@ -44,8 +49,8 @@ class InvalidRangeIndexChecker(BaseChecker):
                     if (
                         abs(eval_parm[2]) >= abs(eval_parm[0] - eval_parm[1])
                         or eval_parm[2] == 0
-                        or (eval_parm[0] > eval_parm[1] and eval_parm[2] < 0)
-                        or (eval_parm[0] < eval_parm[1] and eval_parm[2] > 0)
+                        or (eval_parm[0] > eval_parm[1] and eval_parm[2] > 0)
+                        or (eval_parm[0] < eval_parm[1] and eval_parm[2] < 0)
                     ):
                         args = "{}".format(node.lineno)
                         self.add_message("invalid-range-index", node=node, args=args)

--- a/tests/test_custom_checkers/test_invalid_range_checker.py
+++ b/tests/test_custom_checkers/test_invalid_range_checker.py
@@ -1,0 +1,85 @@
+"""Test suite for testing the InvalidRangeIndexChecker."""
+import astroid
+import pylint.testutils
+
+from python_ta.checkers.invalid_range_index_checker import InvalidRangeIndexChecker
+
+
+class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
+    CHECKER_CLASS = InvalidRangeIndexChecker
+
+    def _test_invalid(self, src):
+        mod = astroid.parse(src)
+        node, *_ = mod.nodes_of_class(astroid.nodes.Call)
+
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(msg_id="invalid-range-index", node=node, line=1, args="1"),
+            ignore_position=True,
+        ):
+            self.checker.visit_call(node)
+
+    def _test_valid(self, src):
+        mod = astroid.parse(src)
+        node, *_ = mod.nodes_of_class(astroid.nodes.Call)
+
+        with self.assertNoMessages():
+            self.checker.visit_call(node)
+
+    def test_zero_param(self) -> None:
+        """Tests range()"""
+
+        self._test_invalid("range()")
+
+    def test_one_param(self) -> None:
+        """Tests range(x) where x >= 2"""
+
+        self._test_valid("range(5)")
+
+    def test_invalid_one_param(self) -> None:
+        """Tests range(x) where x < 2"""
+
+        self._test_invalid("range(1)")
+        self._test_invalid("range(0)")
+        self._test_invalid("range(-1)")
+
+    def test_two_param(self) -> None:
+        """Tests range(x, y) where y - x >= 2"""
+
+        self._test_valid("range(2, 5)")
+
+    def test_invalid_two_param(self) -> None:
+        """Tests range(x, y) where y - x < 2"""
+
+        self._test_invalid("range(2, 3)")
+        self._test_invalid("range(2, 2)")
+        self._test_invalid("range(2, 1)")
+
+    def test_non_int_param(self) -> None:
+        """Tests range(x) where x is not int"""
+
+        self._test_invalid("range(5.5)")
+
+    def test_three_param(self) -> None:
+        """Tests range(x, y, z) where y - x < 2"""
+
+        self._test_valid("range(1, 5, 3)")
+        self._test_valid("range(5, 1, -3)")
+
+    def test_three_param_big_inc(self) -> None:
+        """Tests range(x, y, z) where abs(z) > abs(x - y)"""
+
+        self._test_invalid("range(1, 5, 12)")
+        self._test_invalid("range(1, 5, -12)")
+        self._test_invalid("range(1, -5, 12)")
+        self._test_invalid("range(-1, -5, 12)")
+
+    def test_three_param_zero_inc(self) -> None:
+        """Tests range(x, y, z) where z = 0"""
+
+        self._test_invalid("range(1, 5, 0)")
+
+    def test_three_param_opposite_inc(self) -> None:
+        """Tests range(x, y, z) where z is going in the wrong direction"""
+
+        self._test_invalid("range(1, 5, -2)")
+        self._test_invalid("range(5, 1, 2)")


### PR DESCRIPTION
## Motivation and Context

Addresses #967

## Your Changes

**Description**:

- In `invalid_range_checker.py`, I reversed the signs on lines 52 and 53 to fix the bug
- In `invalid_range_checker.py`, I added `and not isinstance(item, nodes.UnaryOp)` because negative numbers wouldn't be caught
- I created `test_invalid_range_checker.py` since there was no test written for it

**Type of change** (select all that apply):

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Test update (change that modifies or updates tests only)

## Testing

Created `test_invalid_range_checker.py` and made sure all the checks would pass

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [ ] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
