### PR TITLE
fix limitation 2 for accumulation table and add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Both PlainReporter and ColorReporter emphasize specific code chunks by using overline characters under any part that is highlighted as ERROR.
 - Added new configuration option `allow-pylint-comments` to let users choose whether PythonTA should allow comments beginning with pylint: or not.
 - `AccumulationTable` can now track variables initialized within the `for` loop. Prior, only variables initialized before the `for` loop could be tracked.
+- `AccumulationTable` can now take in any accumulator expressions, for eg. `x * 2`, instead of just variables
 
 ## [2.6.4] - 2024-11-10
 

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -134,20 +134,10 @@ The `AccumulationTable` is a new PythonTA feature and currently has the followin
 
 1. `AccumulationTable` uses [`sys.settrace`] to update variable state, and so is not compatible with other libraries (e.g. debuggers, code coverage tools).
 
-2. Only supports loop accumulation variables, but not accumulators as part of an object.
-   For example, instance attribute accumulators are not supported:
-
-   ```python
-   class MyClass:
-       def update_my_sum(self, numbers):
-           for number in numbers:
-               self.sum_so_far = self.sum_so_far + number
-   ```
-
-3. Loop variable state is stored by creating shallow copies of the objects.
+2. Loop variable state is stored by creating shallow copies of the objects.
    Loops that mutate a nested part of an object will not have their state displayed properly.
 
-4. The `AccumulationTable` context manager can only log the execution of one for loop.
+3. The `AccumulationTable` context manager can only log the execution of one for loop.
    To log the state of multiple for loops, each must be wrapped in a separate `with` statement and fresh `AccumulationTable` instance.
 
 [tabulate]: https://github.com/astanin/python-tabulate

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -96,10 +96,8 @@ class AccumulationTable:
         for accumulator in self.loop_accumulators:
             if accumulator in frame.f_locals:
                 value = copy.copy(frame.f_locals[accumulator])
-                self.loop_accumulators[accumulator].append(copy.copy(frame.f_locals[accumulator]))
             elif accumulator in frame.f_code.co_varnames or accumulator in frame.f_code.co_names:
-                self.loop_accumulators[accumulator].append(NO_VALUE)
-
+                value = NO_VALUE
             else:
                 # name error wil be raised if accumulator cannot be found
                 value = eval(accumulator, frame.f_globals, frame.f_locals)

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -95,11 +95,8 @@ class AccumulationTable:
             if accumulator in frame.f_locals:
                 value = copy.copy(frame.f_locals[accumulator])
             else:
-                try:
-                    value = eval(accumulator, frame.f_locals)
-                except NameError:
-                    # name error wil be raised if accumulator cannot be found in the context of frame.f_globals
-                    value = eval(accumulator, frame.f_globals)
+                # name error wil be raised if accumulator cannot be found
+                value = eval(accumulator, frame.f_globals, frame.f_locals)
 
             self.loop_accumulators[accumulator].append(value)
 

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -93,9 +93,15 @@ class AccumulationTable:
 
         for accumulator in self.loop_accumulators:
             if accumulator in frame.f_locals:
-                self.loop_accumulators[accumulator].append(copy.copy(frame.f_locals[accumulator]))
+                value = copy.copy(frame.f_locals[accumulator])
             else:
-                raise NameError
+                try:
+                    value = eval(accumulator, frame.f_locals)
+                except NameError:
+                    # name error wil be raised if accumulator cannot be found in the context of frame.f_globals
+                    value = eval(accumulator, frame.f_globals)
+
+            self.loop_accumulators[accumulator].append(value)
 
     def _create_iteration_dict(self) -> dict:
         """Return a dictionary that maps each accumulator

--- a/tests/test_debug/test_accumulation_table.py
+++ b/tests/test_debug/test_accumulation_table.py
@@ -150,9 +150,12 @@ def test_five_nested_while_loop() -> None:
 
 class MyClass:
     items: list
+    sum_so_far: int
+    difference_so_far = 0
 
     def __init__(self, items: list):
         self.items = items
+        self.sum_so_far = 0
 
     def get_total(self) -> None:
         sum_so_far = 0
@@ -163,10 +166,45 @@ class MyClass:
         assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
         assert table.loop_accumulators == {"sum_so_far": [0, 10, 30, 60]}
 
+    def accumulate_instance_var(self) -> None:
+        with AccumulationTable(["self.sum_so_far"]) as table:
+            for item in self.items:
+                self.sum_so_far = self.sum_so_far + item
+
+        assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
+        assert table.loop_accumulators == {"self.sum_so_far": [0, 10, 30, 60]}
+
+    def accumulate_class_var(self) -> None:
+        with AccumulationTable(["MyClass.difference_so_far"]) as table:
+            for item in self.items:
+                MyClass.difference_so_far = MyClass.difference_so_far - item
+
+        assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
+        assert table.loop_accumulators == {"MyClass.difference_so_far": [0, -10, -30, -60]}
+
 
 def test_class_var() -> None:
     my_class = MyClass([10, 20, 30])
     my_class.get_total()
+
+
+def test_instance_var_accumulator() -> None:
+    my_class = MyClass([10, 20, 30])
+    my_class.accumulate_instance_var()
+
+
+def test_class_var_accumulator() -> None:
+    my_class = MyClass([10, 20, 30])
+    my_class.accumulate_class_var()
+
+
+def test_invalid_accumulator() -> None:
+    test_list = [10, 20, 30]
+    sum_so_far = 0
+    with pytest.raises(NameError):
+        with AccumulationTable(["invalid"]) as table:
+            for number in test_list:
+                sum_so_far = sum_so_far + number
 
 
 def test_two_loop_vars_one_accumulator() -> None:

--- a/tests/test_debug/test_accumulation_table.py
+++ b/tests/test_debug/test_accumulation_table.py
@@ -148,6 +148,7 @@ def test_five_nested_while_loop() -> None:
     }
 
 
+# make extra test cases because eval can take any expression
 class MyClass:
     items: list
     sum_so_far: int
@@ -196,6 +197,17 @@ def test_instance_var_accumulator() -> None:
 def test_class_var_accumulator() -> None:
     my_class = MyClass([10, 20, 30])
     my_class.accumulate_class_var()
+
+
+def test_expression_accumulator() -> None:
+    test_list = [10, 20, 30]
+    sum_so_far = 0
+    with AccumulationTable(["sum_so_far * 2"]) as table:
+        for item in test_list:
+            sum_so_far = sum_so_far + item
+
+    assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
+    assert table.loop_accumulators == {"sum_so_far * 2": [0, 20, 60, 120]}
 
 
 def test_invalid_accumulator() -> None:

--- a/tests/test_debug/test_accumulation_table.py
+++ b/tests/test_debug/test_accumulation_table.py
@@ -148,7 +148,6 @@ def test_five_nested_while_loop() -> None:
     }
 
 
-# make extra test cases because eval can take any expression
 class MyClass:
     items: list
     sum_so_far: int


### PR DESCRIPTION
## Motivation and Context

Currently, valid accumulators for Accumulation Tables are limited to variables. Accumulators that are part of an object, such as `self.sum_so_far`, cannot be used. This limitation has been removed so users now have more flexibility when choosing their accumulation variables. 
This pull request fixes [limitation 2](https://www.cs.toronto.edu/~david/pyta/debug/) for AccumulationTable.

## Your Changes

**Description**:
I modified `accumulation_table.py` so that the accumulator string passed in by the user is evaluated using the eval function if it is not found as a variable. If the variable cannot be found then a NameError will be raised.

**Type of change** (select all that apply):

- [x] New feature (non-breaking change which adds functionality)

## Testing

I made sure all the existing AccumulationTable tests worked with the new feature. I also added 3 new tests, 1 with the accumulator as an instance variable, 1 with a class variable, and 1 with an invalid accumulator. Finally, I did some manual testing with the cases described above.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported on Coveralls. 
- [x] I have added tests for my changes. 
