### PR TITLE
Fixed infinite recursion in representation invariants with method calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue where annotated constant variable assignment was not considered as permissible top level code and triggered error E9992
 - Fixed issue where top level class attribute assignment was considered as permissible top level code
 - Fixed issue where `check_contracts` fails silently when function preconditions contain precondition violations, and when a representation invariant contains a call to a top-level function (not built-in or imported library).
+- Fixed issue where methods called in representation invariants lead to infinite recursion.
 
 ### New checkers
 

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -164,6 +164,11 @@ def add_class_invariants(klass: type) -> None:
 
         Check representation invariants for this class when not within an instance method of the class.
         """
+        if name == "currently_checking":
+            # This is a special attribute, so representation invariants should not be checked
+            super(klass, self).__setattr__(name, value)
+            return
+
         if not ENABLE_CONTRACT_CHECKING:
             super(klass, self).__setattr__(name, value)
             return
@@ -399,6 +404,12 @@ def _check_class_type_annotations(klass: type, instance: Any) -> None:
 
 def _check_invariants(instance, klass: type, global_scope: dict) -> None:
     """Check that the representation invariants for the instance are satisfied."""
+    if hasattr(instance, "currently_checking"):
+        # If already checking invariants for this instance, skip to avoid infinite recursion
+        return
+
+    instance.currently_checking = True
+
     rep_invariants = getattr(klass, "__representation_invariants__", set())
 
     for invariant, compiled in rep_invariants:
@@ -414,6 +425,10 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
             _debug(f"Warning: could not evaluate representation invariant: {invariant}")
         else:
             if not check:
+                # Remove the "currenlty_checking" attribute before printing the error message to the user
+                if hasattr(instance, "currently_checking"):
+                    delattr(instance, "currently_checking")
+
                 curr_attributes = ", ".join(
                     f"{k}: {_display_value(v)}" for k, v in vars(instance).items()
                 )
@@ -424,6 +439,8 @@ def _check_invariants(instance, klass: type, global_scope: dict) -> None:
                     f'"{instance.__class__.__name__}" representation invariant "{invariant}" was violated for'
                     f" instance attributes {curr_attributes}"
                 )
+
+    delattr(instance, "currently_checking")
 
 
 def _get_legal_return_val_var_name(var_dict: dict) -> str:

--- a/tests/test_contracts/test_class_contracts.py
+++ b/tests/test_contracts/test_class_contracts.py
@@ -441,5 +441,80 @@ def test_invariant_with_function_defined_in_module() -> None:
     )
 
 
+class Course:
+    """Represent a course
+
+    Representation Invariants:
+     - self.num_students > 0
+     - self.validate_code(self.code)
+    """
+
+    code: str
+    num_students: int
+
+    def __init__(self, code: str, num_students: int):
+        self.code = code
+        self.num_students = num_students
+
+    def validate_code(self, code) -> bool:
+        """Validate the code for this course"""
+        return code != ""
+
+
+def test_method_invariant_no_violation() -> None:
+    """
+    Test that no infinite recursion occurs when the representation invariants
+    calls a method of the class, and there is NOT a violation.
+    """
+    course = Course("CSC108", 100)
+    assert course.code == "CSC108"
+    assert course.num_students == 100
+
+
+def test_method_invariant_violation() -> None:
+    """
+    Test that no infinite recursion occurs when the representation invariants
+    calls a method of the class, and there is a violation,
+    Also, test that the correct error is raised.
+    """
+    with pytest.raises(AssertionError) as exception_info:
+        Course("", 100)
+
+    assert (
+        str(exception_info.value) == '"Course" representation invariant '
+        '"self.validate_code(self.code)" was violated for instance attributes'
+        " {code: '', num_students: 100}"
+    )
+
+
+def test_method_invariant_set_valid() -> None:
+    """
+    Test that no infinite recursion occurs when directly setting an attribute
+    with a valid value used in a representation invariant calls a class method.
+    """
+    course = Course("CSC108", 100)
+    course.code = "CSC209"
+    assert course.code == "CSC209"
+    assert course.num_students == 100
+
+
+def test_method_invariant_set_invalid() -> None:
+    """
+    Test that no infinite recursion occurs when directly setting an attribute
+    with an invalid value used in a representation invariant calls a class method.
+    Also, test that the correct error is raised.
+    """
+    course = Course("CSC108", 100)
+
+    with pytest.raises(AssertionError) as exception_info:
+        course.code = ""
+
+    assert (
+        str(exception_info.value) == '"Course" representation invariant '
+        '"self.validate_code(self.code)" was violated for instance attributes'
+        " {code: '', num_students: 100}"
+    )
+
+
 if __name__ == "__main__":
     pytest.main(["test_class_contracts.py"])


### PR DESCRIPTION
<!-- Provide a summary of your changes in the Pull Request Title above. -->
<!-- If this is a work in progress (not yet ready to be merged), make this a draft pull request. -->

## Motivation and Context

<!-- Why is this pull request required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here: -->
<!-- https://docs.github.com/en/github/managing-your-work-on-github/managing-your-work-with-issues-and-pull-requests/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->

When a representation invariant of a class invokes one of its methods, the representation invariants for that class keep being checked recursively, leading to infinite recursion. This pull request fixes this issue, allowing to use class methods in representation invariants for more flexibility.

## Your Changes

<!-- Describe your changes here. -->
I temporarily added an attribute `__pyta_currently_checking` to the instance whose representation invariants are being checked. Such attribute is added at the beginning of the check and deleted at the end, and the representation invariants are only checked when this attribute exists. Finally, I modified `new_setattr` to skip the representation invariant check exclusively for the `__pyta_currently_checking` attribute.

**Description**:

**Type of change** (select all that apply):

<!-- Put an `x` in all the boxes that apply. -->
<!-- Remove any lines that do not apply. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Please describe in detail how you tested this pull request. -->
<!-- This can include tests you added and manual testing. -->

I added four tests to the `test_class_contract.py` file testing for the correct behavior with valid and invalid attribute values both when initializing a class instance and when setting an attribute to a new value.

## Questions and Comments (if applicable)

<!-- Ask any questions you have for the maintainers of this project regarding this PR. -->
<!-- Please describe the steps you have already taken to find the answer to your question. -->
<!-- This will ensure that we can give you clear and relevant advice. -->
<!-- If you have additional comments add them here as well. -->

**Comments**:
I decided to delete the `__pyta_currently_checking` attribute instead of simply setting it to `False` because it should not be accessible to the user after the RI check has concluded.

**Questions**:
- For now, these changes don't seem to allow to call methods of a different class in the representation invariants. When this happens, the check fails silently, and the class instance is created successfully.
- When a class method is called with an argument that is not defined, the precondition check also fails silently.

What should be the expected behavior in both these cases?

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have verified that the CI tests have passed. <!-- (check after opening pull request) -->
- [x] I have reviewed the test coverage changes reported on Coveralls. <!-- (check after opening pull request) -->
- [x] I have added tests for my changes. <!-- (delete this checklist item if not applicable) -->
- [x] I have updated the CHANGELOG.md file. <!-- (delete this checklist item if not applicable) -->
