### PR TITLE
Failing GitHub CI coverage tests [FOR @david-yz-liu]

### DIFF
--- a/tests/test_cfg/test_cfg_generator_z3.py
+++ b/tests/test_cfg/test_cfg_generator_z3.py
@@ -3,6 +3,9 @@ Test suite for generating z3 control flow graphs using the PythonTA API.
 """
 
 import os.path
+from unittest.mock import patch
+
+import pytest
 
 import python_ta.cfg.cfg_generator as cfg_generator
 
@@ -25,3 +28,30 @@ def test_cfg_z3_enabled() -> None:
         # Teardown: close any open file IO and remove the graphviz generated files
         os.remove(gv_file_path)
         os.remove(svg_file_path)
+
+
+# The following tests cover the same ImportError lines locally in `cfg_generator.py`.
+# Note: These were my two "best" attempts... It is still failing on GitHub, but passes locally!
+@patch.dict("sys.modules", {"python_ta.transforms.z3_visitor": None})
+def test_cfg_z3_failed_import_attempt1() -> None:
+    """Test verifies that `generate_cfg` handles ImportError appropriately."""
+    with pytest.raises(ImportError):
+        cfg_generator.generate_cfg(z3_enabled=True)
+
+
+def test_cfg_z3_failed_import_attempt2(monkeypatch) -> None:
+    """Test verifies that `generate_cfg` correctly handles import failure.
+    Note: Test uses monkeypatch since `unittest.mock` to avoid an AttributeError that occurs on GitHub CI.
+    """
+    original = __import__
+
+    def mock_import(name, *args):
+        if "z3_visitor" in name:
+            raise ImportError("Z3Visitor not available")
+        # Use original, since infinite recursion if __import__ is used directly for some reason
+        return original(name, *args)
+
+    monkeypatch.setattr("builtins.__import__", mock_import)
+
+    with pytest.raises(ImportError):
+        cfg_generator.generate_cfg(z3_enabled=True)

--- a/tests/test_cfg/test_cfg_generator_z3.py
+++ b/tests/test_cfg/test_cfg_generator_z3.py
@@ -30,28 +30,9 @@ def test_cfg_z3_enabled() -> None:
         os.remove(svg_file_path)
 
 
-# The following tests cover the same ImportError lines locally in `cfg_generator.py`.
-# Note: These were my two "best" attempts... It is still failing on GitHub, but passes locally!
 @patch.dict("sys.modules", {"python_ta.transforms.z3_visitor": None})
 def test_cfg_z3_failed_import_attempt1() -> None:
     """Test verifies that `generate_cfg` handles ImportError appropriately."""
+    file_path = "examples/pylint/r0912_too_many_branches.py"
     with pytest.raises(ImportError):
-        cfg_generator.generate_cfg(z3_enabled=True)
-
-
-def test_cfg_z3_failed_import_attempt2(monkeypatch) -> None:
-    """Test verifies that `generate_cfg` correctly handles import failure.
-    Note: Test uses monkeypatch since `unittest.mock` to avoid an AttributeError that occurs on GitHub CI.
-    """
-    original = __import__
-
-    def mock_import(name, *args):
-        if "z3_visitor" in name:
-            raise ImportError("Z3Visitor not available")
-        # Use original, since infinite recursion if __import__ is used directly for some reason
-        return original(name, *args)
-
-    monkeypatch.setattr("builtins.__import__", mock_import)
-
-    with pytest.raises(ImportError):
-        cfg_generator.generate_cfg(z3_enabled=True)
+        cfg_generator.generate_cfg(mod=file_path, z3_enabled=True)


### PR DESCRIPTION
## Failing GitHub CI test

I wrote two versions of the same failing test. These tests provide coverage for the import error code in the `_generate` helper in `cfg_generator.py`.

Here are my two best attempts:
1) attempt 1: Use patching to "mock" the error
2) attempt 2: Use monkeypatching to manually replace the module with a "dummy" module

I also tried:
- Using patch to replace the module with a "dummy" module (instead of None)
- Using monkeypatching to manually delete the module
