### PR TITLE
allowed annotated constants to be permitted as top level code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue with error message of C0410 by reformating it to properly fit with the list of modules imported that are provided to it
 - Fixed bug where `_` was marked as a built-in when running PythonTA after running doctest
 - Fixed issue where annotated constant variable assignment was not considered as permissible top level code and triggered error E9992
+- Fixed issue where top level class attribute assignment was considered as permissible top level code
 
 ## [2.7.0] - 2024-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Fixed issue with error message of C0410 by reformating it to properly fit with the list of modules imported that are provided to it
 - Fixed bug where `_` was marked as a built-in when running PythonTA after running doctest
+- Fixed issue where annotated constant variable assignment was not considered as permissible top level code and triggered error E9992
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/checkers/top_level_code_checker.py
+++ b/python_ta/checkers/top_level_code_checker.py
@@ -65,7 +65,7 @@ def _is_allowed_assignment(statement: nodes.NodeNG) -> bool:
             node.name for node in statement.target.nodes_of_class(nodes.AssignName, nodes.Name)
         )
 
-    return all(
+    return names and all(
         re.match(UpperCaseStyle.CONST_NAME_RGX, name)
         or re.match(DEFAULT_PATTERNS["typealias"], name)
         for name in names

--- a/python_ta/checkers/top_level_code_checker.py
+++ b/python_ta/checkers/top_level_code_checker.py
@@ -53,12 +53,15 @@ def _is_allowed_assignment(statement: nodes.NodeNG) -> bool:
     """
     Return whether or not <statement> is a constant assignment or type alias assignment.
     """
-    if not isinstance(statement, nodes.Assign):
+    if not isinstance(statement, nodes.Assign) and not isinstance(statement, nodes.AnnAssign):
         return False
 
     names = []
-    for target in statement.targets:
-        names.extend(node.name for node in target.nodes_of_class(nodes.AssignName, nodes.Name))
+    if isinstance(statement, nodes.Assign):
+        for target in statement.targets:
+            names.extend(node.name for node in target.nodes_of_class(nodes.AssignName, nodes.Name))
+    else:
+        names.append(statement.target.name)
 
     return all(
         re.match(UpperCaseStyle.CONST_NAME_RGX, name)

--- a/python_ta/checkers/top_level_code_checker.py
+++ b/python_ta/checkers/top_level_code_checker.py
@@ -61,7 +61,9 @@ def _is_allowed_assignment(statement: nodes.NodeNG) -> bool:
         for target in statement.targets:
             names.extend(node.name for node in target.nodes_of_class(nodes.AssignName, nodes.Name))
     else:
-        names.append(statement.target.name)
+        names.extend(
+            node.name for node in statement.target.nodes_of_class(nodes.AssignName, nodes.Name)
+        )
 
     return all(
         re.match(UpperCaseStyle.CONST_NAME_RGX, name)

--- a/tests/test_custom_checkers/test_top_level_code_checker.py
+++ b/tests/test_custom_checkers/test_top_level_code_checker.py
@@ -86,6 +86,15 @@ class TestTopLevelCodeChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_module(mod)
 
+    def test_no_message_annotated_constant_assignment(self):
+        """Top level constant assignment with annotation allowed, no message."""
+        src = """
+        MAX_DURATION: int = 30
+        """
+        mod = astroid.parse(src)
+        with self.assertNoMessages():
+            self.checker.visit_module(mod)
+
     def test_message_regular_assignment(self):
         """Top level regular assignment not allowed, raises a message."""
         src = """

--- a/tests/test_custom_checkers/test_top_level_code_checker.py
+++ b/tests/test_custom_checkers/test_top_level_code_checker.py
@@ -183,3 +183,20 @@ class TestTopLevelCodeChecker(pylint.testutils.CheckerTestCase):
         mod = astroid.parse(src)
         with self.assertNoMessages():
             self.checker.visit_module(mod)
+
+    def test_message_attribute_assignment(self):
+        """Top level code to assign attributes not allowed, raises a message."""
+        src = """
+        class X:
+            a = 5
+        Y = X()
+        Y.a = 6
+        """
+        mod = astroid.parse(src)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="forbidden-top-level-code", node=mod.body[2], args=5
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_module(mod)

--- a/tests/test_custom_checkers/test_top_level_code_checker.py
+++ b/tests/test_custom_checkers/test_top_level_code_checker.py
@@ -86,6 +86,20 @@ class TestTopLevelCodeChecker(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_module(mod)
 
+    def test_message_annotated_assignment(self):
+        """Top level regular assignment with annotation not allowed, raises a message."""
+        src = """
+        max_num: int = 30
+        """
+        mod = astroid.parse(src)
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="forbidden-top-level-code", node=mod.body[0], args=2
+            ),
+            ignore_position=True,
+        ):
+            self.checker.visit_module(mod)
+
     def test_no_message_annotated_constant_assignment(self):
         """Top level constant assignment with annotation allowed, no message."""
         src = """


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
This pull request aims to resolve #1012 

Although uncommon, Python allows for type annotation to variable assignments. However, performing annotated constant variable assignment is in a different node type than regular constant assignment and causes the checker `top_level_code_checker` to incorrectly parse the statement. This causes it to consider the statement as forbidden top level code since it was uncounted for and incorrectly adds an error message. This pull request fixes the issue by parsing both annotated and unannotated constant variable assignment statements. 


Additionally, changing the attributes of classes in top level code was not picked up by the checker. This corrects the behaviour.
## Your Changes

<!-- Describe your changes here. -->

Changed the `_is_allowed_assignment` function in `top_level_code_checker` to parse nodes of type `AnnAssign` in addition to nodes of type `Assign` to consider if they are constant assignments.

Added a check to see if names was non-empty when checking assignment statements to prevent Attribute assignments to be passed.

Fix was noted in the changelog.

**Description**:

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->
Tested manually that annotated constant assignment causes no message to be raised.
Added test case in test suite for this case and verified test passed in addition to preexisting tests for this checker.
Additional test was added to check that attribute assignment is caught correctly

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->
Is this separation of cases acceptable or is there a more efficient method to implement the change?

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
