### PR TITLE
Improvements to python_ta.debug.snapshot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue in contract-checking `new_setattr` where an instance attribute was not always reset when reassigning it to an invalid value
 - Fixed issue in `AccumulationTable` where accumulation expressions could not refer to loop variables
 - Fixed issue in `snapshot` where some imported objects were being included in the output
+- Fixed issue in `snapshot` where aliases were being returned rather than object copies
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed issue in `autoformat` where the default `max-line-length` value was not used
 - Fixed issue in contract-checking `new_setattr` where an instance attribute was not always reset when reassigning it to an invalid value
 - Fixed issue in `AccumulationTable` where accumulation expressions could not refer to loop variables
+- Fixed issue in `snapshot` where some imported objects were being included in the output
 
 ### 🔧 Internal changes
 

--- a/python_ta/debug/snapshot.py
+++ b/python_ta/debug/snapshot.py
@@ -33,6 +33,7 @@ def get_filtered_global_variables(frame: FrameType) -> dict:
         and not inspect.ismodule(global_vars[var])
         and not inspect.isfunction(global_vars[var])
         and not inspect.isclass(global_vars[var])
+        and getattr(inspect.getmodule(global_vars[var]), "__name__", "__main__") == "__main__"
     }
     return {"__main__": true_global_vars}
 

--- a/tests/test_debug/snapshot_main_frame.py
+++ b/tests/test_debug/snapshot_main_frame.py
@@ -5,6 +5,10 @@ variables from the __main__ stack frame, particularly globally defined variables
 This module is intended exclusively for testing purposes and should not be used for any other purpose.
 """
 
+from __future__ import (
+    annotations,  # "annotations" should not be included in the snapshot
+)
+
 import json
 
 from python_ta.debug.snapshot import snapshot


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

This pull request fixes two issues related to the `python_ta.debug.snapsnot`'s `snapshot` function.

1. Some imported objects (including `from __future__ import annotations`) were not being filtered out in the `get_filtered_global_variables` helper, leading them to appear in the returned snapshot object. I've strengthened this filter by using `inspect.getmodule(obj)` to determine the source of an object. This isn't foolproof, however, as if it returns `None` then the object will be kept in the snapshot.
2. The values returned by `snapshot` were previously aliases of the objects in memory. This mean that if the user called `snapshot` and stored its return value, and then later mutated one of these objects, the returned snapshot object would also be mutated. This is confusing and not the intended behaviour of a "snapshot". I've modified the code to use `copy.deepcopy` to create a copy of the objects when `snapshot` is called. For objects where `copy.deepcopy` fails, a warning is emitted and an alias to the original object is used instead.

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X        |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the list of contributors.

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
