### PR TITLE
Ensure max-line-length default value is used when autoformat=True

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### 🐛 Bug fixes
 
 - Fixed issue in `static-type-checker` such that mypy no longer checks imported modules in the file being checked
+- Fixed issue in `autoformat` where the default `max-line-length` value was not used
 
 ### 🔧 Internal changes
 

--- a/python_ta/__init__.py
+++ b/python_ta/__init__.py
@@ -190,16 +190,13 @@ def _check(
                 )
 
                 if autoformat:
-                    linelen = (
-                        local_config["max-line-length"] if "max-line-length" in local_config else 88
-                    )
                     subprocess.run(
                         [
                             sys.executable,
                             "-m",
                             "black",
                             "--skip-string-normalization",
-                            "--line-length=" + str(linelen),
+                            f"--line-length={linter.config.max_line_length}",
                             file_py,
                         ],
                         encoding="utf-8",

--- a/tests/test_black.py
+++ b/tests/test_black.py
@@ -31,6 +31,15 @@ error_params = [
         False,
         """def foo():print("Hello, world!")\n""",
     ),
+    (
+        # This line is between 80-88 characters; it should be reformatted because the default
+        # max-line-len is 80.
+        """CONST = ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa', 'b']""",
+        {"output-format": "python_ta.reporters.JSONReporter"},
+        True,
+        "CONST = [\n    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',\n"
+        "    'b',\n]\n",
+    ),
 ]
 
 


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

This PR fixes a bug when `python_ta.check_all` is called with `autoformat=True`, and no `max-line-length` configuration value is provided. In this case a line length of 88 was used, instead of the correct value of the linter configuration option.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X        |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
