### PR TITLE
Added documentation and code examples for W0134 return-in-finally checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Bruce Liu,
 Merrick Liu,
 Wendy Liu,
 Yibing (Amy) Lu,
+Maria Shurui Ma
 Aina Fatema Asim Merchant,
 Shweta Mogalapalli,
 Ignas Panero Armoska,

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Bruce Liu,
 Merrick Liu,
 Wendy Liu,
 Yibing (Amy) Lu,
-Maria Shurui Ma
+Maria Shurui Ma,
 Aina Fatema Asim Merchant,
 Shweta Mogalapalli,
 Ignas Panero Armoska,

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -22,16 +22,14 @@ This error occurs when a `return` statement is used inside a `finally` block.
 Corrected Version:
 
 ```python
-def error_code():
-
-    error_codes = [0, 1, 2]
+def error_code(error_codes):
 
     try:
-        return error_codes[2]
+        print(error_codes[0])
     except IndexError:
-        ...
+        return error_codes[1]
 
-    return error_codes[0]
+    return error_codes[2]
 ```
 
 (E0601)=

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -9,34 +9,6 @@ email to \[david at cs dot toronto dot edu\].
 These errors generally indicate a misuse of variables, control flow, or other Python features in our
 code.
 
-(W0134)=
-
-### Return in finally
-
-This error occurs when a `return` statement is used inside a `finally` block. Doing so overwrites any previous return
-values therefore should be avoided.
-
-For example, in the code example below, if an `IndexError` occurs we want
-`error_codes[1]` to be returned, however since there is a return statement in the `finally` block `error_codes[2]` will be
-returned instead. Moving that return statement outside the `finally` block would resolve the issue.
-
-```{literalinclude} /../examples/pylint/w0134_return_in_finally.py
-
-```
-
-Corrected Version:
-
-```python
-def error_code(error_codes):
-
-    try:
-        print(error_codes[0])
-    except IndexError:
-        return error_codes[1]
-
-    return error_codes[2]
-```
-
 (E0601)=
 
 ### Used before assignment (E0601)
@@ -1923,6 +1895,34 @@ def reciprocal(num: float) -> float:
         raise ValueError('num cannot be 0!')
     else:
         return 1 / num
+```
+
+(W0134)=
+
+### Return in finally (W0134)
+
+This error occurs when a `return` statement is used inside a `finally` block. Doing so overwrites any previous return
+values therefore should be avoided.
+
+For example, in the code example below, if an `IndexError` occurs we want
+`error_codes[1]` to be returned, however since there is a return statement in the `finally` block `error_codes[2]` will be
+returned instead. Moving that return statement outside the `finally` block would resolve the issue.
+
+```{literalinclude} /../examples/pylint/w0134_return_in_finally.py
+
+```
+
+Corrected Version:
+
+```python
+def error_code(error_codes):
+
+    try:
+        print(error_codes[0])
+    except IndexError:
+        return error_codes[1]
+
+    return error_codes[2]
 ```
 
 (W0702)=

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -513,7 +513,7 @@ This error occurs when a non-mapping value is used in a place where mapping is e
 
 ### Unnecessary negation (C0117)
 
-This error occurs when a boolean expression contains an unecessary negation. If we are getting this
+This error occurs when a boolean expression contains an unnecessary negation. If we are getting this
 error, the expression can be simplified to not use a negation.
 
 ```{literalinclude} /../examples/pylint/c0117_unnecessary_negation.py

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -13,7 +13,12 @@ code.
 
 ### Return in finally
 
-This error occurs when a `return` statement is used inside a `finally` block.
+This error occurs when a `return` statement is used inside a `finally` block. Doing so overwrites any previous return
+values therefore should be avoided.
+
+For example, in the code example below, if an `IndexError` occurs we want
+`error_codes[1]` to be returned, however since there is a return statement in the `finally` block `error_codes[2]` will be
+returned instead. Moving that return statement outside the `finally` block would resolve the issue.
 
 ```{literalinclude} /../examples/pylint/w0134_return_in_finally.py
 
@@ -511,7 +516,7 @@ This error occurs when a non-mapping value is used in a place where mapping is e
 
 ### Unnecessary negation (C0117)
 
-This error occurs when a boolean expression contains an unnecessary negation. If we are getting this
+This error occurs when a boolean expression contains an nnecessary negation. If we are getting this
 error, the expression can be simplified to not use a negation.
 
 ```{literalinclude} /../examples/pylint/c0117_unnecessary_negation.py

--- a/docs/checkers/index.md
+++ b/docs/checkers/index.md
@@ -9,6 +9,31 @@ email to \[david at cs dot toronto dot edu\].
 These errors generally indicate a misuse of variables, control flow, or other Python features in our
 code.
 
+(W0134)=
+
+### Return in finally
+
+This error occurs when a `return` statement is used inside a `finally` block.
+
+```{literalinclude} /../examples/pylint/w0134_return_in_finally.py
+
+```
+
+Corrected Version:
+
+```python
+def error_code():
+
+    error_codes = [0, 1, 2]
+
+    try:
+        return error_codes[2]
+    except IndexError:
+        ...
+
+    return error_codes[0]
+```
+
 (E0601)=
 
 ### Used before assignment (E0601)
@@ -488,7 +513,7 @@ This error occurs when a non-mapping value is used in a place where mapping is e
 
 ### Unnecessary negation (C0117)
 
-This error occurs when a boolean expression contains an nnecessary negation. If we are getting this
+This error occurs when a boolean expression contains an unecessary negation. If we are getting this
 error, the expression can be simplified to not use a negation.
 
 ```{literalinclude} /../examples/pylint/c0117_unnecessary_negation.py

--- a/examples/pylint/w0134_return_in_finally.py
+++ b/examples/pylint/w0134_return_in_finally.py
@@ -1,10 +1,8 @@
-def error_code():
-
-    error_codes = [0, 1, 2]
+def error_code(error_codes):
 
     try:
-        return error_codes[2]
+        print(error_codes[0])
     except IndexError:
         return error_codes[1]
     finally:
-        return error_codes[0]  # Error on this line
+        return error_codes[2]  # Error on this line

--- a/examples/pylint/w0134_return_in_finally.py
+++ b/examples/pylint/w0134_return_in_finally.py
@@ -1,0 +1,10 @@
+def error_code():
+
+    error_codes = [0, 1, 2]
+
+    try:
+        return error_codes[2]
+    except IndexError:
+        return error_codes[1]
+    finally:
+        return error_codes[0]  # Error on this line


### PR DESCRIPTION
## Motivation and Context

W0134 return-in-finally is a new check in Pylint which was added at the end of last semester, so it needed to be added to the PythonTA documentation. This pull request resolves the issue by providing documentation and examples for this checker.

Fixes pyta-uoft/pyta#999.

## Your Changes

**Description**:

- Added documentation for W0134 return-in-finally checker.
- Wrote a code example that raises the W0134 return-in-finally error.
- Provided a correction to the example code that demonstrates how to resolve the W0134 return-in-finally error.

**Type of change** (select all that apply):

- [X] Documentation update (change that modifies or updates documentation only)

## Testing

This pull request was tested using PythonTA with the code below. 

```python
import python_ta

python_ta.check_all()
```
The PythonTA report correctly showed that the W0134 (return-in-finally) error was raised.


## Questions and Comments (if applicable)

I am not too sure how to classify the W0134 (return-in-finally) error. I chose to put it under "Improper Python usage" since I think that it does "indicate a misuse of variables, control flow, or other Python features in our code" and it is similar to other errors in the same section (such as Return outside function (E0104) and Unreachable (W0101)). However, when I ran PythonTA, it put the W0134 (return-in-finally) error under "Style and Convention", which also makes a bit of sense. Since I am not too sure how exactly this checker should be classified, I would like to ask under which section should it be put and in the future how should I decide if there are conflicts like this happening.

## Checklist

- [X] I have performed a self-review of my own code.
- [X] I have verified that the CI tests have passed. 
- [X] I have reviewed the test coverage changes reported on Coveralls. 