### PR TITLE
feat: add support for container literals and in operator in ExprWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Custom checkers:
 - Updated usage messages in `examples/sample_usage/` of `draw_cfg.py` and `print_ast.py` to be accurate on all operating systems
 - Removed redundant line from `tests/test_examples.py`
 - Fixed minor typo in an error message in `python_ta/cfg/visitor.py`
+- Updated `ExprWrapper` to support `set/list/tuple` literals and `in/not in` operators
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/transforms/ExprWrapper.py
+++ b/python_ta/transforms/ExprWrapper.py
@@ -124,12 +124,14 @@ class ExprWrapper:
                 return left < right
             elif op == ">":
                 return left > right
-            elif op == "in":
+            elif op == "in" and isinstance(right, list):
                 return z3.Or(*[left == element for element in right])
-            elif op == "not in":
+            elif op == "not in" and isinstance(right, list):
                 return z3.And(*[left != element for element in right])
             else:
-                raise Z3ParseException(f"Unhandled binary operation {op}.")
+                raise Z3ParseException(
+                    f"Unhandled binary operation {op} with operator types {left} and {right}."
+                )
         except TypeError:
             raise Z3ParseException(f"Operation {op} incompatible with types {left} and {right}.")
 

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -56,14 +56,15 @@ def test_bool_constraints():
         assert solver.check() == z3.sat
 
 
-def test_list_constraints():
+def test_container_constraints():
     z3v = Z3Visitor()
     code = """
     def f(x: int):
         '''
         Preconditions:
             - x in [1, 2, 3]
-            - x not in [4, 5, 6, 7, 8]
+            - x not in {4, 5, 6, 7, 8}
+            - x in (1, 2)
         '''
         pass
     """
@@ -72,7 +73,11 @@ def test_list_constraints():
     # Declare variables
     x = z3.Int("x")
     # Construct expected
-    expected = [z3.Or(x == 1, x == 2, x == 3), z3.And(x != 4, x != 5, x != 6, x != 7, x != 8)]
+    expected = [
+        z3.Or(x == 1, x == 2, x == 3),
+        z3.And(x != 4, x != 5, x != 6, x != 7, x != 8),
+        z3.Or(x == 1, x == 2),
+    ]
     actual = function_def.z3_constraints
     assert actual != []
     for e, a in zip(expected, actual):

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -83,21 +83,33 @@ container_list = [
         pass
     """,
     """
-    def in_empty_container(x: int):
+    def in_empty_list(x: int):
         '''
         Preconditions:
             - x in []
-            - x in set()
+        '''
+        pass
+    """,
+    """
+    def in_empty_tuple(x: int):
+        '''
+        Preconditions:
             - x in ()
         '''
         pass
     """,
     """
-    def not_in_empty_container(x: int):
+    def not_in_empty_list(x: int):
         '''
         Preconditions:
             - x not in []
-            - x not in set()
+        '''
+        pass
+    """,
+    """
+    def not_in_empty_tuple(x: int):
+        '''
+        Preconditions:
             - x not in ()
         '''
         pass
@@ -126,8 +138,10 @@ container_expected = [
     [z3.And(x != 1, x != 2, x != 3)],
     [z3.And(x != 1, x != 2, x != 3)],
     [z3.And(x != 1, x != 2, x != 3)],
-    [z3.BoolVal(False), z3.BoolVal(False)],
-    [z3.BoolVal(True), z3.BoolVal(True)],
+    [z3.BoolVal(False)],
+    [z3.BoolVal(False)],
+    [z3.BoolVal(True)],
+    [z3.BoolVal(True)],
 ]
 
 # lists of all test cases

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -1,11 +1,23 @@
+from typing import List
+
 import astroid
+import pytest
 import z3
 
 from python_ta.transforms.z3_visitor import Z3Visitor
 
 
-def test_arithmetic_constraints():
+def _get_constraints_from_code(code) -> List[z3.ExprRef]:
+    """
+    Return the z3 constraints of the given function
+    """
     z3v = Z3Visitor()
+    mod = z3v.visitor.visit(astroid.parse(code))
+    function_def = mod.body[0]
+    return function_def.z3_constraints
+
+
+def test_arithmetic_constraints():
     code = """
     def f(x: int, y: int, z: float, a):
         '''
@@ -15,15 +27,13 @@ def test_arithmetic_constraints():
         '''
         pass
     """
-    mod = z3v.visitor.visit(astroid.parse(code))
-    function_def = mod.body[0]
     # Declare variables
     x = z3.Int("x")
     y = z3.Int("y")
     z = z3.Real("z")
     # Construct expected
     expected = [x**2 + y**2 == z**2, z3.And([x > 0, y > 0, z == 0])]
-    actual = function_def.z3_constraints
+    actual = _get_constraints_from_code(code)
     for e, a in zip(expected, actual):
         solver = z3.Solver()
         solver.add(e == a)
@@ -31,7 +41,6 @@ def test_arithmetic_constraints():
 
 
 def test_bool_constraints():
-    z3v = Z3Visitor()
     code = """
     def f(x: bool, y: bool, z: bool, a):
         '''
@@ -41,15 +50,13 @@ def test_bool_constraints():
         '''
         pass
     """
-    mod = z3v.visitor.visit(astroid.parse(code))
-    function_def = mod.body[0]
     # Declare variables
     x = z3.Bool("x")
     y = z3.Bool("y")
     z = z3.Bool("z")
     # Construct expected
     expected = [z3.And([x, y, z]), z3.Not(z3.Or([x, y, z]))]
-    actual = function_def.z3_constraints
+    actual = _get_constraints_from_code(code)
     for e, a in zip(expected, actual):
         solver = z3.Solver()
         solver.add(e == a)
@@ -57,30 +64,100 @@ def test_bool_constraints():
 
 
 def test_container_constraints():
-    z3v = Z3Visitor()
-    code = """
-    def f(x: int):
+    code_list = [
+        """
+    def in_list(x: int):
         '''
         Preconditions:
             - x in [1, 2, 3]
-            - x not in {4, 5, 6, 7, 8}
-            - x in (1, 2)
         '''
         pass
-    """
-    mod = z3v.visitor.visit(astroid.parse(code))
-    function_def = mod.body[0]
+    """,
+        """
+    def in_set(x: int):
+        '''
+        Preconditions:
+            - x in {1, 2, 3}
+        '''
+        pass
+    """,
+        """
+    def in_tuple(x: int):
+        '''
+        Preconditions:
+            - x in (1, 2, 3)
+        '''
+        pass
+    """,
+        """
+    def not_in_list(x: int):
+        '''
+        Preconditions:
+            - x not in [1, 2, 3]
+        '''
+        pass
+    """,
+        """
+    def not_in_list(x: int):
+        '''
+        Preconditions:
+            - x not in {1, 2, 3}
+        '''
+        pass
+    """,
+        """
+    def not_in_tuple(x: int):
+        '''
+        Preconditions:
+            - x not in (1, 2, 3)
+        '''
+        pass
+    """,
+        """
+    def in_empty_container(x: int):
+        '''
+        Preconditions:
+            - x in []
+            - x in set()
+            - x in ()
+        '''
+        pass
+    """,
+        """
+    def not_in_empty_container(x: int):
+        '''
+        Preconditions:
+            - x not in []
+            - x not in set()
+            - x not in ()
+        '''
+        pass
+
+    """,
+    ]
     # Declare variables
     x = z3.Int("x")
     # Construct expected
-    expected = [
-        z3.Or(x == 1, x == 2, x == 3),
-        z3.And(x != 4, x != 5, x != 6, x != 7, x != 8),
-        z3.Or(x == 1, x == 2),
+    expected_list = [
+        [z3.Or(x == 1, x == 2, x == 3)],
+        [z3.Or(x == 1, x == 2, x == 3)],
+        [z3.Or(x == 1, x == 2, x == 3)],
+        [z3.And(x != 1, x != 2, x != 3)],
+        [z3.And(x != 1, x != 2, x != 3)],
+        [z3.And(x != 1, x != 2, x != 3)],
+        [z3.BoolVal(False), z3.BoolVal(False)],
+        [z3.BoolVal(True), z3.BoolVal(True)],
     ]
-    actual = function_def.z3_constraints
-    assert actual != []
-    for e, a in zip(expected, actual):
-        solver = z3.Solver()
-        solver.add(e == a)
-        assert solver.check() == z3.sat
+
+    for expected, code in zip(expected_list, code_list):
+        actual = _get_constraints_from_code(code)
+        assert len(actual) == len(expected)
+
+        @pytest.mark.parametrize("expected, actual", zip(expected, actual))
+        def check_constraint(expected, actual):
+            solver = z3.Solver()
+            solver.add(expected == actual)
+            assert solver.check() == z3.sat
+
+        for expected, actual in zip(expected, actual):
+            check_constraint(expected, actual)

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -98,7 +98,7 @@ def test_container_constraints():
         pass
     """,
         """
-    def not_in_list(x: int):
+    def not_in_set(x: int):
         '''
         Preconditions:
             - x not in {1, 2, 3}

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -54,3 +54,28 @@ def test_bool_constraints():
         solver = z3.Solver()
         solver.add(e == a)
         assert solver.check() == z3.sat
+
+
+def test_list_constraints():
+    z3v = Z3Visitor()
+    code = """
+    def f(x: int):
+        '''
+        Preconditions:
+            - x in [1, 2, 3]
+            - x not in [4, 5, 6, 7, 8]
+        '''
+        pass
+    """
+    mod = z3v.visitor.visit(astroid.parse(code))
+    function_def = mod.body[0]
+    # Declare variables
+    x = z3.Int("x")
+    # Construct expected
+    expected = [z3.Or(x == 1, x == 2, x == 3), z3.And(x != 4, x != 5, x != 6, x != 7, x != 8)]
+    actual = function_def.z3_constraints
+    assert actual != []
+    for e, a in zip(expected, actual):
+        solver = z3.Solver()
+        solver.add(e == a)
+        assert solver.check() == z3.sat

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -6,6 +6,134 @@ import z3
 
 from python_ta.transforms.z3_visitor import Z3Visitor
 
+# test cases for arithmetic expressions
+arithmetic_list = [
+    """
+    def f(x: int, y: int, z: float, a):
+        '''
+        Preconditions:
+            - x ** 2 + y ** 2 == z ** 2
+            - x > 0 and y > 0 and z == 0
+        '''
+        pass
+    """
+]
+
+# test cases for boolean expressions
+boolean_list = [
+    """
+    def f(x: bool, y: bool, z: bool, a):
+        '''
+        Preconditions:
+            - x and y and z
+            - not (x or y or z)
+        '''
+        pass
+    """
+]
+
+# test cases for container (list/set/tuple) expressions
+container_list = [
+    """
+    def in_list(x: int):
+        '''
+        Preconditions:
+            - x in [1, 2, 3]
+        '''
+        pass
+    """,
+    """
+    def in_set(x: int):
+        '''
+        Preconditions:
+            - x in {1, 2, 3}
+        '''
+        pass
+    """,
+    """
+    def in_tuple(x: int):
+        '''
+        Preconditions:
+            - x in (1, 2, 3)
+        '''
+        pass
+    """,
+    """
+    def not_in_list(x: int):
+        '''
+        Preconditions:
+            - x not in [1, 2, 3]
+        '''
+        pass
+    """,
+    """
+    def not_in_set(x: int):
+        '''
+        Preconditions:
+            - x not in {1, 2, 3}
+        '''
+        pass
+    """,
+    """
+    def not_in_tuple(x: int):
+        '''
+        Preconditions:
+            - x not in (1, 2, 3)
+        '''
+        pass
+    """,
+    """
+    def in_empty_container(x: int):
+        '''
+        Preconditions:
+            - x in []
+            - x in set()
+            - x in ()
+        '''
+        pass
+    """,
+    """
+    def not_in_empty_container(x: int):
+        '''
+        Preconditions:
+            - x not in []
+            - x not in set()
+            - x not in ()
+        '''
+        pass
+    """,
+]
+
+
+# expected arithmetic expressions
+x = z3.Int("x")
+y = z3.Int("y")
+z = z3.Real("z")
+arithmetic_expected = [[x**2 + y**2 == z**2, z3.And([x > 0, y > 0, z == 0])]]
+
+# expected boolean expressions
+x = z3.Bool("x")
+y = z3.Bool("y")
+z = z3.Bool("z")
+boolean_expected = [[z3.And([x, y, z]), z3.Not(z3.Or([x, y, z]))]]
+
+# expected container expressions
+x = z3.Int("x")
+container_expected = [
+    [z3.Or(x == 1, x == 2, x == 3)],
+    [z3.Or(x == 1, x == 2, x == 3)],
+    [z3.Or(x == 1, x == 2, x == 3)],
+    [z3.And(x != 1, x != 2, x != 3)],
+    [z3.And(x != 1, x != 2, x != 3)],
+    [z3.And(x != 1, x != 2, x != 3)],
+    [z3.BoolVal(False), z3.BoolVal(False)],
+    [z3.BoolVal(True), z3.BoolVal(True)],
+]
+
+# lists of all test cases
+code_list = [arithmetic_list, boolean_list, container_list]
+expected_list = [arithmetic_expected, boolean_expected, container_expected]
+
 
 def _get_constraints_from_code(code) -> List[z3.ExprRef]:
     """
@@ -17,147 +145,12 @@ def _get_constraints_from_code(code) -> List[z3.ExprRef]:
     return function_def.z3_constraints
 
 
-def test_arithmetic_constraints():
-    code = """
-    def f(x: int, y: int, z: float, a):
-        '''
-        Preconditions:
-            - x ** 2 + y ** 2 == z ** 2
-            - x > 0 and y > 0 and z == 0
-        '''
-        pass
-    """
-    # Declare variables
-    x = z3.Int("x")
-    y = z3.Int("y")
-    z = z3.Real("z")
-    # Construct expected
-    expected = [x**2 + y**2 == z**2, z3.And([x > 0, y > 0, z == 0])]
-    actual = _get_constraints_from_code(code)
-    for e, a in zip(expected, actual):
-        solver = z3.Solver()
-        solver.add(e == a)
-        assert solver.check() == z3.sat
-
-
-def test_bool_constraints():
-    code = """
-    def f(x: bool, y: bool, z: bool, a):
-        '''
-        Preconditions:
-            - x and y and z
-            - not (x or y or z)
-        '''
-        pass
-    """
-    # Declare variables
-    x = z3.Bool("x")
-    y = z3.Bool("y")
-    z = z3.Bool("z")
-    # Construct expected
-    expected = [z3.And([x, y, z]), z3.Not(z3.Or([x, y, z]))]
-    actual = _get_constraints_from_code(code)
-    for e, a in zip(expected, actual):
-        solver = z3.Solver()
-        solver.add(e == a)
-        assert solver.check() == z3.sat
-
-
-def test_container_constraints():
-    code_list = [
-        """
-    def in_list(x: int):
-        '''
-        Preconditions:
-            - x in [1, 2, 3]
-        '''
-        pass
-    """,
-        """
-    def in_set(x: int):
-        '''
-        Preconditions:
-            - x in {1, 2, 3}
-        '''
-        pass
-    """,
-        """
-    def in_tuple(x: int):
-        '''
-        Preconditions:
-            - x in (1, 2, 3)
-        '''
-        pass
-    """,
-        """
-    def not_in_list(x: int):
-        '''
-        Preconditions:
-            - x not in [1, 2, 3]
-        '''
-        pass
-    """,
-        """
-    def not_in_set(x: int):
-        '''
-        Preconditions:
-            - x not in {1, 2, 3}
-        '''
-        pass
-    """,
-        """
-    def not_in_tuple(x: int):
-        '''
-        Preconditions:
-            - x not in (1, 2, 3)
-        '''
-        pass
-    """,
-        """
-    def in_empty_container(x: int):
-        '''
-        Preconditions:
-            - x in []
-            - x in set()
-            - x in ()
-        '''
-        pass
-    """,
-        """
-    def not_in_empty_container(x: int):
-        '''
-        Preconditions:
-            - x not in []
-            - x not in set()
-            - x not in ()
-        '''
-        pass
-
-    """,
-    ]
-    # Declare variables
-    x = z3.Int("x")
-    # Construct expected
-    expected_list = [
-        [z3.Or(x == 1, x == 2, x == 3)],
-        [z3.Or(x == 1, x == 2, x == 3)],
-        [z3.Or(x == 1, x == 2, x == 3)],
-        [z3.And(x != 1, x != 2, x != 3)],
-        [z3.And(x != 1, x != 2, x != 3)],
-        [z3.And(x != 1, x != 2, x != 3)],
-        [z3.BoolVal(False), z3.BoolVal(False)],
-        [z3.BoolVal(True), z3.BoolVal(True)],
-    ]
-
-    for expected, code in zip(expected_list, code_list):
-        actual = _get_constraints_from_code(code)
-        assert len(actual) == len(expected)
-
-        @pytest.mark.parametrize("expected, actual", zip(expected, actual))
-        def check_constraint(expected, actual):
+@pytest.mark.parametrize("code, expected", zip(code_list, expected_list))
+def test_constraint(code, expected):
+    for function, function_expected in zip(code, expected):
+        function_actual = _get_constraints_from_code(function)
+        assert len(function_actual) == len(function_expected)
+        for a, e in zip(function_actual, function_expected):
             solver = z3.Solver()
-            solver.add(expected == actual)
+            solver.add(a == e)
             assert solver.check() == z3.sat
-
-        for expected, actual in zip(expected, actual):
-            check_constraint(expected, actual)


### PR DESCRIPTION

## Proposed Changes

Extend `ExprWrapper` to support `List/Set/Tuple` literals and `in/not in` operators.
...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |     X     |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
