### PR TITLE
refactoring node_printers.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added tests for node_printers.py functions rendering the PEP8 error messages: E101, E116, E124, E128, E201, E202
 - Added tests for node_printers.py functions rendering the following PEP8 error codes: E221, E251, E261, E272, E273, E302, E305, E306
-- Refactored node_printers.py by grouping repeated code in helper functions and grouping identical functions in single functions to reduce code duplication
+- Refactored node_printers.py by grouping repeated code in helper functions and grouping identical functions into a single functions to reduce code duplication
 
 ## [2.11.1] - 2025-08-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Added tests for node_printers.py functions rendering the PEP8 error messages: E101, E116, E124, E128, E201, E202
 - Added tests for node_printers.py functions rendering the following PEP8 error codes: E221, E251, E261, E272, E273, E302, E305, E306
+- Refactored node_printers.py by grouping repeated code in helper functions and grouping identical functions in single functions to reduce code duplication
 
 ## [2.11.1] - 2025-08-17
 

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -133,7 +133,7 @@ def render_missing_space_in_doctest(msg, _node, source_lines=None):
 
 
 def get_col(msg):
-    """Returns the column number of the character containing the error"""
+    """Return the column number of the character causing the error"""
     res = re.search(r"column (\d+)", msg.msg)
     col = int(res.group().split()[-1])
     return col
@@ -153,7 +153,7 @@ def render_pep8_errors(msg, _node, source_lines=None):
             line = msg.line
             col = get_col(msg)
             yield from render_context(line - 3, line, source_lines)
-            yield from RENDERERS[error_code](msg, _node, line, col, source_lines[line - 1])
+            yield from RENDERERS[error_code](msg, line, col, source_lines[line - 1])
             yield from render_context(line + 1, line + 3, source_lines)
             return
 
@@ -166,14 +166,14 @@ def render_blank_line(line):
     yield (line + 1, slice(None, None), LineType.ERROR, " " * 28)
 
 
-def render_pep8_errors_e101_and_e123(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e101_and_e123_and_e116(msg, line, col, source_line=None):
     """Render a PEP8 indentation contains mixed spaces and tabs message
     AND a PEP8 closing bracket does not match indentation of opening bracket's line message."""
     curr_idx = len(source_line) - len(source_line.lstrip())
     yield (line, slice(0, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e115(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e115(msg, line, col, source_line=None):
     """Render a PEP8 expected an indented block (comment) message."""
     yield (
         line,
@@ -183,23 +183,11 @@ def render_pep8_errors_e115(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e116(msg, _node, line, col, source_line=None):
-    """Render a PEP8 unexpected indentation (comment) message"""
-    curr_idx = len(source_line) - len(source_line.lstrip())
-    yield (
-        line,
-        slice(0, curr_idx),
-        LineType.ERROR,
-        source_line,
-    )
-
-
-def render_pep8_errors_e122_and_e127_and_e131(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e122_and_e127_and_e131(msg, line, col, source_line=None):
     """
     Render a PEP8 continuation line missing indentation or outdented message, a line over-indented for visual indent
     message, and a continuation line unaligned for hanging indent message.
     """
-
     curr_line_start_index = len(source_line) - len(source_line.lstrip())
     end_index = curr_line_start_index if curr_line_start_index > 0 else len(source_line)
     yield (
@@ -210,13 +198,12 @@ def render_pep8_errors_e122_and_e127_and_e131(msg, _node, line, col, source_line
     )
 
 
-def render_pep8_errors_e124(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e124(msg, line, col, source_line=None):
     """Render a PEP8 closing bracket does not match visual indentation message."""
-
     yield (line, slice(col, col + 1), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e125_and_e129(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e125_and_e129(msg, line, col, source_line=None):
     """Render a PEP8 continuation line with same indent as next logical line message
     AND a PEP8 visually indented line with same indent as next logical line messsage"""
     curr_idx = len(source_line) - len(source_line.lstrip())
@@ -228,15 +215,12 @@ def render_pep8_errors_e125_and_e129(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e128(msg, _node, line, col, source_line):
+def render_pep8_errors_e128(msg, line, col, source_line):
     """Render a PEP8 continuation line under-indented for visual indent message."""
-
     yield (line, slice(0, col if col != 0 else None), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272(
-    msg, _node, line, col, source_line=None
-):
+def render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272(msg, line, col, source_line=None):
     """Render a PEP8 whitespace after '(' message,
     a PEP8 whitespace before ')' message,
     a PEP8 whitespace before ‘,’, ‘;’, or ‘:’ message,
@@ -245,40 +229,35 @@ def render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272(
     a PEP8 multiple spaces after keyword message,
     a PEP8 multiple spaces before keyword message
     and a PEP8 multiple spaces after operator message."""
-
     curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e204(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e204(msg, line, col, source_line=None):
     """Render a PEP8 whitespace after decorator '@' message"""
-
     # calculates the length of the leading whitespaces by subtracting the length of everything after the first character after stripping all leading whitespaces from the total line length
     curr_idx = col + len(source_line[col:]) - len(source_line[col + 1 :].lstrip())
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e223_and_e274(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e223_and_e274(msg, line, col, source_line=None):
     """Render a PEP8 tab before operator message and a PEP8 tab before keyword message."""
-
     curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip("\t"))
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e224_and_e273(msg, _node, line, col, source_line):
+def render_pep8_errors_e224_and_e273(msg, line, col, source_line):
     """Render a PEP8 tab after operator message and a PEP8 tab after keyword message."""
-
     curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip("\t"))
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e225(msg, _node, line, col, source_line):
+def render_pep8_errors_e225(msg, line, col, source_line):
     """Render a PEP8 missing whitespace around operator message"""
-
     curr_idx = col + 1
 
     two_char_operators = {
@@ -308,9 +287,8 @@ def render_pep8_errors_e225(msg, _node, line, col, source_line):
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e226(msg, _node, line, col, source_line):
+def render_pep8_errors_e226(msg, line, col, source_line):
     """Render a PEP8 missing whitespace around arithmetic operator message"""
-
     end_idx = col + 1
 
     multi_char_operators = {"//"}
@@ -321,9 +299,8 @@ def render_pep8_errors_e226(msg, _node, line, col, source_line):
     yield (line, slice(col, end_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e227(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e227(msg, line, col, source_line=None):
     """Render a PEP8 missing whitespace around bitwise or shift operator message."""
-
     # Check which operator to get the correct range of the line to highlight.
     # Default highlight is one character, but may be updated to two.
     # Note that only binary bitwise operators that are more than one character are included.
@@ -334,9 +311,8 @@ def render_pep8_errors_e227(msg, _node, line, col, source_line=None):
     yield (line, slice(col, end_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e228(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e228(msg, line, col, source_line=None):
     """Render a PEP8 missing whitespace around modulo operator message."""
-
     yield (
         line,
         slice(col, col + 1),
@@ -345,16 +321,14 @@ def render_pep8_errors_e228(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e231(msg, _node, line, col, source_line=None):
-
+def render_pep8_errors_e231(msg, line, col, source_line=None):
     curr_idx = col + 1
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e251(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e251(msg, line, col, source_line=None):
     """Render a PEP8 unexpected spaces around keyword / parameter equals message."""
-
     equals_sign_idx = source_line[col:].find("=")
     code = source_line[col : col + equals_sign_idx if equals_sign_idx != -1 else None]
     end_idx = col + len(code) - len(code.lstrip())
@@ -362,9 +336,8 @@ def render_pep8_errors_e251(msg, _node, line, col, source_line=None):
     yield (line, slice(col, end_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e261(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e261(msg, line, col, source_line=None):
     """Render a PEP8 at least two spaces before inline comment message."""
-
     yield (
         line,
         slice(col, len(source_line)),
@@ -373,17 +346,15 @@ def render_pep8_errors_e261(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e262(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e262(msg, line, col, source_line=None):
     """Render a PEP8 inline comment should start with '# ' message"""
-
     keyword_idx = len(source_line) - len(source_line[col:].lstrip("# \t"))
 
     yield (line, slice(col, keyword_idx), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e265(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e265(msg, line, col, source_line=None):
     """Render a PEP8 block comment should start with '# ' message."""
-
     yield (
         line,
         slice(0, len(source_line)),
@@ -392,9 +363,8 @@ def render_pep8_errors_e265(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e266(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e266(msg, line, col, source_line=None):
     """Render a PEP8 too many leading ‘#’ for block comment message."""
-
     curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip("#"))
 
     yield (
@@ -405,9 +375,8 @@ def render_pep8_errors_e266(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e275(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e275(msg, line, col, source_line=None):
     """Render a PEP8 missing whitespace after keyword message."""
-
     # Get the range for highlighting the corresponding keyword.
     keyword = source_line[:col].split()[-1]
     keyword_idx = source_line.index(keyword)
@@ -420,10 +389,9 @@ def render_pep8_errors_e275(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e301(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e301(msg, line, col, source_line=None):
     """Render a PEP8 expected 1 blank line message."""
     line -= 1
-
     body = source_line[line]
     indentation = len(body) - len(body.lstrip())
     yield (
@@ -434,7 +402,7 @@ def render_pep8_errors_e301(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e302(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e302(msg, line, col, source_line=None):
     """Render a PEP8 expected 2 blank lines message."""
     line -= 1
     if "found 0" in msg.msg:
@@ -453,7 +421,7 @@ def render_pep8_errors_e302(msg, _node, line, col, source_line=None):
         yield (None, slice(None, None), LineType.ERROR, NEW_BLANK_LINE_MESSAGE)
 
 
-def render_pep8_errors_e303(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e303(msg, line, col, source_line=None):
     """Render a PEP8 too many blank lines message."""
     line -= 1
     while source_line.strip() == "":
@@ -467,7 +435,7 @@ def render_pep8_errors_e303(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e304(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e304(msg, line, col, source_line=None):
     """Render a PEP8 blank lines found after function decorator message."""
     line -= 1
     while source_line.strip() == "":
@@ -479,7 +447,7 @@ def render_pep8_errors_e304(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e305(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e305(msg, line, col, source_line=None):
     """Render a PEP8 expected 2 blank lines after class or function definition message."""
     line -= 1
     if "found 0" in msg.msg:
@@ -498,7 +466,7 @@ def render_pep8_errors_e305(msg, _node, line, col, source_line=None):
         yield (None, slice(None, None), LineType.ERROR, NEW_BLANK_LINE_MESSAGE)
 
 
-def render_pep8_errors_e306(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e306(msg, line, col, source_line=None):
     """Render a PEP8 expected 1 blank line before a nested definition message."""
     line -= 1
     body = source_line[line]
@@ -511,7 +479,7 @@ def render_pep8_errors_e306(msg, _node, line, col, source_line=None):
     )
 
 
-def render_pep8_errors_e502(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e502(msg, line, col, source_line=None):
     """Render a PEP8 the backslash is redundant between brackets."""
     yield (line, slice(col, col + 1), LineType.ERROR, source_line)
 
@@ -593,10 +561,10 @@ CUSTOM_MESSAGES = {
 }
 
 RENDERERS = {
-    "E101": render_pep8_errors_e101_and_e123,
-    "E123": render_pep8_errors_e101_and_e123,
+    "E101": render_pep8_errors_e101_and_e123_and_e116,
+    "E123": render_pep8_errors_e101_and_e123_and_e116,
     "E115": render_pep8_errors_e115,
-    "E116": render_pep8_errors_e116,
+    "E116": render_pep8_errors_e101_and_e123_and_e116,
     "E122": render_pep8_errors_e122_and_e127_and_e131,
     "E127": render_pep8_errors_e122_and_e127_and_e131,
     "E131": render_pep8_errors_e122_and_e127_and_e131,

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -230,9 +230,8 @@ def render_pep8_errors_e125_and_e129(msg, _node, line, source_lines=None):
 
 def render_pep8_errors_e128(msg, _node, line, source_lines):
     """Render a PEP8 continuation line under-indented for visual indent message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     yield from render_context(line - 2, line, source_lines)
     yield (line, slice(0, col if col != 0 else None), LineType.ERROR, source_lines[line - 1])
@@ -250,11 +249,10 @@ def render_pep8_errors_e201_e202_e203_e211(msg, _node, line, source_lines=None):
     yield (line, slice(col, curr_idx), LineType.ERROR, source_lines[line - 1])
 
 
-def render_pep8_errors_e204(msg, _node, source_lines=None):
+def render_pep8_errors_e204(msg, _node, line, source_lines=None):
     """Render a PEP8 whitespace after decorator '@' message"""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     # calculates the length of the leading whitespaces by subtracting the length of everything after the first character after stripping all leading whitespaces from the total line length
     curr_idx = (
         col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col + 1 :].lstrip())
@@ -265,11 +263,10 @@ def render_pep8_errors_e204(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e221(msg, _node, source_lines=None):
+def render_pep8_errors_e221(msg, _node, line, source_lines=None):
     """Render a PEP8 multiple spaces before operator message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip())
 
     yield from render_context(line - 2, line, source_lines)
@@ -277,11 +274,10 @@ def render_pep8_errors_e221(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e222(msg, _node, source_lines=None):
+def render_pep8_errors_e222(msg, _node, line, source_lines=None):
     """Render a PEP8 multiple spaces after operator message"""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     curr_idx = col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip())
     yield from render_context(line - 2, line, source_lines)
@@ -289,11 +285,10 @@ def render_pep8_errors_e222(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e223_and_e274(msg, _node, source_lines=None):
+def render_pep8_errors_e223_and_e274(msg, _node, line, source_lines=None):
     """Render a PEP8 tab before operator message and a PEP8 tab before keyword message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = (
         col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip("\t"))
     )
@@ -303,11 +298,10 @@ def render_pep8_errors_e223_and_e274(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e224_and_e273(msg, _node, source_lines):
+def render_pep8_errors_e224_and_e273(msg, _node, line, source_lines):
     """Render a PEP8 tab after operator message and a PEP8 tab after keyword message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = (
         col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip("\t"))
     )
@@ -317,11 +311,10 @@ def render_pep8_errors_e224_and_e273(msg, _node, source_lines):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e225(msg, _node, source_lines):
+def render_pep8_errors_e225(msg, _node, line, source_lines):
     """Render a PEP8 missing whitespace around operator message"""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = col + 1
 
     two_char_operators = {
@@ -353,11 +346,10 @@ def render_pep8_errors_e225(msg, _node, source_lines):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e226(msg, _node, source_lines):
+def render_pep8_errors_e226(msg, _node, line, source_lines):
     """Render a PEP8 missing whitespace around arithmetic operator message"""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     end_idx = col + 1
 
     multi_char_operators = {"//"}
@@ -370,11 +362,10 @@ def render_pep8_errors_e226(msg, _node, source_lines):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e227(msg, _node, source_lines=None):
+def render_pep8_errors_e227(msg, _node, line, source_lines=None):
     """Render a PEP8 missing whitespace around bitwise or shift operator message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     # Check which operator to get the correct range of the line to highlight.
     # Default highlight is one character, but may be updated to two.
     # Note that only binary bitwise operators that are more than one character are included.
@@ -387,11 +378,10 @@ def render_pep8_errors_e227(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e228(msg, _node, source_lines=None):
+def render_pep8_errors_e228(msg, _node, line, source_lines=None):
     """Render a PEP8 missing whitespace around modulo operator message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     yield from render_context(line - 2, line, source_lines)
     yield (
@@ -403,10 +393,9 @@ def render_pep8_errors_e228(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e231(msg, _node, source_lines=None):
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+def render_pep8_errors_e231(msg, _node, line, source_lines=None):
+
+    col = get_col(msg)
     curr_idx = col + 1
 
     yield from render_context(line - 2, line, source_lines)
@@ -414,11 +403,10 @@ def render_pep8_errors_e231(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e251(msg, _node, source_lines=None):
+def render_pep8_errors_e251(msg, _node, line, source_lines=None):
     """Render a PEP8 unexpected spaces around keyword / parameter equals message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     equals_sign_idx = source_lines[line - 1][col:].find("=")
     code = source_lines[line - 1][col : col + equals_sign_idx if equals_sign_idx != -1 else None]
     end_idx = col + len(code) - len(code.lstrip())
@@ -428,11 +416,10 @@ def render_pep8_errors_e251(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e261(msg, _node, source_lines=None):
+def render_pep8_errors_e261(msg, _node, line, source_lines=None):
     """Render a PEP8 at least two spaces before inline comment message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     yield from render_context(line - 2, line, source_lines)
     yield (
@@ -444,11 +431,10 @@ def render_pep8_errors_e261(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e262(msg, _node, source_lines=None):
+def render_pep8_errors_e262(msg, _node, line, source_lines=None):
     """Render a PEP8 inline comment should start with '# ' message"""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     source_line = source_lines[line - 1]
     keyword_idx = len(source_line) - len(source_line[col:].lstrip("# \t"))
@@ -458,9 +444,9 @@ def render_pep8_errors_e262(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e265(msg, _node, source_lines=None):
+def render_pep8_errors_e265(msg, _node, line, source_lines=None):
     """Render a PEP8 block comment should start with '# ' message."""
-    line = msg.line
+
     yield from render_context(line - 2, line, source_lines)
     yield (
         line,
@@ -471,11 +457,10 @@ def render_pep8_errors_e265(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e266(msg, _node, source_lines=None):
+def render_pep8_errors_e266(msg, _node, line, source_lines=None):
     """Render a PEP8 too many leading ‘#’ for block comment message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = (
         col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip("#"))
     )
@@ -490,11 +475,10 @@ def render_pep8_errors_e266(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e271(msg, _node, source_lines=None):
+def render_pep8_errors_e271(msg, _node, line, source_lines=None):
     """Render a PEP8 multiple spaces after keyword message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip())
 
     yield from render_context(line - 2, line, source_lines)
@@ -502,11 +486,10 @@ def render_pep8_errors_e271(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e272(msg, _node, source_lines=None):
+def render_pep8_errors_e272(msg, _node, line, source_lines=None):
     """Render a PEP8 multiple spaces before keyword message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
     curr_idx = col + len(source_lines[line - 1][col:]) - len(source_lines[line - 1][col:].lstrip())
 
     yield from render_context(line - 2, line, source_lines)
@@ -514,11 +497,10 @@ def render_pep8_errors_e272(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e275(msg, _node, source_lines=None):
+def render_pep8_errors_e275(msg, _node, line, source_lines=None):
     """Render a PEP8 missing whitespace after keyword message."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     # Get the range for highlighting the corresponding keyword.
     keyword = source_lines[line - 1][:col].split()[-1]
@@ -534,9 +516,9 @@ def render_pep8_errors_e275(msg, _node, source_lines=None):
     yield from render_context(line + 1, line + 3, source_lines)
 
 
-def render_pep8_errors_e301(msg, _node, source_lines=None):
+def render_pep8_errors_e301(msg, _node, line, source_lines=None):
     """Render a PEP8 expected 1 blank line message."""
-    line = msg.line - 1
+    line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
     body = source_lines[line]
     indentation = len(body) - len(body.lstrip())
@@ -549,9 +531,9 @@ def render_pep8_errors_e301(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e302(msg, _node, source_lines=None):
+def render_pep8_errors_e302(msg, _node, line, source_lines=None):
     """Render a PEP8 expected 2 blank lines message."""
-    line = msg.line - 1
+    line -= 1
     if "found 0" in msg.msg:
         yield from render_context(line - 1, line + 1, source_lines)
         yield from (
@@ -571,9 +553,9 @@ def render_pep8_errors_e302(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e303(msg, _node, source_lines=None):
+def render_pep8_errors_e303(msg, _node, line, source_lines=None):
     """Render a PEP8 too many blank lines message."""
-    line = msg.line - 1
+    line -= 1
     while source_lines[line - 1].strip() == "":
         line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
@@ -586,9 +568,9 @@ def render_pep8_errors_e303(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e304(msg, _node, source_lines=None):
+def render_pep8_errors_e304(msg, _node, line, source_lines=None):
     """Render a PEP8 blank lines found after function decorator message."""
-    line = msg.line - 1
+    line -= 1
     while source_lines[line - 1].strip() == "":
         line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
@@ -599,9 +581,9 @@ def render_pep8_errors_e304(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e305(msg, _node, source_lines=None):
+def render_pep8_errors_e305(msg, _node, line, source_lines=None):
     """Render a PEP8 expected 2 blank lines after class or function definition message."""
-    line = msg.line - 1
+    line -= 1
     if "found 0" in msg.msg:
         yield from render_context(line - 1, line + 1, source_lines)
         yield from (
@@ -621,9 +603,9 @@ def render_pep8_errors_e305(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e306(msg, _node, source_lines=None):
+def render_pep8_errors_e306(msg, _node, line, source_lines=None):
     """Render a PEP8 expected 1 blank line before a nested definition message."""
-    line = msg.line - 1
+    line -= 1
     yield from render_context(line - 1, line + 1, source_lines)
     body = source_lines[line]
     indentation = len(body) - len(body.lstrip())
@@ -636,11 +618,10 @@ def render_pep8_errors_e306(msg, _node, source_lines=None):
     yield from render_context(msg.line, msg.line + 2, source_lines)
 
 
-def render_pep8_errors_e502(msg, _node, source_lines=None):
+def render_pep8_errors_e502(msg, _node, line, source_lines=None):
     """Render a PEP8 the backslash is redundant between brackets."""
-    line = msg.line
-    res = re.search(r"column (\d+)", msg.msg)
-    col = int(res.group().split()[-1])
+
+    col = get_col(msg)
 
     yield from render_context(line - 2, line, source_lines)
     yield (line, slice(col, col + 1), LineType.ERROR, source_lines[line - 1])

--- a/python_ta/reporters/node_printers.py
+++ b/python_ta/reporters/node_printers.py
@@ -234,11 +234,17 @@ def render_pep8_errors_e128(msg, _node, line, col, source_line):
     yield (line, slice(0, col if col != 0 else None), LineType.ERROR, source_line)
 
 
-def render_pep8_errors_e201_e202_e203_e211(msg, _node, line, col, source_line=None):
+def render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272(
+    msg, _node, line, col, source_line=None
+):
     """Render a PEP8 whitespace after '(' message,
     a PEP8 whitespace before ')' message,
     a PEP8 whitespace before ‘,’, ‘;’, or ‘:’ message,
-    AND a PEP8 whitespace before '(' message.."""
+    a PEP8 whitespace before '(' message,
+    a PEP8 multiple spaces before operator message,
+    a PEP8 multiple spaces after keyword message,
+    a PEP8 multiple spaces before keyword message
+    and a PEP8 multiple spaces after operator message."""
 
     curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
 
@@ -250,22 +256,6 @@ def render_pep8_errors_e204(msg, _node, line, col, source_line=None):
 
     # calculates the length of the leading whitespaces by subtracting the length of everything after the first character after stripping all leading whitespaces from the total line length
     curr_idx = col + len(source_line[col:]) - len(source_line[col + 1 :].lstrip())
-
-    yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
-
-
-def render_pep8_errors_e221(msg, _node, line, col, source_line=None):
-    """Render a PEP8 multiple spaces before operator message."""
-
-    curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
-
-    yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
-
-
-def render_pep8_errors_e222(msg, _node, line, col, source_line=None):
-    """Render a PEP8 multiple spaces after operator message"""
-
-    curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
 
     yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
@@ -386,7 +376,6 @@ def render_pep8_errors_e261(msg, _node, line, col, source_line=None):
 def render_pep8_errors_e262(msg, _node, line, col, source_line=None):
     """Render a PEP8 inline comment should start with '# ' message"""
 
-    source_line = source_line
     keyword_idx = len(source_line) - len(source_line[col:].lstrip("# \t"))
 
     yield (line, slice(col, keyword_idx), LineType.ERROR, source_line)
@@ -414,22 +403,6 @@ def render_pep8_errors_e266(msg, _node, line, col, source_line=None):
         LineType.ERROR,
         source_line + "  # THERE SHOULD ONLY BE ONE '#'",
     )
-
-
-def render_pep8_errors_e271(msg, _node, line, col, source_line=None):
-    """Render a PEP8 multiple spaces after keyword message."""
-
-    curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
-
-    yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
-
-
-def render_pep8_errors_e272(msg, _node, line, col, source_line=None):
-    """Render a PEP8 multiple spaces before keyword message."""
-
-    curr_idx = col + len(source_line[col:]) - len(source_line[col:].lstrip())
-
-    yield (line, slice(col, curr_idx), LineType.ERROR, source_line)
 
 
 def render_pep8_errors_e275(msg, _node, line, col, source_line=None):
@@ -631,13 +604,13 @@ RENDERERS = {
     "E125": render_pep8_errors_e125_and_e129,
     "E129": render_pep8_errors_e125_and_e129,
     "E128": render_pep8_errors_e128,
-    "E201": render_pep8_errors_e201_e202_e203_e211,
-    "E202": render_pep8_errors_e201_e202_e203_e211,
-    "E203": render_pep8_errors_e201_e202_e203_e211,
+    "E201": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
+    "E202": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
+    "E203": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
     "E204": render_pep8_errors_e204,
-    "E211": render_pep8_errors_e201_e202_e203_e211,
-    "E221": render_pep8_errors_e221,
-    "E222": render_pep8_errors_e222,
+    "E211": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
+    "E221": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
+    "E222": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
     "E223": render_pep8_errors_e223_and_e274,
     "E224": render_pep8_errors_e224_and_e273,
     "E225": render_pep8_errors_e225,
@@ -652,8 +625,8 @@ RENDERERS = {
     "E262": render_pep8_errors_e262,
     "E265": render_pep8_errors_e265,
     "E266": render_pep8_errors_e266,
-    "E271": render_pep8_errors_e271,
-    "E272": render_pep8_errors_e272,
+    "E271": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
+    "E272": render_pep8_errors_e201_e202_e203_e211_e221_e222_e271_e272,
     "E275": render_pep8_errors_e275,
     "E301": render_pep8_errors_e301,
     "E302": render_pep8_errors_e302,


### PR DESCRIPTION
## Proposed Changes

Refactored node_printers.py to reduce code duplication. Created new helper function that calculates the column number of the error and made the render_context calls (the calls responsible for printing the context lines above and below the error line) from render_pep8_errors instead of calling the function inside each renderer.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change


| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |    x     |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

_(Complete each of the following items for your pull request. Indicate that you have completed an item by changing the `[ ]` into a `[x]` in the raw text, or by clicking on the checkbox in the rendered description on GitHub.)_

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the pre-commit.ci checks have passed.
- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments


I'm also noticing that many error messages highlight the same amount of characters. Should I also group those together (for example all error messages that highlight exactly 2 characters) or should I leave it as it is.
