### PR TITLE
feat: Support `!=` Operator in ExprWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Custom checkers:
 - Removed deprecated and redundant `future` argument from `node.frame()` call in `invalid_name_checker.py`
 - Updated pylint to v3.2.6 and astroid to v3.2.4 (no new checks were enabled by default)
 - Excluded `node_modules/` folder from package autodiscovery
+- Added support for the `!=` operator and replaced dictionary indexing with `.get` in `ExprWrapper`.
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/transforms/ExprWrapper.py
+++ b/python_ta/transforms/ExprWrapper.py
@@ -79,7 +79,7 @@ class ExprWrapper:
         Set up the appropriate variable representation in Z3 based on name and type.
         If an error is encountered or a case is unconsidered, return None.
         """
-        typ = self.types[name]
+        typ = self.types.get(name)
         type_to_z3 = {
             "int": z3.Int,
             "float": z3.Real,
@@ -132,6 +132,8 @@ class ExprWrapper:
                 return left**right
             elif op == "==":
                 return left == right
+            elif op == "!=":
+                return left != right
             elif op == "<=":
                 return left <= right
             elif op == ">=":

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -24,6 +24,7 @@ arithmetic_list = [
         Preconditions:
             - x ** 2 + y ** 2 == z ** 2
             - x > 0 and y > 0 and z == 0
+            - x + y != z
         '''
         pass
     """
@@ -213,7 +214,7 @@ string_list = [
 x = z3.Int("x")
 y = z3.Int("y")
 z = z3.Real("z")
-arithmetic_expected = [[x**2 + y**2 == z**2, z3.And([x > 0, y > 0, z == 0])]]
+arithmetic_expected = [[x**2 + y**2 == z**2, z3.And([x > 0, y > 0, z == 0]), x + y != z]]
 
 # expected boolean expressions
 x = z3.Bool("x")

--- a/tests/test_z3_visitor.py
+++ b/tests/test_z3_visitor.py
@@ -135,6 +135,7 @@ string_list = [
         Preconditions:
             - x == y
             - z == x + y
+            - x != z
         '''
         pass
     """,
@@ -242,7 +243,7 @@ x = z3.String("x")
 y = z3.String("y")
 z = z3.String("z")
 string_expected = [
-    [x == y, z == x + y],
+    [x == y, z == x + y, x != z],
     [z3.Contains("abc", x), z3.Contains(y, x)],
     [z3.Not(z3.Contains("abc", x)), z3.Not(z3.Contains(y, x))],
     [


### PR DESCRIPTION
Support `!=` in `apply_bin_op()`
Use `get()` in dictionary lookup in `apply_name()` to prevent `KeyError`


...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |    X      |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
