### PR TITLE
Add infinite-loop detection for `while` loops with immutable condition variables

### DIFF
--- a/python_ta/checkers/infinite_loop_checker.py
+++ b/python_ta/checkers/infinite_loop_checker.py
@@ -198,14 +198,6 @@ class InfiniteLoopChecker(BaseChecker):
         - All variables in the `while` condition are immutable (int, float, complex, bool,
           str, bytes, tuple, frozenset, or NoneType)
         - None of these variables are reassigned in the loop body"""
-        # Infer the loop condition
-        inferred_test = utils.safe_infer(node.test)
-        if isinstance(inferred_test, util.UninferableBase) or inferred_test is None:
-            return False
-        if isinstance(inferred_test, nodes.Const) and inferred_test.value is False:
-            # Condition is always false, loop won't run. No need to check for infinite loop.
-            return False
-
         immutable_types = (
             int,
             float,
@@ -230,6 +222,14 @@ class InfiniteLoopChecker(BaseChecker):
                     immutable_vars.add(child.name)
         if not immutable_vars or immutable_vars != cond_vars:
             # There are no vars with immutables values OR there are vars with mutable values
+            return False
+
+        # Infer the loop condition
+        inferred_test = utils.safe_infer(node.test)
+        if isinstance(inferred_test, util.UninferableBase) or inferred_test is None:
+            return False
+        if isinstance(inferred_test, nodes.Const) and inferred_test.value is False:
+            # Condition is always false, loop won't run. No need to check for infinite loop.
             return False
 
         for child in node.body:


### PR DESCRIPTION
## Proposed Changes

This PR uses **astroid inference** to determine the data type of variables in a `while` loop condition. If all variables are inferred to be immutable, the loop body is checked for reassignments only (i.e., `AssignName` nodes), allowing the detection of potentially infinite loops, such as `while i < 1: print(i)` when `i` is immutable.  

### Behaviour
- Loops with conditions that are always `False` or cannot be inferred are ignored.  
- If all condition variables are immutable and none are reassigned in the loop body, the loop is flagged as potentially infinite.  
- Any mutable variable or other operations on immutable variables prevent the loop from being flagged.  

### More about

1. **Mixed mutable and immutable variables:** Not flagged, since behaviour is undefined.  
2. **Reassigned immutable variables:** Loops are not flagged if any immutable variable is reassigned, as it could change the loop condition.  
3. **Have to infer loop condition:** If not checked, loops with False conditions may still be flagged.
4. **Inference limitations:** Variables with complex number value (immutable type), may not be inferable by `astroid` :(  .In such cases, the loop is not flagged.  

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |    X     |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |    X     |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [ ] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [ ] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [ ] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [ ] I have updated the project Changelog (this is required for all changes).
- [ ] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [ ] I have verified that the pre-commit.ci checks have passed.
- [ ] I have verified that the CI tests have passed.
- [ ] I have reviewed the test coverage changes reported by Coveralls.
- [ ] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

_(Include any questions or comments you have regarding your changes.)_
