### PR TITLE
Do not infer variables in invalid-range-index check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fix bug in ending location setting for `Attribute` and `DelAttr` nodes when the same attribute
   was accessed twice on the same line.
 - Fix bug where the `naming-convention-violation` checker was checking variables defined in a module's main block. This was inconsistent with the `forbidden-global-variables` checker.
+- Fixed bug with `invalid-range-index`: do not attempt any inference of variables in `range` expressions. All range arguments involving variables will be ignored by this checker.
 
 ### New checkers
 

--- a/python_ta/checkers/invalid_range_index_checker.py
+++ b/python_ta/checkers/invalid_range_index_checker.py
@@ -26,8 +26,11 @@ class InvalidRangeIndexChecker(BaseChecker):
             if not (name in node.frame() or name in node.root()) and name == "range":
                 args = node.args  # the arguments of 'range' call
 
-                inferred_params = [utils.safe_infer(arg) for arg in args]
+                # ignore calls involving variables; these cannot be inferred properly
+                if any(any(arg.nodes_of_class(nodes.Name)) for arg in args):
+                    return
 
+                inferred_params = [utils.safe_infer(arg) for arg in args]
                 # Check whether every inference was successful
                 if not all(isinstance(node, nodes.Const) for node in inferred_params):
                     return

--- a/tests/test_custom_checkers/test_invalid_range_index_checker.py
+++ b/tests/test_custom_checkers/test_invalid_range_index_checker.py
@@ -1,4 +1,5 @@
 import astroid
+import astroid.nodes as nodes
 import pylint.testutils
 
 from python_ta.checkers.invalid_range_index_checker import InvalidRangeIndexChecker
@@ -129,6 +130,14 @@ class TestInvalidRangeIndexChecker(pylint.testutils.CheckerTestCase):
         ):
             self.checker.visit_call(range_node)
 
+    def test_uninferable(self):
+        src = """
+        range(0, [][1])
+        """
+        range_node = astroid.extract_node(src)
+        with self.assertNoMessages():
+            self.checker.visit_call(range_node)
+
     def test_variables_undefined(self):
         src = """
         range(start, stop)  # These variables are undefined
@@ -141,17 +150,28 @@ class TestInvalidRangeIndexChecker(pylint.testutils.CheckerTestCase):
         src = """
         start = 1
         stop = 10
-        range(start, -stop)  # These variables can be inferred
+        range(start, -stop)
         """
         range_node = astroid.extract_node(src)
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="invalid-range-index",
-                node=range_node,
-                args="4",
-            ),
-            ignore_position=True,
-        ):
+        # Even though these variables can have their values inferred,
+        # we are conservative and do not attempt inference (see test_variables_ambiguous below).
+        with self.assertNoMessages():
+            self.checker.visit_call(range_node)
+
+    def test_variables_ambiguous(self):
+        src = """
+        def f(numbers):
+            result = []
+            for _ in numbers:
+                result.append(1)
+
+            range(len(result))  #@
+        """
+        range_node = astroid.extract_node(src)
+        # In this case, result is currently being inferred as an empty list [],
+        # but may not be empty. So to be conservative we do not attempt to infer
+        # its result, and instead skip checking this range expression.
+        with self.assertNoMessages():
             self.checker.visit_call(range_node)
 
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Currently, this code is being flagged as an `invalid-range-index` error:

```python
def f(numbers):
    result = []
    for _ in numbers:
        result.append(1)

    range(len(result))
```

The variable `result` was being inferred only as an empty list, which is incorrect.

## Your Changes

<!-- Describe your changes here. -->

**Description**: As this is an issue with astroid inference, I've modified the checker to skip all range expressions that use variables.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Added test cases and tested manually.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
