### PR TITLE
Improve Loop Variable Extraction for Nested Structures in the Accumulation Table Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `check_contracts` no longer makes methods immediately enforce Representation Invariant checks when setting attributes of instances with the same type (one `Node` modifies another `Node` instance) and only checks RIs for these instances after the method returns.
 - Fixed error in `contracts` where comments in docstring assertions are not removed while parsing
 - Improved error message in `patches/transforms.py` where CFGVisitor is run
+- Fixed a bug in AccumulationTable where loop variable names weren't being captured for all nested targets.
 
 ### 📚 Documentation Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Removed unused imports from `python_ta` module
 - Wrapped type-only imports in if `TYPE_CHECKING` guards
 - Refactored `render_pep8_errors` to use a dict that maps error codes to error functions instead of repeated conditional statements
+- Added two test cases to `test_accumulation_table.py` to verify that `AccumulationTable` correctly extracts loop variables from nested tuple structures.
 
 ## [2.10.1] - 2025-02-19
 

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -175,15 +175,11 @@ class AccumulationTable:
 
         self._loop_lineno = inspect.getlineno(func_frame) + node.lineno
 
-        # Case 1: nested structure found in node.target (e.g. for a, (b, c) in ...)
-        if isinstance(node, astroid.For) and isinstance(node.target, astroid.Tuple):
+        if isinstance(node, astroid.For):
             self.loop_variables = {
                 nested_node.name: []
                 for nested_node in node.target.nodes_of_class(astroid.AssignName)
             }
-        # Case 2: single loop variable found in node.target (e.g. for x in ...)
-        elif isinstance(node, astroid.For):
-            self.loop_variables = {node.target.name: []}
 
         assert (
             self.loop_accumulators != {} or self.loop_variables != {}

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -161,25 +161,6 @@ class AccumulationTable:
         if event == "line" and frame.f_lineno == self._loop_lineno:
             self._record_iteration(frame)
 
-    def extract_loop_variables(self, target: Any) -> dict:
-        # if isinstance(target, astroid.Name):
-        #     return {target.name: []}
-        # elif isinstance(target, (astroid.Tuple, astroid.List)):
-        #     loop_variables = {}
-        #     for element in target.elts:
-        #         loop_variables.update(self.extract_loop_variables(element))
-        #     return loop_variables
-        # else:
-        #     # loop variable just either be a Name node, or a tuple
-        #     # if this branch returns, _setup_table will catch the error
-        #     print(f"[WARNING] Unexpected loop target node: {target!r}")
-        #     return {}
-        print(
-            "[DEBUG] loop variable names:",
-            [node.AssignName for node in target.nodes_of_class(astroid.AssignName)],
-        )
-        return
-
     def _setup_table(self) -> None:
         """
         Get the frame of the code containing the with statement, cut down the source code

--- a/tests/test_debug/test_accumulation_table.py
+++ b/tests/test_debug/test_accumulation_table.py
@@ -153,6 +153,40 @@ def test_five_nested_while_loop() -> None:
     }
 
 
+def test_accumulation_table_nested_tuple():
+    data = [
+        ("a", ([1, 2], 3)),
+        ("b", ([4, 5], 6)),
+        ("c", ([7, 8], 9)),
+    ]
+
+    with AccumulationTable(["data"]) as table:
+        for letter, (lst, num) in data:
+            lst[0] *= 2
+
+    assert table.loop_variables == {
+        "letter": ["N/A", "a", "b", "c"],
+        "lst": ["N/A", [2, 2], [8, 5], [14, 8]],
+        "num": ["N/A", 3, 6, 9],
+    }
+
+
+def test_accumulation_table_deeply_nested_tuple():
+    data = [
+        ("x", ([1], (2, 3))),
+        ("y", ([4], (5, 6))),
+    ]
+
+    with AccumulationTable(["data"]) as table:
+        for a, (b, (c, d)) in data:
+            b[0] += 1
+
+    assert table.loop_variables["a"] == ["N/A", "x", "y"]
+    assert table.loop_variables["b"] == ["N/A", [2], [5]]
+    assert table.loop_variables["c"] == ["N/A", 2, 5]
+    assert table.loop_variables["d"] == ["N/A", 3, 6]
+
+
 def test_accumulation_table_list_deepcopy():
     data = [[1], [2], [3]]
     with AccumulationTable(["data"]) as table:


### PR DESCRIPTION
## Proposed Changes

Fixes a bug in the `AccumulationTable` class where loop variable names weren't being captured for nested targets.
Now supports both single variables and nested unpacking like `for a, (b, c) in ....`
I used the `astroid.nodes_of_class` method and added logic to handle both flat and nested loop targets.
...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |    x      |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
