### PR TITLE
Parametrized tests for test_pycodestyle_checker

### DIFF
--- a/tests/test_custom_checkers/test_pycodestyle_checker.py
+++ b/tests/test_custom_checkers/test_pycodestyle_checker.py
@@ -1,186 +1,202 @@
 import os
-
 import pylint.testutils
 from astroid.astroid_manager import MANAGER
+import pytest
 
 from python_ta.checkers.pycodestyle_checker import PycodestyleChecker
 
 DIR_PATH = os.path.join(__file__, "../../../examples/custom_checkers/e9989_pycodestyle/")
 
 
+def pytest_generate_tests(metafunc):
+    # called once per each test function
+    funcarglist = metafunc.cls.params.get(metafunc.function.__name__, [])
+    argnames = sorted(funcarglist[0]) if funcarglist else []
+    metafunc.parametrize(
+        argnames, [[funcargs[name] for name in argnames] for funcargs in funcarglist]
+    )
+
+
 class TestPycodestyleChecker(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = PycodestyleChecker
     CONFIG = {"pycodestyle_ignore": ["E24"]}
 
-    def test_error_e123(self) -> None:
-        """Tests that PEP8 error E123 closing bracket does not match indentation of opening bracket's line triggers"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e123_error.py"))
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="pep8-errors",
-                line=3,
-                args=(
-                    "E123",
-                    "line 3, column 4: closing bracket does not match indentation of opening bracket's line",
+    params = {
+        "test_error_e123": [dict(filename="e123_error.py", should_raise=True)],
+        "test_no_error_e123": [dict(filename="e123_no_error.py", should_raise=False)],
+        "test_error_e203": [dict(filename="e203_error.py", should_raise=True)],
+        "test_no_error_e203": [dict(filename="e203_no_error.py", should_raise=False)],
+        "test_error_e222": [dict(filename="e222_error.py", should_raise=True)],
+        "test_no_error_e222": [dict(filename="e222_no_error.py", should_raise=False)],
+        "test_error_e223": [dict(filename="e223_error.py", should_raise=True)],
+        "test_no_error_e223": [dict(filename="e223_no_error.py", should_raise=False)],
+        "test_error_e224": [dict(filename="e224_error.py", should_raise=True)],
+        "test_no_error_e224": [dict(filename="e224_no_error.py", should_raise=False)],
+        "test_error_e226": [dict(filename="e226_error.py", should_raise=True)],
+        "test_no_error_e226": [dict(filename="e226_no_error.py", should_raise=False)],
+        "test_error_e227": [dict(filename="e227_error.py", should_raise=True)],
+        "test_no_error_e227": [dict(filename="e227_no_error.py", should_raise=False)],
+        "test_error_e228": [dict(filename="e228_error.py", should_raise=True)],
+        "test_no_error_e228": [dict(filename="e228_no_error.py", should_raise=False)],
+        "test_error_e262": [dict(filename="e262_error.py", should_raise=True)],
+        "test_no_error_e262": [dict(filename="e262_no_error.py", should_raise=False)],
+        "test_error_e265": [dict(filename="e265_error.py", should_raise=True)],
+        "test_no_error_e265": [dict(filename="e265_no_error.py", should_raise=False)],
+    }
+
+    def run_test(self, filename, should_raise, msg_args=None):
+        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, filename))
+        if should_raise:
+            with self.assertAddsMessages(
+                pylint.testutils.MessageTest(
+                    msg_id="pep8-errors",
+                    line=msg_args["line"],
+                    node=None,
+                    args=(msg_args["code"], msg_args["message"]),
                 ),
-            ),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+                ignore_position=True,
+            ):
+                self.checker.process_module(mod)
+        else:
+            with self.assertNoMessages():
+                self.checker.process_module(mod)
 
-    def test_no_error_e123(self) -> None:
-        """Tests that PEP8 error E123 closing bracket does not match indentation of opening bracket's line
-        is NOT triggered"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e123_no_error.py"))
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e123(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 3,
+                "code": "E123",
+                "message": "line 3, column 4: closing bracket does not match indentation of opening bracket's line",
+            },
+        )
 
-    def test_error_e203(self) -> None:
-        """Test that PEP8 error E203 (whitespace before ‘,’, ‘;’, or ‘:’) is triggered"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e203_error.py"))
-        args = ("E203", "line 1, column 30: whitespace before ':'")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, args=args)
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e123(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e203(self) -> None:
-        """Test that PEP8 error E203 (whitespace before ‘,’, ‘;’, or ‘:’) is NOT triggered"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e203_no_error.py"))
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e203(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E203",
+                "message": "line 1, column 30: whitespace before ':'",
+            },
+        )
 
-    def test_error_e222(self) -> None:
-        """Test that PEP8 error E222 (multiple spaces after operator) triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e222_error.py")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="pep8-errors",
-                line=1,
-                node=None,
-                args=("E222", "line 1, column 3: multiple spaces after operator"),
-            ),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e203(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e222(self) -> None:
-        """Test that PEP8 error E222 (multiple spaces after operator) is not triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e222_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e222(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E222",
+                "message": "line 1, column 3: multiple spaces after operator",
+            },
+        )
 
-    def test_error_e223(self) -> None:
-        """Test that PEP8 error E223 (tab before operator) triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e223_error.py")
-        args = ("E223", "line 1, column 1: tab before operator")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, node=None, args=args),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e222(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e223(self) -> None:
-        """Test that PEP8 error E223 (tab before operator) is NOT triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e223_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e223(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E223",
+                "message": "line 1, column 1: tab before operator",
+            },
+        )
 
-    def test_error_e224(self) -> None:
-        """Test that PEP8 error E224 (tab after operator) triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e224_error.py")
-        args = ("E224", "line 1, column 3: tab after operator")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, node=None, args=args),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e223(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e224(self) -> None:
-        """Test that PEP8 error E224 (tab after operator) is NOT triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e224_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e224(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E224",
+                "message": "line 1, column 3: tab after operator",
+            },
+        )
 
-    def test_error_e226(self) -> None:
-        """Test that PEP8 error E226 (missing whitespace around arithmetic operator) is triggered"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e226_error.py"))
-        args = ("E226", "line 1, column 5: missing whitespace around arithmetic operator")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, args=args)
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e224(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e226(self) -> None:
-        """Test that PEP8 error E226 (missing whitespace around arithmeic operator) is NOT triggered"""
-        mod = MANAGER.ast_from_file(os.path.join(DIR_PATH, "e226_no_error.py"))
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e226(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E226",
+                "message": "line 1, column 5: missing whitespace around arithmetic operator",
+            },
+        )
 
-    def test_error_e227(self) -> None:
-        """Test that PEP8 error E227 (missing whitespace around bitwise or shift operator) triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e227_error.py")
-        args = ("E227", "line 1, column 5: missing whitespace around bitwise or shift operator")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, node=None, args=args),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e226(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e227(self) -> None:
-        """Test that PEP8 error E227 (missing whitespace around bitwise or shift operator) is NOT triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e227_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e227(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E227",
+                "message": "line 1, column 5: missing whitespace around bitwise or shift operator",
+            },
+        )
 
-    def test_error_e228(self) -> None:
-        """Test that PEP8 error E228 (missing whitespace around modulo operator) triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e228_error.py")
-        args = ("E228", "line 1, column 5: missing whitespace around modulo operator")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, node=None, args=args),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e227(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e228(self) -> None:
-        """Test that PEP8 error E228 (missing whitespace around modulo operator) is NOT triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e228_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e228(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E228",
+                "message": "line 1, column 5: missing whitespace around modulo operator",
+            },
+        )
 
-    def test_error_e262(self) -> None:
-        """Test that PEP8 error E262 (inline comment should start with '# ') triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e262_error.py")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(
-                msg_id="pep8-errors",
-                line=1,
-                node=None,
-                args=("E262", "line 1, column 7: inline comment should start with '# '"),
-            ),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e228(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e262(self) -> None:
-        """Test that PEP8 error E262 (inline comment should start with '# ') is not triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e262_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e262(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E262",
+                "message": "line 1, column 7: inline comment should start with '# '",
+            },
+        )
 
-    def test_error_e265(self) -> None:
-        """Test that PEP8 error E265 (block comment should start with '# ') triggers"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e265_error.py")
-        args = ("E265", "line 1, column 0: block comment should start with '# '")
-        with self.assertAddsMessages(
-            pylint.testutils.MessageTest(msg_id="pep8-errors", line=1, node=None, args=args),
-            ignore_position=True,
-        ):
-            self.checker.process_module(mod)
+    def test_no_error_e262(self, filename, should_raise):
+        self.run_test(filename, should_raise)
 
-    def test_no_error_e265(self) -> None:
-        """Test that PEP8 error E265 (block comment should start with '# ') is NOT triggered"""
-        mod = MANAGER.ast_from_file(DIR_PATH + "e265_no_error.py")
-        with self.assertNoMessages():
-            self.checker.process_module(mod)
+    def test_error_e265(self, filename, should_raise):
+        self.run_test(
+            filename,
+            should_raise,
+            msg_args={
+                "line": 1,
+                "code": "E265",
+                "message": "line 1, column 0: block comment should start with '# '",
+            },
+        )
+
+    def test_no_error_e265(self, filename, should_raise):
+        self.run_test(filename, should_raise)


### PR DESCRIPTION
## Proposed Changes
Eliminated the duplication of the pycodestyle checker tests by replacing the existing tests with pytest's parameterized tests.

This currently uses the non-decorator version of pytest's parametrized tests.

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |X|
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |X|
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [ ] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

I have marked this as a draft as I would like you to take a quick look at how I've implemented the parametrization. I have chosen to do it by having a separate function do all the work, with a dict (params variable) specifying multiple argument sets for the run_test method, as shown in:  https://docs.pytest.org/en/7.1.x/example/parametrize.html#paramexamples

I found this cleaner than using the decorators, let me know if this makes sense to you! Otherwise, some code clean-up, and verification of all the tests still needs to be done before I mark this as not a draft.