### PR TITLE
Ensure _ is removed from builtins when python_ta is imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Bug fixes
 
 - Fixed issue with error message of C0410 by reformating it to properly fit with the list of modules imported that are provided to it
+- Fixed bug where `_` was marked as a built-in when running PythonTA after running doctest
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -17,22 +17,14 @@ if __name__ == '__main__':
 __version__ = "2.7.1.dev"  # Version number
 
 # First, remove underscore from builtins if it has been bound in the REPL.
+# Must appear before other imports from pylint/python_ta.
 import builtins
-
-from pylint.lint import PyLinter
-
-from .config import (
-    find_local_config,
-    load_config,
-    load_messages_config,
-    override_config,
-)
-from .reporters.core import PythonTaReporter
 
 try:
     del builtins._
 except AttributeError:
     pass
+
 
 import importlib.util
 import logging
@@ -48,10 +40,18 @@ import pylint.config
 import pylint.lint
 import pylint.utils
 from astroid import MANAGER, modutils
+from pylint.lint import PyLinter
 from pylint.utils.pragma_parser import OPTION_PO
 
+from .config import (
+    find_local_config,
+    load_config,
+    load_messages_config,
+    override_config,
+)
 from .patches import patch_all
 from .reporters import REPORTERS
+from .reporters.core import PythonTaReporter
 from .upload import upload_to_server
 
 HELP_URL = "http://www.cs.toronto.edu/~david/pyta/checkers/index.html"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

An instructor reported that running doctest and then PythonTA on a file caused `_` to be flagged as a redefined builtin (W0622, from pylint).

## Your Changes

<!-- Describe your changes here. -->

**Description**: There was originally code in PythonTA that intended to remove `_` from `builtins`. However, other pylint-related imports were storing the `builtins` dict before the code was triggered. The solution was to ensure this code was executed before any other import.

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Ran PythonTA after doctest, and ensured that `_` was not reported as a redefined builtin name.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->