### PR TITLE
Fix C0410 error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved error display for pycodestyle (E9989) errors E123, E203 and E226
 
 ### Bug fixes
+
 - Fixed issue with error message of C0410 by reformating it to properly fit with the list of modules imported that are provided to it
 
 ## [2.7.0] - 2024-12-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Allowed specifying allowed names in configurations `allowed-import-modules` and `extra-imports` instead of just modules
 - Improved error display for pycodestyle (E9989) errors E123, E203 and E226
 
+### Bug fixes
+- Fixed issue with error message of C0410 by reformating it to properly fit with the list of modules imported that are provided to it
+
 ## [2.7.0] - 2024-12-14
 
 ### Enhancements

--- a/python_ta/config/messages_config.toml
+++ b/python_ta/config/messages_config.toml
@@ -105,7 +105,7 @@ E0401 = "Unable to import %s. Check the spelling of the module name, or whether 
 W0401 = "Wildcard (*) imports add all objects from the imported module as global variables, which may result in name collisions. You should only import from %s what you need, or import the whole module (\"import module\") and use dot notation to access the module's functions/classes."
 W0404 = "Module %r was re-imported on line %s. A module should not be imported more than once."
 W0410 = "Imports of '__future__' must be the first non-docstring statement in the module."
-C0410 = "Import each module on line %s on separately, one per line."
+C0410 = "Import the modules (%s) individually, using a separate import statement for each module."
 C0414 = "The 'import as' is used to import a module and give it a different name in this file. If you don't want to rename the module, simply use 'import' instead."
 
 ["pylint.checkers.newstyle".NewStyleConflictChecker]


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

One of the changes made in https://github.com/pyta-uoft/pyta/pull/1010 was to remove the line number argument from the message and replace it with the modules imported. This seemingly caused an interaction with the error message C0410 which used the line number in its message and now receives the modules imported. This change replaces the error message to better accommodate the input string given to it.

## Your Changes

<!-- Describe your changes here. -->

Changed the error message of C0410 in `messages_config.toml` to better fit the names of modules given to it

**Description**:

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Changed file and then triggered message to see if updated version appeared in PythonTA window and confirmed it appeared.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
