### PR TITLE
refactor: Change `inferred` to `safe_infer` and Add Handling for `AstroidError` in `Z3Visitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Custom checkers:
 - Removed deprecated and redundant `future` argument from `node.frame()` call in `invalid_name_checker.py`
 - Updated pylint to v3.2.6 and astroid to v3.2.4 (no new checks were enabled by default)
 - Excluded `node_modules/` folder from package autodiscovery
+- Refactored `Z3Visitor` to use `safe_infer()` instead of `inferred()` and added handling of `AstroidError`.
 
 ## [2.7.0] - 2024-12-14
 

--- a/python_ta/transforms/z3_visitor.py
+++ b/python_ta/transforms/z3_visitor.py
@@ -1,6 +1,7 @@
 import astroid
-from astroid import Uninferable, nodes
+from astroid import AstroidError, Uninferable, nodes
 from astroid.transforms import TransformVisitor
+from astroid.util import safe_infer
 from z3.z3types import Z3Exception
 
 from ..contracts import parse_assertions
@@ -30,10 +31,10 @@ class Z3Visitor:
             if ann is None:
                 continue
             # TODO: what to do about subscripts ex. Set[int], List[Set[int]], ...
-            inferred = ann.inferred()
-            if len(inferred) > 0 and inferred[0] is not Uninferable:
-                if isinstance(inferred[0], nodes.ClassDef):
-                    types[arg.name] = inferred[0].name
+            inferred = safe_infer(ann)
+            if inferred is not Uninferable:
+                if isinstance(inferred, nodes.ClassDef):
+                    types[arg.name] = inferred.name
         # Parse preconditions
         preconditions = parse_assertions(node, parse_token="Precondition")
         # Get z3 constraints
@@ -43,7 +44,7 @@ class Z3Visitor:
             ew = ExprWrapper(pre, types)
             try:
                 transformed = ew.reduce()
-            except (Z3Exception, Z3ParseException):
+            except (AstroidError, Z3Exception, Z3ParseException):
                 transformed = None
             if transformed is not None:
                 z3_constraints.append(transformed)

--- a/python_ta/transforms/z3_visitor.py
+++ b/python_ta/transforms/z3_visitor.py
@@ -32,9 +32,8 @@ class Z3Visitor:
                 continue
             # TODO: what to do about subscripts ex. Set[int], List[Set[int]], ...
             inferred = safe_infer(ann)
-            if inferred is not Uninferable:
-                if isinstance(inferred, nodes.ClassDef):
-                    types[arg.name] = inferred.name
+            if isinstance(inferred, nodes.ClassDef):
+                types[arg.name] = inferred.name
         # Parse preconditions
         preconditions = parse_assertions(node, parse_token="Precondition")
         # Get z3 constraints


### PR DESCRIPTION
Change the use of `inferred()` to `astroid.util.safe_infer()` to prevent `InferenceError` for uninferable types

Add handling of `AstroidError` in parsing python expressions to Z3 expressions via `ExprWrapper`

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |    X      |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
