### PR TITLE
Refactor tests in test_check.py to use pytest.mark.parametrize for better test isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added test case for `check_all` function ensuring proper behaviour when handling inputs in package notation.
 - Improved `get_valid_files_to_check` function by removing unreachable code.
+- Refactored `test_check.py` to use pytest.mark.parametrize, improving test isolation and significantly reducing overall test execution time.
 
 ## [2.10.1] - 2025-02-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added test case for `check_all` function ensuring proper behaviour when handling inputs in package notation.
 - Improved `get_valid_files_to_check` function by removing unreachable code.
-- Refactored `test_check.py` to use pytest.mark.parametrize, improving test isolation and significantly reducing overall test execution time.
+- Refactored `test_check.py` to use pytest.mark.parametrize, improving test isolation and code quality
 
 ## [2.10.1] - 2025-02-19
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -23,6 +23,7 @@ _TEST_FILE_INPUTS = [
     ["examples/nodes/dict.py", "examples/nodes/const.py"],
     ["examples.sample_usage.draw_cfg"],
     ["examples.sample_usage", "examples/nodes/const.py"],
+    ["examples/nodes/const.py"],
     222,
     [
         222,

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -38,6 +38,7 @@ _TEST_FILE_INPUTS = [
         "examples/nodes/while.py",
         "examples/nodes/continue.py",
         "example/nodes/if.py",
+        "example/nodes/deleted.py",
     ],
     222,
     [

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -18,20 +18,35 @@ import pytest
 
 import python_ta
 
+# _TEST_FILE_INPUTS = [
+#     ["examples/nodes/name.py"],
+#     ["examples/nodes/dict.py", "examples/nodes/const.py"],
+#     ["examples.sample_usage.draw_cfg"],
+#     ["examples.sample_usage", "examples/nodes/const.py"],
+#     ["examples/nodes"],
+#     222,
+#     [
+#         222,
+#         "examples/inline_config_comment.py",
+#         "examples/nodes/dict.py",
+#         "file_does_not_exist",
+#         "module_dne.file_dne",
+#     ],
+# ]
 _TEST_FILE_INPUTS = [
     ["examples/nodes/name.py"],
     ["examples/nodes/dict.py", "examples/nodes/const.py"],
     ["examples.sample_usage.draw_cfg"],
     ["examples.sample_usage", "examples/nodes/const.py"],
-    ["examples/nodes"],
+    [222],
     222,
-    [
-        222,
-        "examples/inline_config_comment.py",
-        "examples/nodes/dict.py",
-        "file_does_not_exist",
-        "module_dne.file_dne",
-    ],
+    ["examples/nodes/dict.py examples/nodes/const.py"],
+    [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
+    ["file_does_not_exist"],
+    ["module_dne.file_dne"],
+    ["examples/nodes/const.py"],
+    ["examples/nodes"],
+    ["examples/nodes/name.py"],
 ]
 
 _DEFAULT_CONFIG = {

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -12,10 +12,138 @@ import time
 from os import path, remove
 from pathlib import Path
 from subprocess import Popen
+from typing import Union
 
 import pytest
 
 import python_ta
+
+_TEST_FILE_INPUTS = [
+    ["examples/nodes/name.py"],
+    ["examples/nodes/dict.py", "examples/nodes/const.py"],
+    ["examples.sample_usage.draw_cfg"],
+    ["examples.sample_usage", "examples/nodes/const.py"],
+    [222],
+    222,
+    ["examples/nodes/dict.py examples/nodes/const.py"],
+    [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
+    ["file_does_not_exist"],
+    ["module_dne.file_dne"],
+    ["examples/nodes/const.py"],
+    ["examples/nodes"],
+    ["examples/nodes/name.py"],
+]
+
+_DEFAULT_CONFIG = {
+    "output-format": "pyta-plain",
+    "pyta-error-permission": "no",
+    "pyta-file-permission": "no",
+}
+
+_SPECIAL_CONFIG = {
+    # [ELIF]
+    "max-nested-blocks": 4,
+    # [FORMAT]
+    "max-line-length": 80,
+    # [FORBIDDEN IMPORT]
+    "allowed-import-modules": ["doctest", "unittest", "hypothesis", "python_ta"],
+    # [FORBIDDEN IO]
+    "allowed-io": [],
+    # [MESSAGES CONTROL]
+    "disable": [
+        "R0401",
+        "R0901",
+        "R0903",
+        "R0904",
+        "R0911",
+        "R0916",
+        "W0402",
+        "W0403",
+        "W0410",
+        "W1501",
+        "W1502",
+        "W1505",
+        "E1300",
+        "E1301",
+        "E1302",
+        "E1304",
+        "W1300",
+        "W1301",
+        "W1302",
+        "W1304",
+        "E1124",
+        "E1125",
+        "E1129",
+        "E1132",
+        "W1402",
+        "W0105",
+        "E1303",
+        "W1306",
+        "W1307",
+        "E0116",
+        "E0114",
+        "E0112",
+        "E0115",
+        "E0106",
+        "E0113",
+        "E0111",
+        "E0105",
+        "E0100",
+        "E0117",
+        "W0150",
+        "W0120",
+        "W0124",
+        "W0108",
+        "W0123",
+        "W0122",
+        "W0110",
+        "C0122",
+        "C0200",
+        "W0141",
+        "W0640",
+        "W0623",
+        "W0614",
+        "W0604",
+        "W0603",
+        "W0602",
+        "W0601",
+        "E0604",
+        "E0603",
+        "E1200",
+        "E1201",
+        "E1202",
+        "W1201",
+        "E1205",
+        "E1206",
+        "similarities",
+        "newstyle",
+        "python3",
+        "W0512",
+        "C0403",
+        "C0401",
+        "C0402",
+        "E1701",
+        "E1700",
+        "W0332",
+        "C0327",
+        "C0328",
+        "E0202",
+        "E0241",
+        "E0704",
+        "W0211",
+        "W0232",
+        "W0511",
+        "R0204",
+        "C0303",
+        "W0231",
+    ],
+    # [CUSTOM PYTA OPTIONS]
+    "output-format": "pyta-plain",
+    "pyta-error-permission": "no",
+    "pyta-file-permission": "no",
+}
+
+_CONFIG = [_DEFAULT_CONFIG, _SPECIAL_CONFIG]
 
 
 def test_check_on_dir():
@@ -47,36 +175,15 @@ def test_check_on_dir():
     assert not sample_files, f"the following files not checked by python_ta: {sample_files}"
 
 
-def test_check_on_file():
-    """Test files"""
-    _inputs = [["examples/nodes/name.py"], ["examples/nodes/dict.py", "examples/nodes/const.py"]]
-    for item in _inputs:
-        python_ta.check_all(
-            item,
-            config={
-                "output-format": "pyta-plain",
-                "pyta-error-permission": "no",
-                "pyta-file-permission": "no",
-            },
-        )
-
-
-def test_check_on_package():
-    """Test inputs written in package notation."""
-    _inputs = [
-        ["examples.sample_usage.draw_cfg"],
-        ["examples.sample_usage", "examples/nodes/const.py"],
-    ]
-    for item in _inputs:
-        python_ta.check_all(
-            item,
-            output="pyta_output.html",
-            config={
-                "output-format": "pyta-plain",
-                "pyta-error-permission": "no",
-                "pyta-file-permission": "no",
-            },
-        )
+# Cartesian Product between both lists.
+@pytest.mark.parametrize("input_files", _TEST_FILE_INPUTS)
+@pytest.mark.parametrize("config", _CONFIG)
+def test_check_behaviour(input_files: Union[str, list[str]], config: dict) -> None:
+    python_ta.check_all(
+        input_files,
+        output="pyta_output.html",
+        config=config,
+    )
     file_exists = path.exists("pyta_output.html")
 
     assert file_exists
@@ -86,160 +193,16 @@ def test_check_on_package():
         remove("pyta_output.html")
 
 
-def test_check_on_bad_input():
-    """Test bad inputs. In all cases, pyta should recover.
-    Any valid files, if any, should be checked.
-    """
-    _inputs = [
-        [222],
-        222,
-        ["examples/nodes/dict.py examples/nodes/const.py"],
-        [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
-        ["file_does_not_exist"],
-        ["module_dne.file_dne"],
-    ]
-    for item in _inputs:
-        python_ta.check_all(
-            item,
-            config={
-                "output-format": "pyta-plain",
-                "pyta-error-permission": "no",
-                "pyta-file-permission": "no",
-            },
-        )
+@pytest.mark.parametrize("input_files", _TEST_FILE_INPUTS)
+def test_check_no_reporter_output(
+    prevent_webbrowser_and_httpserver, input_files: Union[str, list[str]]
+) -> None:
+    """Test whether not specifying an output does not save a file.
 
+    An [INFO] message may still be printed because PythonTA logs this by default when no output argument is provided.
+    Even though no file is created and the browser does not actually open."""
 
-def test_check_with_config():
-    """Test inputs along with a config arg."""
-    _inputs = [["examples/nodes/const.py"], ["examples/nodes"]]
-    CONFIG = {
-        # [ELIF]
-        "max-nested-blocks": 4,
-        # [FORMAT]
-        "max-line-length": 80,
-        # [FORBIDDEN IMPORT]
-        "allowed-import-modules": ["doctest", "unittest", "hypothesis", "python_ta"],
-        # [FORBIDDEN IO]
-        "allowed-io": [],
-        # [MESSAGES CONTROL]
-        "disable": [
-            "R0401",
-            "R0901",
-            "R0903",
-            "R0904",
-            "R0911",
-            "R0916",
-            "W0402",
-            "W0403",
-            "W0410",
-            "W1501",
-            "W1502",
-            "W1505",
-            "E1300",
-            "E1301",
-            "E1302",
-            "E1304",
-            "W1300",
-            "W1301",
-            "W1302",
-            "W1304",
-            "E1124",
-            "E1125",
-            "E1129",
-            "E1132",
-            "W1402",
-            "W0105",
-            "E1303",
-            "W1306",
-            "W1307",
-            "E0116",
-            "E0114",
-            "E0112",
-            "E0115",
-            "E0106",
-            "E0113",
-            "E0111",
-            "E0105",
-            "E0100",
-            "E0117",
-            "W0150",
-            "W0120",
-            "W0124",
-            "W0108",
-            "W0123",
-            "W0122",
-            "W0110",
-            "C0122",
-            "C0200",
-            "W0141",
-            "W0640",
-            "W0623",
-            "W0614",
-            "W0604",
-            "W0603",
-            "W0602",
-            "W0601",
-            "E0604",
-            "E0603",
-            "E1200",
-            "E1201",
-            "E1202",
-            "W1201",
-            "E1205",
-            "E1206",
-            "similarities",
-            "newstyle",
-            "python3",
-            "W0512",
-            "C0403",
-            "C0401",
-            "C0402",
-            "E1701",
-            "E1700",
-            "W0332",
-            "C0327",
-            "C0328",
-            "E0202",
-            "E0241",
-            "E0704",
-            "W0211",
-            "W0232",
-            "W0511",
-            "R0204",
-            "C0303",
-            "W0231",
-        ],
-        # [CUSTOM PYTA OPTIONS]
-        "output-format": "pyta-plain",
-        "pyta-error-permission": "no",
-        "pyta-file-permission": "no",
-    }
-    for item in _inputs:
-        python_ta.check_all(item, config=CONFIG)
-
-
-def test_check_saves_file() -> None:
-    """Test whether or not specifiying an output properly saves a file"""
-    _inputs = [["examples/nodes/name.py"]]
-    for item in _inputs:
-        # Note that the reporter output will be created in the main directory
-        python_ta.check_all(item, output="pyta_output.html")
-
-    file_exists = path.exists("pyta_output.html")
-
-    assert file_exists
-
-    # If the file exists, the assertion passes and the file gets removed from the main directory
-    if file_exists:
-        remove("pyta_output.html")
-
-
-def test_check_no_reporter_output(prevent_webbrowser_and_httpserver) -> None:
-    """Test whether not specifiying an output does not save a file"""
-    _inputs = [["examples/nodes/name.py"]]
-    for item in _inputs:
-        # Note that the reporter output *would have been* created in the main directory
-        python_ta.check_all(item)
+    python_ta.check_all(input_files)
 
     file_exists = path.exists("pyta_output.html")
 

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -23,15 +23,14 @@ _TEST_FILE_INPUTS = [
     ["examples/nodes/dict.py", "examples/nodes/const.py"],
     ["examples.sample_usage.draw_cfg"],
     ["examples.sample_usage", "examples/nodes/const.py"],
-    [222],
     222,
-    ["examples/nodes/dict.py examples/nodes/const.py"],
-    [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
-    ["file_does_not_exist"],
-    ["module_dne.file_dne"],
-    ["examples/nodes/const.py"],
-    ["examples/nodes"],
-    ["examples/nodes/name.py"],
+    [
+        222,
+        "examples/inline_config_comment.py",
+        "examples/nodes/dict.py",
+        "file_does_not_exist",
+        "module_dne.file_dne",
+    ],
 ]
 
 _DEFAULT_CONFIG = {
@@ -175,15 +174,20 @@ def test_check_on_dir():
     assert not sample_files, f"the following files not checked by python_ta: {sample_files}"
 
 
-# Cartesian Product between both lists.
 @pytest.mark.parametrize("input_files", _TEST_FILE_INPUTS)
 @pytest.mark.parametrize("config", _CONFIG)
-def test_check_behaviour(input_files: Union[str, list[str]], config: dict) -> None:
-    python_ta.check_all(
-        input_files,
-        output="pyta_output.html",
-        config=config,
-    )
+def test_check_behaviour(input_files: Union[str, list[str]], config) -> None:
+    """Test whether check_all behaves correctly for a variety of valid and invalid inputs."""
+    python_ta.check_all(input_files, config)
+
+
+@pytest.mark.parametrize("input_files", _TEST_FILE_INPUTS)
+def test_check_saves_file(input_files: Union[str, list[str]]) -> None:
+    """Test whether or not specifiying an output properly saves a file"""
+
+    # Note that the reporter output will be created in the main directory
+    python_ta.check_all(input_files, output="pyta_output.html")
+
     file_exists = path.exists("pyta_output.html")
 
     assert file_exists
@@ -197,7 +201,7 @@ def test_check_behaviour(input_files: Union[str, list[str]], config: dict) -> No
 def test_check_no_reporter_output(
     prevent_webbrowser_and_httpserver, input_files: Union[str, list[str]]
 ) -> None:
-    """Test whether not specifying an output does not save a file.
+    """Test whether not specifying an output does not save a file
 
     An [INFO] message may still be printed because PythonTA logs this by default when no output argument is provided.
     Even though no file is created and the browser does not actually open."""

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -23,7 +23,7 @@ _TEST_FILE_INPUTS = [
     ["examples/nodes/dict.py", "examples/nodes/const.py"],
     ["examples.sample_usage.draw_cfg"],
     ["examples.sample_usage", "examples/nodes/const.py"],
-    ["examples/nodes/const.py"],
+    ["examples/nodes"],
     222,
     [
         222,

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -18,36 +18,50 @@ import pytest
 
 import python_ta
 
+_TEST_FILE_INPUTS = [
+    [
+        "examples/nodes/name.py",
+    ],
+    [
+        "examples/nodes/dict.py",
+        "examples/nodes/const.py",
+    ],
+    [
+        "examples.sample_usage.draw_cfg",
+    ],
+    [
+        "examples.sample_usage",
+        "examples/nodes/const.py",
+    ],
+    [
+        "examples/nodes/for.py",
+        "examples/nodes/while.py",
+        "examples/nodes/continue.py",
+    ],
+    222,
+    [
+        222,
+        "examples/inline_config_comment.py",
+        "examples/nodes/dict.py",
+        "file_does_not_exist",
+        "module_dne.file_dne",
+    ],
+]
 # _TEST_FILE_INPUTS = [
 #     ["examples/nodes/name.py"],
 #     ["examples/nodes/dict.py", "examples/nodes/const.py"],
 #     ["examples.sample_usage.draw_cfg"],
 #     ["examples.sample_usage", "examples/nodes/const.py"],
-#     ["examples/nodes"],
+#     [222],
 #     222,
-#     [
-#         222,
-#         "examples/inline_config_comment.py",
-#         "examples/nodes/dict.py",
-#         "file_does_not_exist",
-#         "module_dne.file_dne",
-#     ],
+#     ["examples/nodes/dict.py examples/nodes/const.py"],
+#     [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
+#     ["file_does_not_exist"],
+#     ["module_dne.file_dne"],
+#     ["examples/nodes/const.py"],
+#     ["examples/nodes"],
+#     ["examples/nodes/name.py"],
 # ]
-_TEST_FILE_INPUTS = [
-    ["examples/nodes/name.py"],
-    ["examples/nodes/dict.py", "examples/nodes/const.py"],
-    ["examples.sample_usage.draw_cfg"],
-    ["examples.sample_usage", "examples/nodes/const.py"],
-    [222],
-    222,
-    ["examples/nodes/dict.py examples/nodes/const.py"],
-    [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
-    ["file_does_not_exist"],
-    ["module_dne.file_dne"],
-    ["examples/nodes/const.py"],
-    ["examples/nodes"],
-    ["examples/nodes/name.py"],
-]
 
 _DEFAULT_CONFIG = {
     "output-format": "pyta-plain",

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -37,6 +37,7 @@ _TEST_FILE_INPUTS = [
         "examples/nodes/for.py",
         "examples/nodes/while.py",
         "examples/nodes/continue.py",
+        "example/nodes/if.py",
     ],
     222,
     [

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -33,13 +33,6 @@ _TEST_FILE_INPUTS = [
         "examples.sample_usage",
         "examples/nodes/const.py",
     ],
-    [
-        "examples/nodes/for.py",
-        "examples/nodes/while.py",
-        "examples/nodes/continue.py",
-        "example/nodes/if.py",
-        "example/nodes/deleted.py",
-    ],
     222,
     [
         222,
@@ -49,21 +42,6 @@ _TEST_FILE_INPUTS = [
         "module_dne.file_dne",
     ],
 ]
-# _TEST_FILE_INPUTS = [
-#     ["examples/nodes/name.py"],
-#     ["examples/nodes/dict.py", "examples/nodes/const.py"],
-#     ["examples.sample_usage.draw_cfg"],
-#     ["examples.sample_usage", "examples/nodes/const.py"],
-#     [222],
-#     222,
-#     ["examples/nodes/dict.py examples/nodes/const.py"],
-#     [222, "examples/inline_config_comment.py", "examples/nodes/dict.py"],
-#     ["file_does_not_exist"],
-#     ["module_dne.file_dne"],
-#     ["examples/nodes/const.py"],
-#     ["examples/nodes"],
-#     ["examples/nodes/name.py"],
-# ]
 
 _DEFAULT_CONFIG = {
     "output-format": "pyta-plain",
@@ -206,7 +184,13 @@ def test_check_on_dir():
     assert not sample_files, f"the following files not checked by python_ta: {sample_files}"
 
 
-@pytest.mark.parametrize("input_files", _TEST_FILE_INPUTS)
+@pytest.mark.parametrize(
+    "input_files",
+    _TEST_FILE_INPUTS
+    + [
+        "examples/nodes",
+    ],
+)
 @pytest.mark.parametrize("config", _CONFIG)
 def test_check_behaviour(input_files: Union[str, list[str]], config) -> None:
     """Test whether check_all behaves correctly for a variety of valid and invalid inputs."""


### PR DESCRIPTION
## Proposed Changes

Made 2 **key changes**:
1) Added `pytest.mark.parameterize` annotation to pull the inputs out of similar unit test function
2) Optimized the test input list

As explained above, I used the `pytest.mark.parameterize` annotation. This in turn meant that I could delete 3 unit tests, and had to modify 2 others. For the main test function `test_check_behaviour()`, I used the cartesian product feature to test all inputs on both a default config, and a special config.

However, this turned out to be highly inefficient; it took Pytest around 1min50s to run `test_check.py` on my computer. After further digging, I realized that the reasons behind this were:
1) There were a lot of redundant test inputs
2) The cartesian product coupled with these inefficient inputs resulted in around 80 tests being ran

With that in mind, for the second key change, I simply optimized the test inputs by:
- Removing redundant input files
- Removing directories (There was an excess of directories which increases the runtime by a lot)

This resulted in Pytest taking around 50s to run `test_check.py` on my computer. For reference, the master branch takes around 45s to run on my computer. This was the best I could do, since any further change affected the coverage.

**Final thoughts**:
- Using `pytest.mark.parameterize` definitely makes the file more clean, and removes redundant code. However even after optimization, Pytest takes longer (albeit around 5 more seconds) to run `test_check.py`.

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |     X     |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - Not applicable
- [x] I have updated the project documentation, if applicable.
  - Not applicable
- [x] I have updated the project Changelog (this is required for all changes).
- [x] ~~If this is my first contribution, I have added myself to the list of contributors.~~

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

### 1)
I believe that the optimization was directly related to the refactoring I was doing. I may be mistaken though...
Should I have created a new PR for this issue?

### 2)
Also, this piece of code (although ugly) saves around 30s when running the test file:

```
@pytest.mark.parametrize( "input_files", _TEST_FILE_INPUTS + ["examples/nodes",])
```
Is this problematic? Should I make a separate variable for `_TEST_FILE_INPUTS + ["examples/nodes",]`?

### 3)

I tried isolating different files from `examples/nodes` but no matter what I did, there was always a coverage problem.

### 4)
Finally, as usual, any tips/criticism is highly appreciated and welcome. I'm always looking to improve!
