### PR TITLE
Fixed reports to only include config files when they have errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### 🐛 Bug fixes
 
+- Fixed reports to only include config files when they have errors
+
 ### 🔧 Internal changes
 
 ## [2.11.0] - 2025-08-16

--- a/python_ta/check/helpers.py
+++ b/python_ta/check/helpers.py
@@ -93,7 +93,7 @@ def check_file(
 
         # At this point, the only possible errors are those from parsing the config file
         # so print them, if there are any.
-        if current_reporter.messages:
+        if current_reporter.has_messages():
             current_reporter.print_messages()
     else:
         linter.set_reporter(current_reporter)
@@ -291,8 +291,6 @@ def reset_linter(
         load_config(linter, default_config_path)
         # If we do specify to load the default config, we just need to override the options later.
         set_config = override_config
-        if default_config_path in linter.reporter.messages:
-            del linter.reporter.messages[default_config_path]
 
     if isinstance(config, str) and config != "":
         set_config(linter, config)

--- a/python_ta/reporters/core.py
+++ b/python_ta/reporters/core.py
@@ -139,6 +139,13 @@ class PythonTaReporter(BaseReporter):
 
             curr_messages[-1] = NewMessage(msg, node, snippet)
 
+    def gather_messages(self) -> dict[str, list[Message]]:
+        """Return a filtered version of self.messages for reporting.
+
+        This filters out configuration files (i.e., non-".py" files) that do not have any errors.
+        """
+        return {path: msgs for path, msgs in self.messages.items() if path.endswith(".py") or msgs}
+
     def group_messages(
         self, messages: list[Message]
     ) -> tuple[dict[str, list[Message]], dict[str, list[Message]]]:

--- a/python_ta/reporters/html_reporter.py
+++ b/python_ta/reporters/html_reporter.py
@@ -62,7 +62,9 @@ class HTMLReporter(PythonTaReporter):
         This method can be implemented to display them after they've
         been aggregated.
         """
-        grouped_messages = {path: self.group_messages(msgs) for path, msgs in self.messages.items()}
+        grouped_messages = {
+            path: self.group_messages(msgs) for path, msgs in self.gather_messages().items()
+        }
 
         template_f = self.linter.config.pyta_template_file
         template_f = (

--- a/python_ta/reporters/json_reporter.py
+++ b/python_ta/reporters/json_reporter.py
@@ -33,7 +33,7 @@ class JSONReporter(PythonTaReporter):
         been aggregated.
         """
         output = []
-        for k, msgs in self.messages.items():
+        for k, msgs in self.gather_messages().items():
             output.append(
                 {
                     "filename": k,

--- a/tests/test_check.py
+++ b/tests/test_check.py
@@ -72,8 +72,9 @@ def test_check_on_dir():
             msg.message.symbol for msg in messages
         }, f"astroid-error encountered for {filename}"
         name = os.path.basename(filename)
-        assert name in sample_files, f"{name} not in sample_files"
-        sample_files.remove(name)
+        assert name in sample_files or name == ".pylintrc", f"{name} not in sample_files"
+        if name in sample_files:
+            sample_files.remove(name)
 
     assert not sample_files, f"the following files not checked by python_ta: {sample_files}"
 

--- a/tests/test_config/file_fixtures/test_color_no_errors.pylintrc
+++ b/tests/test_config/file_fixtures/test_color_no_errors.pylintrc
@@ -1,0 +1,8 @@
+[REPORTS]
+
+output-format = pyta-color
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10

--- a/tests/test_config/file_fixtures/test_color_unknown_key.pylintrc
+++ b/tests/test_config/file_fixtures/test_color_unknown_key.pylintrc
@@ -1,0 +1,11 @@
+[REPORTS]
+
+output-format = pyta-color
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10
+
+# This key is unknown to PythonTA and causes an error to be reported
+extra-key = hello

--- a/tests/test_config/file_fixtures/test_html_no_errors.pylintrc
+++ b/tests/test_config/file_fixtures/test_html_no_errors.pylintrc
@@ -1,0 +1,8 @@
+[REPORTS]
+
+output-format = pyta-html
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10

--- a/tests/test_config/file_fixtures/test_html_unknown_key.pylintrc
+++ b/tests/test_config/file_fixtures/test_html_unknown_key.pylintrc
@@ -1,0 +1,11 @@
+[REPORTS]
+
+output-format = pyta-html
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10
+
+# This key is unknown to PythonTA and causes an error to be reported
+extra-key = hello

--- a/tests/test_config/file_fixtures/test_json_no_errors.pylintrc
+++ b/tests/test_config/file_fixtures/test_json_no_errors.pylintrc
@@ -1,0 +1,8 @@
+[REPORTS]
+
+output-format = pyta-json
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10

--- a/tests/test_config/file_fixtures/test_json_unknown_key.pylintrc
+++ b/tests/test_config/file_fixtures/test_json_unknown_key.pylintrc
@@ -1,0 +1,11 @@
+[REPORTS]
+
+output-format = pyta-json
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10
+
+# This key is unknown to PythonTA and causes an error to be reported
+extra-key = hello

--- a/tests/test_config/file_fixtures/test_plain_no_errors.pylintrc
+++ b/tests/test_config/file_fixtures/test_plain_no_errors.pylintrc
@@ -1,0 +1,8 @@
+[REPORTS]
+
+output-format = pyta-plain
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10

--- a/tests/test_config/file_fixtures/test_plain_unknown_key.pylintrc
+++ b/tests/test_config/file_fixtures/test_plain_unknown_key.pylintrc
@@ -1,0 +1,11 @@
+[REPORTS]
+
+output-format = pyta-plain
+
+[CUSTOM PYTA OPTIONS]
+
+# Default max amount of messages for reporter to display.
+pyta-number-of-messages = 10
+
+# This key is unknown to PythonTA and causes an error to be reported
+extra-key = hello

--- a/tests/test_config/test_config.py
+++ b/tests/test_config/test_config.py
@@ -2,6 +2,7 @@
 Test suite for checking whether configuration worked correctly with user-inputted configurations.
 """
 
+import io
 import json
 import os
 from unittest.mock import mock_open, patch
@@ -191,6 +192,52 @@ def test_print_messages_config_parsing_error(capsys) -> None:
     out = capsys.readouterr().out
 
     assert "W0012" in out
+
+
+@pytest.mark.parametrize(
+    argnames=["config_filename"],
+    argvalues=[
+        ("test_plain_no_errors.pylintrc",),
+        ("test_color_no_errors.pylintrc",),
+        ("test_html_no_errors.pylintrc",),
+        ("test_json_no_errors.pylintrc",),
+    ],
+)
+def test_no_config_reported_when_no_error(config_filename: str) -> None:
+    """Test that check_all does not display output for a custom config file
+    when the file has no errors.
+    """
+    curr_dir = os.path.dirname(__file__)
+    config = os.path.join(curr_dir, "file_fixtures", config_filename)
+    output = io.StringIO()
+
+    python_ta.check_all(module_name="examples/nodes/name.py", config=config, output=output)
+
+    output_contents = output.getvalue()
+    assert config_filename not in output_contents
+
+
+@pytest.mark.parametrize(
+    argnames=["config_filename"],
+    argvalues=[
+        ("test_plain_unknown_key.pylintrc",),
+        ("test_color_unknown_key.pylintrc",),
+        ("test_html_unknown_key.pylintrc",),
+        ("test_json_unknown_key.pylintrc",),
+    ],
+)
+def test_config_reported_when_logical_error(config_filename: str) -> None:
+    """Test that check_all displays output for a custom config file
+    when the file has a semantic error (invalid key name).
+    """
+    curr_dir = os.path.dirname(__file__)
+    config = os.path.join(curr_dir, "file_fixtures", config_filename)
+    output = io.StringIO()
+
+    python_ta.check_all(module_name="examples/nodes/name.py", config=config, output=output)
+
+    output_contents = output.getvalue()
+    assert config_filename in output_contents
 
 
 def test_no_snippet_for_config_parsing_errors(prevent_webbrowser_and_httpserver) -> None:


### PR DESCRIPTION
## Proposed Changes

_(Describe your changes here. Also describe the motivation for your changes: what problem do they solve, or how do they improve the application or codebase? If this pull request fixes an open issue, [use a keyword to link this pull request to the issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).)_

Pylint checks configuration files for errors, registering these files in the reporters. Previously, the reporters included a section for custom configuration files in the output report (invoking `print_messages/`display_messages`), which is not expected behaviour (and not the case in previous versions of PyTA).

This PR fixes this by:

- fixing the guard to `reporter.print_messages` in the `check_file` function
- filtering out config files without errors from the `HTMLReporter` and `JSONReporter` `display_messages` methods

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

_(Write an `X` or a brief description next to the type or types that best describe your changes.)_

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  | X        |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [X] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [X] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [X] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
