### PR TITLE
Ensure pycodestyle W503 is disabled by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Bug fixes
+
+- Ensure pycodestyle W503, line break before binary operator, is disabled (regression from 2.6.2).
+
 ## [2.6.2] - 2023-09-22
 
 ### Bug fixes

--- a/python_ta/config/.pylintrc
+++ b/python_ta/config/.pylintrc
@@ -134,5 +134,5 @@ pycodestyle-ignore =
     W292,  # pylint C0304
     W293,  # pylint C0303
     W391,  # pylint C0305
-    W503   # this one just conflicts with pycodestyle W504
+    W503,  # this one just conflicts with pycodestyle W504
     W605,  # pylint W1401


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Looks like #938 accidentally introduced a bug in re-enabling pycodestyle's W503 error (due to a misconfiguration in the default `.pylintrc` file).

## Your Changes

<!-- Describe your changes here. -->

**Description**: Fixed the .pylintrc file.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Manual testing to verify that this check is now disabled by default.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
