### PR TITLE
Allow AccumulationTable accumulation expressions to refer to loop variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue in `static-type-checker` such that mypy no longer checks imported modules in the file being checked
 - Fixed issue in `autoformat` where the default `max-line-length` value was not used
 - Fixed issue in contract-checking `new_setattr` where an instance attribute was not always reset when reassigning it to an invalid value
+- Fixed issue in `AccumulationTable` where accumulation expressions could not refer to loop variables
 
 ### 🔧 Internal changes
 

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -104,8 +104,15 @@ class AccumulationTable:
                 value = NO_VALUE
             else:
                 # name error wil be raised if accumulator cannot be found
-                value = eval(accumulator, frame.f_globals, frame.f_locals)
-                value = copy.deepcopy(value)
+                try:
+                    value = eval(accumulator, frame.f_globals, frame.f_locals)
+                except NameError as e:
+                    if sys.version_info >= (3, 10) and e.name in self.loop_variables:
+                        value = NO_VALUE
+                    else:
+                        raise
+                else:
+                    value = copy.deepcopy(value)
 
             self.loop_accumulators[accumulator].append(value)
 

--- a/tests/test_debug/test_accumulation_table.py
+++ b/tests/test_debug/test_accumulation_table.py
@@ -5,6 +5,7 @@ types of accumulator loops
 
 import copy
 import shutil
+import sys
 
 import pytest
 import tabulate
@@ -334,6 +335,18 @@ def test_expression_accumulator() -> None:
 
     assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
     assert table.loop_accumulators == {"sum_so_far * 2": [0, 20, 60, 120]}
+
+
+@pytest.mark.skipif(sys.version_info < (3, 10), reason="requires Python 3.10 or higher")
+def test_expression_with_loop_var_accumulator() -> None:
+    test_list = [10, 20, 30]
+    sum_so_far = 0
+    with AccumulationTable(["item * 2"]) as table:
+        for item in test_list:
+            sum_so_far = sum_so_far + item
+
+    assert table.loop_variables == {"item": ["N/A", 10, 20, 30]}
+    assert table.loop_accumulators == {"item * 2": ["N/A", 20, 40, 60]}
 
 
 def test_invalid_accumulator() -> None:


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

Previously, if `AccumulationTable` was passed an accumulation expression that involved a loop variable, evaluating that expression for the first row of the table (representing state before the loop executes) led to a `NameError` because the loop variable was not yet defined.

This PR fixes this bug by handling this `NameError`; it relies on the `name` attribute of this error, which is only available for Python 3.10+. So, the previous behaviour remains on Python 3.9 and earlier.



<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X        |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
