### PR TITLE
added CFGEdge augment to store condition node in If/While conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Improved error display for pycodestyle (E9989) errors E123, E203, E222, E226, and E262
 - Added the configuration option to ignore naming convention violations (C9103 and C9104) for names matching the provided regular expression.
 - Update to pylint v3.1 and and astroid v3.1
+- Stored actual AST condition node in edges leading out of If/While blocks in generated control flow graphs.
 
 ### Bug fixes
 

--- a/python_ta/cfg/graph.py
+++ b/python_ta/cfg/graph.py
@@ -28,7 +28,7 @@ class ControlFlowGraph:
         self,
         pred: Optional[CFGBlock] = None,
         edge_label: Optional[Any] = None,
-        edge_condition: NodeNG = None,
+        edge_condition: Optional[NodeNG] = None,
     ) -> CFGBlock:
         """Create a new CFGBlock for this graph.
 
@@ -56,7 +56,7 @@ class ControlFlowGraph:
         source: CFGBlock,
         target: CFGBlock,
         edge_label: Optional[Any] = None,
-        edge_condition: NodeNG = None,
+        edge_condition: Optional[NodeNG] = None,
     ) -> None:
         """Link source to target, or merge source into target if source is empty.
 
@@ -202,20 +202,20 @@ class CFGEdge:
 
     Edges are directed, and in the future may be augmented with auxiliary metadata about the control flow.
 
-    Condition stores the AST node representing the condition tested in If and While statements.
+    The condition attribute stores the AST node representing the condition tested in If and While statements.
     """
 
     source: CFGBlock
     target: CFGBlock
     label: Optional[Any]
-    condition: NodeNG
+    condition: Optional[NodeNG]
 
     def __init__(
         self,
         source: CFGBlock,
         target: CFGBlock,
         edge_label: Optional[Any] = None,
-        condition: NodeNG = None,
+        condition: Optional[NodeNG] = None,
     ) -> None:
         self.source = source
         self.target = target

--- a/python_ta/cfg/visitor.py
+++ b/python_ta/cfg/visitor.py
@@ -156,7 +156,9 @@ class CFGVisitor:
         old_curr = self._current_block
 
         # Handle "then" branch and label it.
-        then_block = self._current_cfg.create_block(old_curr, edge_label="True")
+        then_block = self._current_cfg.create_block(
+            old_curr, edge_label="True", edge_condition=node.test
+        )
         self._current_block = then_block
         for child in node.body:
             child.accept(self)
@@ -167,7 +169,9 @@ class CFGVisitor:
             end_else = old_curr
         else:
             # Label the edge to the else block.
-            else_block = self._current_cfg.create_block(old_curr, edge_label="False")
+            else_block = self._current_cfg.create_block(
+                old_curr, edge_label="False", edge_condition=node.test
+            )
             self._current_block = else_block
             for child in node.orelse:
                 child.accept(self)
@@ -177,7 +181,9 @@ class CFGVisitor:
         self._current_cfg.link_or_merge(end_if, after_if_block)
         # Label the edge if there was no "else" branch
         if node.orelse == []:
-            self._current_cfg.link_or_merge(end_else, after_if_block, edge_label="False")
+            self._current_cfg.link_or_merge(
+                end_else, after_if_block, edge_label="False", edge_condition=node.test
+            )
         else:
             self._current_cfg.link_or_merge(end_else, after_if_block)
 
@@ -207,7 +213,9 @@ class CFGVisitor:
         )
 
         # Handle "body" branch
-        body_block = self._current_cfg.create_block(test_block, edge_label="True")
+        body_block = self._current_cfg.create_block(
+            test_block, edge_label="True", edge_condition=node.test
+        )
         self._current_block = body_block
         for child in node.body:
             child.accept(self)
@@ -218,7 +226,9 @@ class CFGVisitor:
         self._control_boundaries.pop()
 
         # Handle "else" branch
-        else_block = self._current_cfg.create_block(test_block, edge_label="False")
+        else_block = self._current_cfg.create_block(
+            test_block, edge_label="False", edge_condition=node.test
+        )
         self._current_block = else_block
         for child in node.orelse:
             child.accept(self)

--- a/tests/test_cfg/test_label_if.py
+++ b/tests/test_cfg/test_label_if.py
@@ -23,10 +23,12 @@ def _extract_edge_labels(cfg: ControlFlowGraph) -> Tuple[int, int]:
     return labels.count("True"), labels.count("False")
 
 
-def _extract_edge_conditions(cfg: ControlFlowGraph) -> List[astroid.NodeNG]:
-    """Return the edge conditions in the given cfg as a list of AST nodes representing the condition."""
+def _extract_edge_conditions(cfg: ControlFlowGraph) -> List[str]:
+    """Return the edge conditions in the given cfg as a list of strings representing the condition."""
 
-    conditions = [edge.condition for edge in cfg.get_edges() if edge.condition is not None]
+    conditions = [
+        edge.condition.as_string() for edge in cfg.get_edges() if edge.condition is not None
+    ]
     return conditions
 
 
@@ -86,9 +88,7 @@ def test_condition_if_no_else() -> None:
         x = 4
     """
     expected_num_conditions = 2
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     assert all(condition == "x > 0" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
@@ -104,9 +104,7 @@ def test_condition_if_else() -> None:
         x = -1
     """
     expected_num_conditions = 2
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     assert all(condition == "x > 0" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
@@ -126,9 +124,7 @@ def test_condition_if_elsif() -> None:
         x = -1
     """
     expected_num_conditions = 6
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     expected_conditions = ["x > 5", "x > 5", "x > 3", "x > 3", "x > 0", "x > 0"]
     assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions

--- a/tests/test_cfg/test_label_if.py
+++ b/tests/test_cfg/test_label_if.py
@@ -86,8 +86,10 @@ def test_condition_if_no_else() -> None:
         x = 4
     """
     expected_num_conditions = 2
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    assert all(condition == "x > 0" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
 
@@ -102,8 +104,10 @@ def test_condition_if_else() -> None:
         x = -1
     """
     expected_num_conditions = 2
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    assert all(condition == "x > 0" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
 
@@ -122,6 +126,9 @@ def test_condition_if_elsif() -> None:
         x = -1
     """
     expected_num_conditions = 6
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    expected_conditions = ["x > 5", "x > 5", "x > 3", "x > 3", "x > 0", "x > 0"]
+    assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions

--- a/tests/test_cfg/test_label_while.py
+++ b/tests/test_cfg/test_label_while.py
@@ -178,8 +178,10 @@ def test_while_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 2
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    assert all(condition == "i < 10" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
 
@@ -195,8 +197,10 @@ def test_while_else_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 2
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    assert all(condition == "i < 10" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
 
@@ -216,8 +220,11 @@ def test_complex_while_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 6
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    expected_conditions = ["i < 10", "j < 5", "j < 5", "i > 4", "i > 4", "i < 10"]
+    assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions
 
 
@@ -239,6 +246,9 @@ def test_complex_while_else_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 6
-    found_conditions = _extract_edge_conditions(build_cfg(src))
-    assert all(isinstance(condition, astroid.nodes.Compare) for condition in found_conditions)
+    found_conditions = [
+        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
+    ]
+    expected_conditions = ["i < 10", "j < 5", "j < 5", "i > 4", "i > 4", "i < 10"]
+    assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions

--- a/tests/test_cfg/test_label_while.py
+++ b/tests/test_cfg/test_label_while.py
@@ -25,10 +25,12 @@ def _extract_num_labels(cfg: ControlFlowGraph) -> int:
     return sum(1 for edge in cfg.get_edges() if edge.label is not None)
 
 
-def _extract_edge_conditions(cfg: ControlFlowGraph) -> List[astroid.NodeNG]:
-    """Return the edge conditions in the given cfg as a list of AST nodes representing the condition."""
+def _extract_edge_conditions(cfg: ControlFlowGraph) -> List[str]:
+    """Return the edge conditions in the given cfg as a list of strings representing the condition."""
 
-    conditions = [edge.condition for edge in cfg.get_edges() if edge.condition is not None]
+    conditions = [
+        edge.condition.as_string() for edge in cfg.get_edges() if edge.condition is not None
+    ]
     return conditions
 
 
@@ -178,9 +180,7 @@ def test_while_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 2
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     assert all(condition == "i < 10" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
@@ -197,9 +197,7 @@ def test_while_else_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 2
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     assert all(condition == "i < 10" for condition in found_conditions)
     assert len(found_conditions) == expected_num_conditions
 
@@ -220,9 +218,7 @@ def test_complex_while_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 6
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     expected_conditions = ["i < 10", "j < 5", "j < 5", "i > 4", "i > 4", "i < 10"]
     assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions
@@ -246,9 +242,7 @@ def test_complex_while_else_conditions() -> None:
     print('not else')
     """
     expected_num_conditions = 6
-    found_conditions = [
-        condition.as_string() for condition in _extract_edge_conditions(build_cfg(src))
-    ]
+    found_conditions = _extract_edge_conditions(build_cfg(src))
     expected_conditions = ["i < 10", "j < 5", "j < 5", "i > 4", "i > 4", "i < 10"]
     assert found_conditions == expected_conditions
     assert len(found_conditions) == expected_num_conditions


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

Currently the edges in a generated control flow graph coming out of If and While conditions are labelled with True or False. We can augment the edge instead to store the actual condition as an attribute, allowing us to accumulate logical conditions along a particular path in the graph.

## Your Changes

<!-- Describe your changes here. -->

Added a new instance attribute to CFGEdge called condition to represent the condition node. Updated methods that add an label to also add a condition.

**Description**:

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] New feature (non-breaking change which adds functionality)


## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

Added automated tests to see if condition attributes were set correctly. The attributes are not visibly displayed in the generated CFG.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
