### PR TITLE
Ensure naming-convention-violation does not check variables in main block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fix bug in ending location setting for `Attribute` and `DelAttr` nodes when the same attribute
   was accessed twice on the same line.
+- Fix bug where the `naming-convention-violation` checker was checking variables defined in a module's main block. This was inconsistent with the `forbidden-global-variables` checker.
 
 ## [2.6.4] - 2024-11-10
 

--- a/python_ta/checkers/invalid_name_checker.py
+++ b/python_ta/checkers/invalid_name_checker.py
@@ -9,6 +9,8 @@ from pylint.checkers.base.name_checker.checker import _redefines_import
 from pylint.checkers.utils import only_required_for_messages
 from pylint.lint import PyLinter
 
+from python_ta.utils import _is_in_main
+
 # Bad variable names.
 BAD_NAMES = {"l", "I", "O"}
 
@@ -334,7 +336,7 @@ class InvalidNameChecker(BaseChecker):
             self._check_name("argument", node.name, node)
 
         # Check names defined in module scope
-        elif isinstance(frame, nodes.Module):
+        elif isinstance(frame, nodes.Module) and not _is_in_main(node):
             # Check names defined in Assign nodes
             if isinstance(assign_type, nodes.Assign):
                 inferred_assign_type = utils.safe_infer(assign_type.value)

--- a/tests/test_custom_checkers/test_invalid_name_checker.py
+++ b/tests/test_custom_checkers/test_invalid_name_checker.py
@@ -481,6 +481,18 @@ class TestInvalidNameChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_assignname(assignname_node)
 
+    def test_name_in_main_block(self) -> None:
+        """Test that the checker does not report a top-level variable that is assigned within
+        a main block."""
+        src = """
+        if __name__ == '__main__':
+            const_not_upper = "it is not"
+        """
+        mod = astroid.parse(src)
+        assignname_node, *_ = mod.nodes_of_class(nodes.AssignName)
+        with self.assertNoMessages():
+            self.checker.visit_assignname(assignname_node)
+
 
 def test_module_name_no_snippet() -> None:
     """Test that PythonTA does not build a snippet for the message added by this checker."""


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

The `naming-convention-violation` error was being flagged for variables defined within a main block. However, this was unintentional (and inconsistent with the global variables checker), as instructors sometimes like to use the main block to write demo code to provide to students.

## Your Changes

<!-- Describe your changes here. -->

**Description**: Update the `naming-convention-violation` check to exclude variables in the main block.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Tested manually and added an additional test case.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
