### PR TITLE
Raise AssertionError when precondition contains precondition violations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed bug where `_` was marked as a built-in when running PythonTA after running doctest
 - Fixed issue where annotated constant variable assignment was not considered as permissible top level code and triggered error E9992
 - Fixed issue where top level class attribute assignment was considered as permissible top level code
-- Fixed issue where `check_contracts` fails silently when function preconditions contain precondition violations
+- Fixed issue where `check_contracts` fails silently when function preconditions contain precondition violations, and when a representation invariant contains a call to a top-level function (not built-in or imported library).
 
 ## [2.7.0] - 2024-12-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed bug where `_` was marked as a built-in when running PythonTA after running doctest
 - Fixed issue where annotated constant variable assignment was not considered as permissible top level code and triggered error E9992
 - Fixed issue where top level class attribute assignment was considered as permissible top level code
+- Fixed issue where `check_contracts` fails silently when function preconditions contain precondition violations
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -408,6 +408,8 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
                 f"{instance.__class__.__qualname__}: {invariant}"
             )
             check = eval(compiled, {**global_scope, "self": instance})
+        except AssertionError as e:
+            raise AssertionError(str(e)) from None
         except:
             _debug(f"Warning: could not evaluate representation invariant: {invariant}")
         else:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -475,8 +475,9 @@ def _check_assertions(
         try:
             _debug(f"Checking {condition_type} for {wrapped.__qualname__}: {assertion_str}")
             check = eval(compiled, {**wrapped.__globals__, **function_locals, **return_val_dict})
-        except:
+        except PyTAContractError as e:
             _debug(f"Warning: could not evaluate {condition_type}: {assertion_str}")
+            raise AssertionError(str(e)) from None
         else:
             if not check:
                 arg_string = ", ".join(

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -475,9 +475,10 @@ def _check_assertions(
         try:
             _debug(f"Checking {condition_type} for {wrapped.__qualname__}: {assertion_str}")
             check = eval(compiled, {**wrapped.__globals__, **function_locals, **return_val_dict})
-        except PyTAContractError as e:
-            _debug(f"Warning: could not evaluate {condition_type}: {assertion_str}")
+        except AssertionError as e:
             raise AssertionError(str(e)) from None
+        except:
+            _debug(f"Warning: could not evaluate {condition_type}: {assertion_str}")
         else:
             if not check:
                 arg_string = ", ".join(

--- a/tests/test_contracts/nested_preconditions_example.py
+++ b/tests/test_contracts/nested_preconditions_example.py
@@ -40,19 +40,16 @@ class Student:
 
     Representation Invariants:
      - validate_student_number(self.student_number)
-     - self.condition2(self.gpa)
-     - self.validate_age(self.age)
+     - my_function(self.age)
     """
 
     name: str
     student_number: int
-    gpa: float
     age: int
 
-    def __init__(self, name, student_number, gpa, age):
+    def __init__(self, name, student_number, age):
         self.name = name
         self.student_number = student_number
-        self.gpa = gpa
         self.age = age
 
     def condition1(self, y: float):
@@ -75,6 +72,3 @@ class Student:
          - self.condition1(z)
         """
         return z
-
-    def validate_age(self, age):
-        return age > 0

--- a/tests/test_contracts/test_class_contracts.py
+++ b/tests/test_contracts/test_class_contracts.py
@@ -424,5 +424,40 @@ def test_no_premature_check_from_deep_helper_in_init() -> None:
     assert dark_widget.secondary_color == "mahogany"
 
 
+def test_invariant_with_function_defined_in_module() -> None:
+    """Test that a representation invariant violation is detected when the invariant
+    contains a call to a function (top-level) defined by the user
+    This test is based on the code found at ./test_nested_preconditions_example.py
+    """
+    import test_nested_preconditions_example as example
+
+    with pytest.raises(AssertionError) as exception_info:
+        example.Student("Bob", 0000000000, 3.5, 18)
+
+    assert (
+        str(exception_info.value) == '"Student" representation invariant '
+        '"validate_student_number(self.student_number)" '
+        "was violated for instance attributes "
+        "{name: " + "'Bob'" + ", student_number: 0, gpa: 3.5, age: 18}"
+    )
+
+
+def test_invariant_with_class_method() -> None:
+    """Test that a representation invariant violation is detected when the invariant
+    contains a call to a function (class method) defined by the user.
+    This test is based on the code found at ./test_nested_preconditions_example.py
+    """
+    import test_nested_preconditions_example as example
+
+    with pytest.raises(AssertionError) as exception_info:
+        example.Student("Bob", 1001001000, 3.5, -1)
+
+    assert (
+        str(exception_info.value) == '"Student" representation invariant '
+        '"self.validate_age(self.age)" was violated for instance attributes '
+        "{name: " + "'Bob'" + ", student_number: 1001001000, gpa: 3.5, age: -1}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main(["test_class_contracts.py"])

--- a/tests/test_contracts/test_class_contracts.py
+++ b/tests/test_contracts/test_class_contracts.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Set, Tuple
 
 import pytest
+from nested_preconditions_example import Student
 
 import python_ta.contracts
 from python_ta.contracts import check_all_contracts
@@ -426,36 +427,17 @@ def test_no_premature_check_from_deep_helper_in_init() -> None:
 
 def test_invariant_with_function_defined_in_module() -> None:
     """Test that a representation invariant violation is detected when the invariant
-    contains a call to a function (top-level) defined by the user
+    contains a call to a function (top-level, not class method) defined by the user.
     This test is based on the code found at ./test_nested_preconditions_example.py
     """
-    import test_nested_preconditions_example as example
-
     with pytest.raises(AssertionError) as exception_info:
-        example.Student("Bob", 0000000000, 3.5, 18)
+        Student("Bob", 0, 19)
 
     assert (
         str(exception_info.value) == '"Student" representation invariant '
         '"validate_student_number(self.student_number)" '
         "was violated for instance attributes "
-        "{name: " + "'Bob'" + ", student_number: 0, gpa: 3.5, age: 18}"
-    )
-
-
-def test_invariant_with_class_method() -> None:
-    """Test that a representation invariant violation is detected when the invariant
-    contains a call to a function (class method) defined by the user.
-    This test is based on the code found at ./test_nested_preconditions_example.py
-    """
-    import test_nested_preconditions_example as example
-
-    with pytest.raises(AssertionError) as exception_info:
-        example.Student("Bob", 1001001000, 3.5, -1)
-
-    assert (
-        str(exception_info.value) == '"Student" representation invariant '
-        '"self.validate_age(self.age)" was violated for instance attributes '
-        "{name: " + "'Bob'" + ", student_number: 1001001000, gpa: 3.5, age: -1}"
+        "{name: " + "'Bob'" + ", student_number: 0, age: 19}"
     )
 
 

--- a/tests/test_contracts/test_contracts.py
+++ b/tests/test_contracts/test_contracts.py
@@ -2,6 +2,7 @@ import sys
 from typing import Dict, List, Set
 
 import pytest
+from nested_preconditions_example import Student, my_function
 
 import python_ta.contracts
 from python_ta.contracts import check_contracts
@@ -710,8 +711,6 @@ def test_nested_preconditions_contract_checking() -> None:
     checking the precondition for another function.
     This test is based on the code found at ./test_nested_preconditions_example.py
     """
-    from test_nested_preconditions_example import my_function
-
     with pytest.raises(AssertionError) as exception_info:
         my_function(-1)
 
@@ -727,9 +726,7 @@ def test_nested_method_preconditions_contract_checking() -> None:
     occurs while checking the precondition for another class method.
     This test is based on the code found at ./test_nested_preconditions_example.py
     """
-    from test_nested_preconditions_example import Student
-
-    student = Student("Bob", 1001001000, 2.5, 20)
+    student = Student("Bob", 1001001000, 19)
 
     with pytest.raises(AssertionError) as exception_info:
         student.function(-1.5)
@@ -740,12 +737,10 @@ def test_nested_method_preconditions_contract_checking() -> None:
 def test_precondition_violation_in_representation_invariant() -> None:
     """
     Test that an AssetionError is correclty raised when a representation invarinat of a class
-    contains a call to a function whose preconditio is being violated.
+    contains a call to a function whose precondition is being violated.
     This test is based on the code found at ./test_nested_preconditions_example.py
     """
-    from test_nested_preconditions_example import Student
-
     with pytest.raises(AssertionError) as exception_info:
-        Student("Bob", 1001001000, -0.5, 20)
+        Student("Bob", 1001001000, -19)
 
-    assert 'condition2 precondition "x > 0" was violated' in str(exception_info.value)
+    assert 'my_condition2 precondition "x > 0" was violated' in str(exception_info.value)

--- a/tests/test_contracts/test_contracts.py
+++ b/tests/test_contracts/test_contracts.py
@@ -708,7 +708,7 @@ def test_nested_preconditions_contract_checking() -> None:
     """
     Test that an AssertionError is correctly raised when a precondition violation occurs while
     checking the precondition for another function.
-    This test is based on the code found at ./test_nested_preconditions_example
+    This test is based on the code found at ./test_nested_preconditions_example.py
     """
     from test_nested_preconditions_example import my_function
 
@@ -719,3 +719,19 @@ def test_nested_preconditions_contract_checking() -> None:
         str(exception_info.value)
         == 'my_condition2 precondition "x > 0" was violated for arguments {x: -1} '
     )
+
+
+def test_nested_method_preconditions_contract_checking() -> None:
+    """
+    Test that an AssertionError is correctly raised when a class method precondition violation
+    occurs while checking the precondition for another class method.
+    This test is based on the code found at ./test_nested_preconditions_example.py
+    """
+    from test_nested_preconditions_example import Student
+
+    student = Student("Bob", 1001001000, 2.5)
+
+    with pytest.raises(AssertionError) as exception_info:
+        student.function(-1)
+
+    assert 'condition2 precondition "x > 0" was violated' in str(exception_info.value)

--- a/tests/test_contracts/test_contracts.py
+++ b/tests/test_contracts/test_contracts.py
@@ -729,9 +729,23 @@ def test_nested_method_preconditions_contract_checking() -> None:
     """
     from test_nested_preconditions_example import Student
 
-    student = Student("Bob", 1001001000, 2.5)
+    student = Student("Bob", 1001001000, 2.5, 20)
 
     with pytest.raises(AssertionError) as exception_info:
-        student.function(-1)
+        student.function(-1.5)
+
+    assert 'condition2 precondition "x > 0" was violated' in str(exception_info.value)
+
+
+def test_precondition_violation_in_representation_invariant() -> None:
+    """
+    Test that an AssetionError is correclty raised when a representation invarinat of a class
+    contains a call to a function whose preconditio is being violated.
+    This test is based on the code found at ./test_nested_preconditions_example.py
+    """
+    from test_nested_preconditions_example import Student
+
+    with pytest.raises(AssertionError) as exception_info:
+        Student("Bob", 1001001000, -0.5, 20)
 
     assert 'condition2 precondition "x > 0" was violated' in str(exception_info.value)

--- a/tests/test_contracts/test_contracts.py
+++ b/tests/test_contracts/test_contracts.py
@@ -702,3 +702,20 @@ def test_invalid_attr_type_disable_contract_checking(disable_contract_checking) 
     my_person = Person()
     my_person.age = "John"
     assert my_person.age == "John"
+
+
+def test_nested_preconditions_contract_checking() -> None:
+    """
+    Test that an AssertionError is correctly raised when a precondition violation occurs while
+    checking the precondition for another function.
+    This test is based on the code found at ./test_nested_preconditions_example
+    """
+    from test_nested_preconditions_example import my_function
+
+    with pytest.raises(AssertionError) as exception_info:
+        my_function(-1)
+
+    assert (
+        str(exception_info.value)
+        == 'my_condition2 precondition "x > 0" was violated for arguments {x: -1} '
+    )

--- a/tests/test_contracts/test_nested_preconditions_example.py
+++ b/tests/test_contracts/test_nested_preconditions_example.py
@@ -28,38 +28,53 @@ def my_function(z: int):
     return z
 
 
+def validate_student_number(student_number: int):
+    """Validate the student number of a student"""
+    return student_number > 0
+
+
 @check_contracts
 class Student:
     """
     A representation of a student
+
+    Representation Invariants:
+     - validate_student_number(self.student_number)
+     - self.condition2(self.gpa)
+     - self.validate_age(self.age)
     """
 
     name: str
     student_number: int
     gpa: float
+    age: int
 
-    def __init__(self, name, student_number, gpa):
+    def __init__(self, name, student_number, gpa, age):
         self.name = name
         self.student_number = student_number
         self.gpa = gpa
+        self.age = age
 
-    def condition1(self, y):
+    def condition1(self, y: float):
         """
         Preconditions:
          - self.condition2(y)
         """
         return y > 0
 
-    def condition2(self, x):
+    def condition2(self, x: float):
         """
         Preconditions:
          - x > 0
         """
         return x > 0
 
-    def function(self, z: int):
+    def function(self, z: float):
         """
         Preconditions:
          - self.condition1(z)
         """
         return z
+
+    def validate_age(self, age):
+        return age > 0

--- a/tests/test_contracts/test_nested_preconditions_example.py
+++ b/tests/test_contracts/test_nested_preconditions_example.py
@@ -1,0 +1,29 @@
+from python_ta.contracts import check_contracts
+
+
+@check_contracts
+def my_condition1(y: int):
+    """
+    Preconditions:
+    - my_condition2(y)
+    """
+    return y > 0
+
+
+@check_contracts
+def my_condition2(x: int):
+    """
+    Preconditions:
+    - x > 0
+    """
+    return x > 0
+
+
+@check_contracts
+def my_function(z: int):
+    """
+
+    Preconditions:
+    - my_condition1(z)
+    """
+    return z

--- a/tests/test_contracts/test_nested_preconditions_example.py
+++ b/tests/test_contracts/test_nested_preconditions_example.py
@@ -22,8 +22,44 @@ def my_condition2(x: int):
 @check_contracts
 def my_function(z: int):
     """
-
     Preconditions:
     - my_condition1(z)
     """
     return z
+
+
+@check_contracts
+class Student:
+    """
+    A representation of a student
+    """
+
+    name: str
+    student_number: int
+    gpa: float
+
+    def __init__(self, name, student_number, gpa):
+        self.name = name
+        self.student_number = student_number
+        self.gpa = gpa
+
+    def condition1(self, y):
+        """
+        Preconditions:
+         - self.condition2(y)
+        """
+        return y > 0
+
+    def condition2(self, x):
+        """
+        Preconditions:
+         - x > 0
+        """
+        return x > 0
+
+    def function(self, z: int):
+        """
+        Preconditions:
+         - self.condition1(z)
+        """
+        return z


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context
When the preconditions for a function contain a call to another function whose preconditions are violated, `check_contracts` fails silently, without raising an `AssertionError`, as it happens when the violated precondition is checked direclty instead. This pull request addresses this behavior, so that nested precondition violations are correctly signaled through an `AssertionError`. In addition, this pull request also solves a related issues with Representation Invariants, allowing for the use or user defined functions (possibly with preconditions) within representation invariants.

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: --> closes #1003 
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

## Your Changes

<!-- Describe your changes here. -->

I modified part of the exception handling in `python_ta.contracts.__init__.py`. The functions `_check_assertions` and `_check_invariants` now raise an `AssertionError` directly when an `AssertionError` is found in function preconditions or class invariants, instead of simply adding a message to the debugging log.
This allows for preconditions and representation invariants violations to be signaled as soon as they occur, and to display the error message relative to the inner precondition violation.

**Description**:

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

I have created the test file `nested_preconditions_example.py` with example code that failed silently before the change. Then, I added unit test to `test_contracts.py` and `test_class_contracts.py` which use the code in `nested_preconditions_example.py` to test that an `AssertionError` is correctly raised in the appropriate scenarios.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x]  I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
