### PR TITLE
Fix invalid-range-index checker when using variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Added new configuration option `use-pyta-error-messages` to let users choose whether PythonTA should overwrite pylint's error messages.
 - Both PlainReporter and ColorReporter emphasize specific code chunks by using overline characters under any part that is highlighted as ERROR.
 
+### Bug fixes
+
+- Fixed bug with `invalid-range-index-checker` when variables are used in `range` expressions.
+
 ## [2.6.3] - 2023-10-09
 
 ### Bug fixes

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -1,8 +1,6 @@
 """Checker for index ranges"""
-from ast import literal_eval
-
 from astroid import nodes
-from pylint.checkers import BaseChecker
+from pylint.checkers import BaseChecker, utils
 from pylint.checkers.utils import only_required_for_messages
 from pylint.lint import PyLinter
 
@@ -27,11 +25,14 @@ class InvalidRangeIndexChecker(BaseChecker):
             # locals nor globals scope)
             if not (name in node.frame() or name in node.root()) and name == "range":
                 args = node.args  # the arguments of 'range' call
-                # guard nodes (e.g. Name) not properly handled by literal_eval.
-                if any([not isinstance(arg, (nodes.Const, nodes.UnaryOp)) for arg in args]):
+
+                inferred_params = [utils.safe_infer(arg) for arg in args]
+
+                # Check whether every inference was successful
+                if not all(isinstance(node, nodes.Const) for node in inferred_params):
                     return
 
-                eval_params = list(map(lambda z: literal_eval(z.as_string()), args))
+                eval_params = [const.value for const in inferred_params]
 
                 if (
                     len(args) == 0

--- a/tests/test_custom_checkers/test_invalid_range_index_checker.py
+++ b/tests/test_custom_checkers/test_invalid_range_index_checker.py
@@ -114,6 +114,46 @@ class TestInvalidRangeIndexChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_call(range_node)
 
+    def test_wrong_type(self):
+        src = """
+        range("hello", "bye")
+        """
+        range_node = astroid.extract_node(src)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="invalid-range-index",
+                node=range_node,
+                args="2",
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_call(range_node)
+
+    def test_variables_undefined(self):
+        src = """
+        range(start, stop)  # These variables are undefined
+        """
+        range_node = astroid.extract_node(src)
+        with self.assertNoMessages():
+            self.checker.visit_call(range_node)
+
+    def test_variables_defined(self):
+        src = """
+        start = 1
+        stop = 10
+        range(start, -stop)  # These variables can be inferred
+        """
+        range_node = astroid.extract_node(src)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="invalid-range-index",
+                node=range_node,
+                args="4",
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_call(range_node)
+
 
 if __name__ == "__main__":
     import pytest


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The existing `InvalidRangeIndexChecker` uses `ast.literal_eval`, which does not work on variables, and so caused an error to be raised.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Switch to using `astroid`'s `safe_infer` function.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Manual testing and added test cases.


## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
