### PR TITLE
Added output format parameter to AccumulationTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update how error messages are overridden such that section headers are no longer required within the config file
 - Added `presistent_server` which recives the watch property changes through websockets and updates the HTML report
 - Added optional `on_verify_fail` argument to `check_all` and `check_error`, allowing users to raise a `ValueError` and immediately stop execution when a file cannot be checked.
+- Added optional `format` and `output` arguments to the `AccumulationTable` class, allowing users to select between csv or table formatted outputs, and whether the output is written to the console or a file.
 
 ### 💫 New checkers
 
@@ -31,6 +32,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### 📚 Documentation Updates
 
 - Linked the contributions list (README.md) in the pull request template
+- Updated documentation to reflect the new output and format parameters in the `AccumulationTable` class.
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update `check_all` and `check_error` functions to let users pass in `typing.IO` objects to the `output` argument
 - Update the `forbidden-io-function-checker` to check functions from imported modules as well as methods (according to their qualified name)
 - Update the `forbidden-io-function-checker` to flag aliases of forbidden functions
-- Update how error messages are overridden such that section headers are no longer required within the config file
+- Update how error messages are /voverridden such that section headers are no longer required within the config file
 - Added `presistent_server` which recives the watch property changes through websockets and updates the HTML report
 - Added optional `on_verify_fail` argument to `check_all` and `check_error`, allowing users to raise a `ValueError` and immediately stop execution when a file cannot be checked.
 - Added optional `format` and `output` arguments to the `AccumulationTable` class, allowing users to select between csv or table formatted outputs, and whether the output is written to the console or a file.
@@ -32,7 +32,6 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### 📚 Documentation Updates
 
 - Linked the contributions list (README.md) in the pull request template
-- Updated documentation to reflect the new output and format parameters in the `AccumulationTable` class.
 
 ### 🔧 Internal changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,10 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update `check_all` and `check_error` functions to let users pass in `typing.IO` objects to the `output` argument
 - Update the `forbidden-io-function-checker` to check functions from imported modules as well as methods (according to their qualified name)
 - Update the `forbidden-io-function-checker` to flag aliases of forbidden functions
-- Update how error messages are /voverridden such that section headers are no longer required within the config file
+- Update how error messages are overridden such that section headers are no longer required within the config file
 - Added `presistent_server` which recives the watch property changes through websockets and updates the HTML report
 - Added optional `on_verify_fail` argument to `check_all` and `check_error`, allowing users to raise a `ValueError` and immediately stop execution when a file cannot be checked.
-- Added optional `format` and `output` arguments to the `AccumulationTable` class, allowing users to select between csv or table formatted outputs, and whether the output is written to the console or a file.
+- Added the optional `format` argument to the `AccumulationTable` class, allowing users to select between csv or table formatted outputs.
 
 ### 💫 New checkers
 

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -136,7 +136,7 @@ def calculate_sum_and_averages(numbers: list) -> list:
 
 You also have the option to pass in a file path as an attribute to the AccumulationTable object. In this case, the table will be appended to the file instead of being written the console.
 
-Finally, you can also specify the output as a third attribute using the format argument. By default, the format is "table", which produces the same nicely formatted tabular output shown above. If you want to write the output as a .csv file, pass "csv" as the format.
+Finally, you can also specify the output format as a third attribute using the `format` argument. By default, the format is "table", which produces the same nicely formatted tabular output shown above. If you want to write the output as a .csv file, pass "csv" as the format.
 
 For example, the following code writes a csv formattted output to `output.txt`.
 

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -160,8 +160,6 @@ def calculate_sum_and_averages(numbers: list) -> list:
     return list_so_far
 ```
 
-The file is opened in append mode, so if a file already exists, the new table will be added at the end. If the file does not currently exist, then a new file will be created.
-
 ## Current limitations
 
 The `AccumulationTable` is a new PythonTA feature and currently has the following known limitations:

--- a/docs/debug/index.md
+++ b/docs/debug/index.md
@@ -135,7 +135,10 @@ def calculate_sum_and_averages(numbers: list) -> list:
 ```
 
 You also have the option to pass in a file path as an attribute to the AccumulationTable object. In this case, the table will be appended to the file instead of being written the console.
-For example:
+
+Finally, you can also specify the output as a third attribute using the format argument. By default, the format is "table", which produces the same nicely formatted tabular output shown above. If you want to write the output as a .csv file, pass "csv" as the format.
+
+For example, the following code writes a csv formattted output to `output.txt`.
 
 ```python
 from python_ta.debug import AccumulationTable
@@ -148,7 +151,7 @@ def calculate_sum_and_averages(numbers: list) -> list:
     list_so_far = []
     avg_so_far = None
     output_file = 'output.txt'
-    with AccumulationTable(["sum_so_far", "avg_so_far", "list_so_far"], output_file) as table:
+    with AccumulationTable(["sum_so_far", "avg_so_far", "list_so_far"], output=output_file, format='csv') as table:
         for number in numbers:
             sum_so_far = sum_so_far + number
             avg_so_far = sum_so_far / (len(list_so_far) + 1)
@@ -156,6 +159,8 @@ def calculate_sum_and_averages(numbers: list) -> list:
 
     return list_so_far
 ```
+
+The file is opened in append mode, so if a file already exists, the new table will be added at the end. If the file does not currently exist, then a new file will be created.
 
 ## Current limitations
 

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -164,13 +164,6 @@ class AccumulationTable:
                 except OSError as e:
                     print(f"Error writing table formatted data to file: {e}")
         else:
-
-            # builds a list of dicts for each row of data in iteration_dict, required for the csv formatting library
-            # [
-            #   {"iteration": 0, "x": 5, "total": 5},
-            #   {"iteration": 1, "x": 6, "total": 11},
-            #   {"iteration": 2, "x": 7, "total": 18}
-            # ]
             csv_preformat = [
                 dict(zip(iteration_dict.keys(), row)) for row in zip(*iteration_dict.values())
             ]

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -113,7 +113,7 @@ class AccumulationTable:
             elif accumulator in frame.f_code.co_varnames or accumulator in frame.f_code.co_names:
                 value = NO_VALUE
             else:
-                # name error will be raised if accumulator cannot be found
+                # name error wil be raised if accumulator cannot be found
                 try:
                     value = eval(accumulator, frame.f_globals, frame.f_locals)
                 except NameError as e:

--- a/python_ta/debug/accumulation_table.py
+++ b/python_ta/debug/accumulation_table.py
@@ -152,7 +152,7 @@ class AccumulationTable:
             try:
                 file_io = open(self.output_filepath, "a", newline="")
             except OSError as e:
-                print(f"Error opening file: {e}")
+                print(f"Error opening output file: {e}")
                 return
 
         try:


### PR DESCRIPTION
## Proposed Changes

In this PR, I've added a third optional parameter to the AccumulationTable class, allowing users to specify the output format as either `"table"` or `"csv"`. Currently, the class already supported writing output to files, but only in the default 'table' format.

By integrating file output with the 'csv' format, this change makes it easier to log results in a standardized format that’s easy to parse.

Finally, I added 2 new tests to verify this functionality. I also updated the documentation accordingly.

### AccumulationTable Output Options

| `output`          | `format`  | Behavior                                                                                         |
|-------------------|-----------|--------------------------------------------------------------------------------------------------|
| `None`            | `'table'` | Prints a formatted table to the console using the `tabulate` library.                            |
| `None`            | `'csv'`   | Prints raw CSV data to the console with headers and rows.                                        |
| `filepath` (str)  | `'table'` | Appends a formatted table to the specified file using `tabulate`.                               |
| `filepath` (str)  | `'csv'`   | Appends CSV-formatted data (with headers) to the specified file.                                 |
### Notes (default behavior):
- `output`: Can be `None` (default, print to console) or a string specifying the path to a file.
- `format`: Can be `'table'` (default, human-readable) or `'csv'` (machine-readable).
- For both formats, data is appended (not overwritten) if writing to a file.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |     x     |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
