### PR TITLE
Relax Representation Invariant Checking Logic for Recursive Classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 🐛 Bug fixes
 
-- `check_contracts` no longer makes methods immediately enforces Representation Invariant checks when setting attributes of instances with the same type (one `Node` modifies another `Node` instance) and only checks RIs for these instances after the method returns.
+- `check_contracts` no longer makes methods immediately enforce Representation Invariant checks when setting attributes of instances with the same type (one `Node` modifies another `Node` instance) and only checks RIs for these instances after the method returns.
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 🐛 Bug fixes
 
+- `check_contracts` no longer makes methods immediately enforces Representation Invariant checks when setting attributes of instances with the same type (one `Node` modifies another `Node` instance) and only checks RIs for these instances after the method returns.
+
 ### 🔧 Internal changes
 
 ## [2.10.1] - 2025-02-19

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -445,9 +445,7 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
                 # across the function call.
                 mutated_instances = getattr(instance_klass, "__mutated_instances__", [])
                 for mutable_instance in mutated_instances:
-                    instances_klass = type(mutable_instance)
-                    instance_klass_module_dict = _get_module(instances_klass).__dict__
-                    _check_invariants(mutable_instance, instances_klass, instance_klass_module_dict)
+                    _check_invariants(mutable_instance, klass, klass_mod.__dict__)
         except PyTAContractError as e:
             raise AssertionError(str(e)) from None
         else:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -449,7 +449,11 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
                     # for the parent class and not the child class.
                     mutated_instance_klass = type(mutated_instance)
                     mutated_instance_klass_mod = _get_module(mutated_instance_klass)
-                    _check_invariants(mutated_instance, mutated_instance_klass, mutated_instance_klass_mod.__dict__)
+                    _check_invariants(
+                        mutated_instance,
+                        mutated_instance_klass,
+                        mutated_instance_klass_mod.__dict__,
+                    )
         except PyTAContractError as e:
             raise AssertionError(str(e)) from None
         else:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -445,7 +445,11 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
                 # across the function call.
                 mutated_instances = getattr(instance_klass, "__mutated_instances__", [])
                 for mutated_instance in mutated_instances:
-                    _check_invariants(mutated_instance, klass, klass_mod.__dict__)
+                    # Mutated instances may be of parent class types so the invariants to check should also be
+                    # for the parent class and not the child class.
+                    mutated_instance_klass = type(mutated_instance)
+                    mutated_instance_klass_mod = _get_module(mutated_instance_klass)
+                    _check_invariants(mutated_instance, mutated_instance_klass, mutated_instance_klass_mod.__dict__)
         except PyTAContractError as e:
             raise AssertionError(str(e)) from None
         else:

--- a/python_ta/contracts/__init__.py
+++ b/python_ta/contracts/__init__.py
@@ -227,8 +227,8 @@ def add_class_invariants(klass: type) -> None:
                     raise AssertionError(str(e)) from None
         else:
             caller_klass = type(caller_self)
-            if '__mutated_instances__' in caller_klass.__dict__:
-                mutable_instances = caller_klass.__dict__['__mutated_instances__']
+            if "__mutated_instances__" in caller_klass.__dict__:
+                mutable_instances = caller_klass.__dict__["__mutated_instances__"]
                 if self not in mutable_instances:
                     mutable_instances.append(self)
 
@@ -428,9 +428,9 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
         # executes another instance method.
         instance_klass = type(instance)
         mutated_instances_to_restore = []
-        if hasattr(instance_klass, '__mutated_instances__'):
-            mutated_instances_to_restore = getattr(instance_klass, '__mutated_instances__')
-        setattr(instance_klass, '__mutated_instances__', [])
+        if hasattr(instance_klass, "__mutated_instances__"):
+            mutated_instances_to_restore = getattr(instance_klass, "__mutated_instances__")
+        setattr(instance_klass, "__mutated_instances__", [])
 
         try:
             r = _check_function_contracts(wrapped, instance, args, kwargs)
@@ -443,7 +443,7 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
 
                 # Additionally check RI violations on PyTA-decorated instances that were mutated
                 # across the function call.
-                mutated_instances = getattr(instance_klass, '__mutated_instances__', [])
+                mutated_instances = getattr(instance_klass, "__mutated_instances__", [])
                 for mutable_instance in mutated_instances:
                     instances_klass = type(mutable_instance)
                     instance_klass_module_dict = _get_module(instances_klass).__dict__
@@ -453,7 +453,7 @@ def _instance_method_wrapper(wrapped: Callable, klass: type) -> Callable:
         else:
             return r
         finally:
-            setattr(instance_klass, '__mutated_instances__', mutated_instances_to_restore)
+            setattr(instance_klass, "__mutated_instances__", mutated_instances_to_restore)
 
     return wrapper(wrapped)
 

--- a/tests/test_contracts/test_class_contracts.py
+++ b/tests/test_contracts/test_class_contracts.py
@@ -209,6 +209,7 @@ def test_change_name_of_parent_invalid_in_method(person, child) -> None:
     Call a method that changes name of an instance of a parent class to something invalid but
     back to something valid.
     Expects normal behavior.
+    This will also check that the child type's RIs are not being enforced on the mutated parent instance.
     """
     child.change_someones_name(person, "Davi")
     assert person.name == "Davi"

--- a/tests/test_contracts/test_class_contracts.py
+++ b/tests/test_contracts/test_class_contracts.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import List, Set, Tuple
+from typing import List, Optional, Set, Tuple
 
 import pytest
 from nested_preconditions_example import Student
@@ -28,9 +28,9 @@ class Person:
     age: int
     name: str
     fav_foods: List[str]
-    _other: Person | None
+    _other: Optional[Person]
 
-    def __init__(self, name, age, fav_food, other: Person | None = None):
+    def __init__(self, name, age, fav_food, other: Optional[Person] = None):
         self.name = name
         self.age = age
         self.fav_foods = fav_food


### PR DESCRIPTION
## Motivation & Proposal

The Representation Invariant checker timing is currently too strict. In many data structures, it's common for instances to mutate other instances of the same type (i.e. graphs/trees or recursive data structures). The current logic enforces RI checks in two places: 1) when an attribute is set EXCEPT for instance methods 2) after the instance method is called. The problem is that Path 1 is executed inside instance methods that set the attributes of different instances of the same type (motivating example below).

The proposed change is to additionally exempt instances of the same type as `self` during the Path 1 check and push checking these RIs until after the instance method has returned, alongside the Path 2 check.

<details>
<summary>More practical motivating example with RecursiveList</summary>

Note: this specific example can technically be avoided by having a better constructor for RecursiveList but the bug still stands regardless.

```python
from __future__ import annotations
from typing import Any
from python_ta.contracts import check_contracts


@check_contracts
class RecursiveList:
    """
    Representation Invariants:
    - (self._value is None and self._rest is None) or \
        (self._value is not None and self._rest is not None)
    """
    _value: Any | None
    _rest: RecursiveList | None

    def __init__(self, items: list) -> None:
        if items == []:
            self._value = None
            self._rest = None
        else:
            self._value = items[0]
            self._rest = RecursiveList(items[1:])

    def insert(self, value: Any):
        """Insert value at the current position (push current value to next position)"""
        new_rest = RecursiveList([])
        # new_rest._value and ._rest are originally None by this construction logic.
        new_rest._value = self._value  # RI violation occurs here despite RI being satisfied in the next line.
        new_rest._rest = self._rest
        self._value = value
        self._rest = new_rest


if __name__ == '__main__':
    node_a = RecursiveList([10, 20, 30])
    node_a.insert(5)

```

</details>

## Changes

* Modified the Path 1 check to also exempt RI checking if the type of the parent frame's `self` matches the type of `self`
* Accumulated all of the instances that were exempt in the Path 1 check to later check at Path 2
* Modified the Path 2 logic to also check RIs of the accumulated instance attributes

* Added unit tests to `test_class_contracts` for both the attribute mutation and function arg mutation cases.

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |     |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |        X |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] ~~I have updated the project documentation, if applicable.~~
  - This is **required** for new features.
- [X] I have updated the project Changelog (this is required for all changes).
- [x] ~~If this is my first contribution, I have added myself to the list of contributors.~~

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

I made a minor logical nuance where subclasses should be able to temporarily violate parent class instances' Representation Invariants in its instance methods (`Child.modify(parent)`). If you think that Child instances should not be allowed to temporarily violate Parent RIs and this check should be strictly equal class types (only Child==Child and Parent == Parent but no Child modifies Parent), let me know! It would effectively just be changing `not isinstance(caller_self, type(self))` to `not type(caller_self) == type(self)`
