### PR TITLE
Add function tracing to SnapshotTracer

### DIFF
--- a/packages/python-ta/CHANGELOG.md
+++ b/packages/python-ta/CHANGELOG.md
@@ -24,6 +24,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Update configuration options to support `.toml` files
 - Updated plain text and HTML PyTA reports to not show sections with no errors and only show 'good job' message once when there are no errors in either section.
 - Added `snapshots` property to `SnapshotTracer` to make captured snapshot data available through the public API.
+- Modified `SnapshotTracer` to trace into calls of functions defined in the same module that `SnapshotTracer` is called.
 
 ### 💫 New checkers
 

--- a/packages/python-ta/docs/debug/index.md
+++ b/packages/python-ta/docs/debug/index.md
@@ -489,7 +489,7 @@ if __name__ == '__main__':
     func_multi_line()
 ```
 
-When this function runs, MemoryViz snapshots are captured and stored internally in the `SnapshotTracer`. These snapshots can be accessed via the `snapshots` property. If `webstepper=True`, the snapshots are rendered into an HTML visualization. For the expected output, refer to the snapshots in `tests/test_debug/snapshot_tracer_testing_snapshots/func_multi_line`.
+When this function runs, MemoryViz snapshots are captured and stored internally in the `SnapshotTracer`. These snapshots can be accessed via the `snapshots` property. If `webstepper=True`, the snapshots are rendered into an HTML visualization. The context manager will step into Python functions defined in the same module as the traced context; calls into external modules and built-ins are not traced. For the expected output, refer to the snapshots in `tests/test_debug/snapshot_tracer_testing_snapshots/func_multi_line`.
 
 ### API
 
@@ -504,5 +504,4 @@ When this function runs, MemoryViz snapshots are captured and stored internally 
 The `SnapshotTracer` has the following limitations:
 
 1. Due to differences in Python interpreters, this context manager only works with Python versions >= 3.10.
-2. The context manager only steps into Python functions defined in the same module as the traced context. Calls into external modules and builtins are not traced.
-3. `SnapshotTracer` uses [`sys.settrace`] to update variable states, and therefore is not compatible with other libraries (e.g., debuggers, code coverage tools).
+2. `SnapshotTracer` uses [`sys.settrace`] to update variable states, and therefore is not compatible with other libraries (e.g., debuggers, code coverage tools).

--- a/packages/python-ta/docs/debug/index.md
+++ b/packages/python-ta/docs/debug/index.md
@@ -486,5 +486,5 @@ When this function runs, MemoryViz snapshots are captured and stored internally 
 The `SnapshotTracer` has the following limitations:
 
 1. Due to differences in Python interpreters, this context manager only works with Python versions >= 3.10.
-2. The context manager does not step into any function calls. Calling functions within the traced function may lead to undefined behavior.
+2. The context manager only steps into Python functions defined in the same module as the traced context. Calls into external modules and builtins are not traced.
 3. `SnapshotTracer` uses [`sys.settrace`] to update variable states, and therefore is not compatible with other libraries (e.g., debuggers, code coverage tools).

--- a/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
@@ -73,14 +73,17 @@ class SnapshotTracer:
         self._origin_file = None
         self._module_source_lines = None
 
-    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
-        """Take a snapshot of the variables in the functions specified in `self.include`, tracing into same-module function calls."""
+    def _global_trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
+        """Global trace function that handles 'call' events to determine which functions to trace into."""
         if event == "call":
             if self._origin_file is None:
                 return None
             # Only trace functions in the same module as the calling function.
             called_file = os.path.normcase(os.path.abspath(frame.f_code.co_filename))
-            if called_file == self._origin_file and frame.f_code.co_name != "_trace_func":
+            if called_file == self._origin_file and frame.f_code.co_name not in (
+                "_trace_func",
+                "_global_trace_func",
+            ):
                 self._start_lineno = min(self._start_lineno, frame.f_code.co_firstlineno)
                 self._end_lineno = max(
                     self._end_lineno,
@@ -90,6 +93,8 @@ class SnapshotTracer:
                 return self._trace_func
             return None
 
+    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
+        """Local trace function set on each frame to take a snapshot of the variables in the functions specified in `self.include`."""
         if event == "line":
             self._start_lineno = min(self._start_lineno, frame.f_lineno)
             self._end_lineno = max(self._end_lineno, frame.f_lineno)
@@ -117,7 +122,7 @@ class SnapshotTracer:
             self._module_source_lines = (
                 Path(self._origin_file).read_text(encoding="utf-8").splitlines()
             )
-        sys.settrace(self._trace_func)
+        sys.settrace(self._global_trace_func)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
@@ -29,17 +29,19 @@ class SnapshotTracer:
         webstepper: Opens the web-based visualizer.
         snapshots: A list of dictionaries that maps the code line number and corresponding MemoryViz JSON snapshot at each traced line.
         _snapshot_args: A dictionary of keyword arguments to pass to the `snapshot` function.
-        _first_line: Line number of the first line in the `with` block.
+        _start_lineno: Line number of the first line to be displayed in the code section of the Webstepper.
+        _end_lineno: Line number of the last line to be displayed in the code section of the Webstepper.
         _origin_file: The absolute path of the module where SnapshotTracer is used.
-        _traced_frames: A list of dictionaries that store the first line number and source lines of same-module functions traced during execution.
+        _module_source_lines: A list of strings representing the source code lines of the module where SnapshotTracer is used.
     """
 
     webstepper: bool
     _snapshots: list[dict[str, Any]]
     _snapshot_args: dict[str, Any]
-    _first_line: int
+    _start_lineno: int
+    _end_lineno: int
     _origin_file: str | None
-    _traced_frames: list[dict[str, Any]]
+    _module_source_lines: list[str] | None
 
     def __init__(
         self,
@@ -66,28 +68,31 @@ class SnapshotTracer:
         self.id_tracker = IDTracker()
 
         self.webstepper = webstepper
-        self._first_line = float("inf")
+        self._start_lineno = sys.maxsize
+        self._end_lineno = 0
         self._origin_file = None
-        self._traced_frames = []
+        self._module_source_lines = None
 
     def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
         """Take a snapshot of the variables in the functions specified in `self.include`, tracing into same-module function calls."""
         if event == "call":
+            if self._origin_file is None:
+                return None
             # Only trace functions in the same module as the calling function.
-            called_file = os.path.normcase(os.path.abspath(frame.f_globals.get("__file__", "")))
+            called_file = os.path.normcase(os.path.abspath(frame.f_code.co_filename))
             if called_file == self._origin_file and frame.f_code.co_name != "_trace_func":
-                self._traced_frames.append(
-                    {
-                        "co_firstlineno": frame.f_code.co_firstlineno,
-                        "source_lines": inspect.getsource(frame.f_code).splitlines(),
-                    }
+                self._start_lineno = min(self._start_lineno, frame.f_code.co_firstlineno)
+                self._end_lineno = max(
+                    self._end_lineno,
+                    frame.f_code.co_firstlineno + len(inspect.getsourcelines(frame)[0]) - 1,
                 )
+                # Return self._trace_func to trace into the called function, otherwise return None to skip tracing.
                 return self._trace_func
             return None
 
-        if self._first_line == float("inf"):
-            self._first_line = frame.f_lineno
         if event == "line":
+            self._start_lineno = min(self._start_lineno, frame.f_lineno)
+            self._end_lineno = max(self._end_lineno, frame.f_lineno)
             snapshot_output = snapshot(
                 id_tracker=self.id_tracker,
                 **self._snapshot_args,
@@ -104,9 +109,14 @@ class SnapshotTracer:
         """Set up the trace function to take snapshots at each line of code."""
         func_frame = inspect.getouterframes(inspect.currentframe())[1].frame
         func_frame.f_trace = self._trace_func
-        self._origin_file = os.path.normcase(
-            os.path.abspath(func_frame.f_globals.get("__file__", ""))
+        origin_file = func_frame.f_globals.get("__file__")
+        self._origin_file = (
+            os.path.normcase(os.path.abspath(origin_file)) if origin_file is not None else None
         )
+        if self._origin_file is not None:
+            self._module_source_lines = (
+                Path(self._origin_file).read_text(encoding="utf-8").splitlines()
+            )
         sys.settrace(self._trace_func)
         return self
 
@@ -143,11 +153,9 @@ class SnapshotTracer:
         template_env = Environment(loader=template_loader)
         template = template_env.get_template("webstepper_template.html.jinja")
 
-        code_text, start_line_number = self._get_code(func_frame)
-
         rendered_html = template.render(
-            code_text=code_text,
-            start_line_number=start_line_number,
+            code_text=self._get_code(),
+            start_line_number=self._start_lineno,
             memory_viz_data=self._snapshots,
             bundle_content=bundle_content,
         )
@@ -162,47 +170,14 @@ class SnapshotTracer:
 
         open_html_in_browser(html_content, port)
 
-    def _get_code(self, func_frame: types.FrameType) -> tuple[str, int]:
+    def _get_code(self) -> str:
         """Retrieve and save the code string to be displayed in Webstepper."""
-        code_lines = inspect.cleandoc(inspect.getsource(func_frame))
-        i = self._first_line - func_frame.f_code.co_firstlineno
-        lst_str_lines = code_lines.splitlines()
-        num_whitespace = len(lst_str_lines[i]) - len(lst_str_lines[i].lstrip())
+        if self._module_source_lines is None or self._start_lineno > self._end_lineno:
+            return ""
 
-        endpoint = len(lst_str_lines)
-        startpoint = i
-        while i < len(lst_str_lines):
-            line = lst_str_lines[i]
-            if (
-                line.strip() != ""
-                and not line.lstrip()[0] == "#"
-                and not line[:num_whitespace].isspace()
-            ):
-                break
-            if line.lstrip() != "" and len(line) - len(line.lstrip()) >= num_whitespace:
-                lst_str_lines[i] = line[num_whitespace:]
-            else:
-                lst_str_lines[i] = line.lstrip()
-            endpoint = i
-            i += 1
-
-        # If any same-module functions were traced, extend the displayed code to include
-        # the entire range of those functions.
-        if self._traced_frames:
-            for traced in self._traced_frames:
-                func_start_line = traced["co_firstlineno"]
-                func_end_line = func_start_line + len(traced["source_lines"]) - 1
-                func_first_index = func_start_line - func_frame.f_code.co_firstlineno
-                func_last_index = func_end_line - func_frame.f_code.co_firstlineno
-
-                if func_first_index < startpoint and func_first_index >= 0:
-                    startpoint = func_first_index
-                if func_last_index > endpoint and func_last_index < len(lst_str_lines):
-                    endpoint = func_last_index
-
-        start_line_number = func_frame.f_code.co_firstlineno + startpoint
-
-        return "\n".join(lst_str_lines[startpoint : endpoint + 1]), start_line_number
+        start_index = max(self._start_lineno - 1, 0)
+        end_index = min(self._end_lineno, len(self._module_source_lines))
+        return "\n".join(self._module_source_lines[start_index:end_index])
 
     @property
     def snapshots(self) -> list[dict[str, Any]]:

--- a/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
@@ -30,12 +30,14 @@ class SnapshotTracer:
         snapshots: A list of dictionaries that maps the code line number and corresponding MemoryViz JSON snapshot at each traced line.
         _snapshot_args: A dictionary of keyword arguments to pass to the `snapshot` function.
         _first_line: Line number of the first line in the `with` block.
+        _origin_file: The absolute path of the module where SnapshotTracer is used.
     """
 
     webstepper: bool
     _snapshots: list[dict[str, Any]]
     _snapshot_args: dict[str, Any]
     _first_line: int
+    _origin_file: str | None
 
     def __init__(
         self,
@@ -63,9 +65,17 @@ class SnapshotTracer:
 
         self.webstepper = webstepper
         self._first_line = float("inf")
+        self._origin_file = None
 
-    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> None:
-        """Take a snapshot of the variables in the functions specified in `self.include`"""
+    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
+        """Take a snapshot of the variables in the functions specified in `self.include`, tracing into same-module function calls."""
+        if event == "call":
+            # Only trace functions in the same module as the calling function.
+            called_file = os.path.normcase(os.path.abspath(frame.f_globals.get("__file__", "")))
+            if called_file == self._origin_file and frame.f_code.co_name != "_trace_func":
+                return self._trace_func
+            return None
+
         if self._first_line == float("inf"):
             self._first_line = frame.f_lineno
         if event == "line":
@@ -85,7 +95,10 @@ class SnapshotTracer:
         """Set up the trace function to take snapshots at each line of code."""
         func_frame = inspect.getouterframes(inspect.currentframe())[1].frame
         func_frame.f_trace = self._trace_func
-        sys.settrace(lambda *_args: None)
+        self._origin_file = os.path.normcase(
+            os.path.abspath(func_frame.f_globals.get("__file__", ""))
+        )
+        sys.settrace(self._trace_func)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:

--- a/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
@@ -9,7 +9,7 @@ import socket
 import sys
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
@@ -65,6 +65,7 @@ class SnapshotTracer:
         self._snapshot_args["memory_viz_args"] = copy.deepcopy(kwargs.get("memory_viz_args", []))
         self._snapshot_args["exclude_frames"] = copy.deepcopy(kwargs.get("exclude_frames", []))
         self._snapshot_args["exclude_frames"].append("_trace_func")
+        self._snapshot_args["exclude_frames"].append("_global_trace_func")
         self.id_tracker = IDTracker()
 
         self.webstepper = webstepper
@@ -73,27 +74,28 @@ class SnapshotTracer:
         self._origin_file = None
         self._module_source_lines = None
 
-    def _global_trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
+    def _global_trace_func(
+        self, frame: types.FrameType, event: str, _arg: Any
+    ) -> Callable[[types.FrameType, str, Any], None] | None:
         """Global trace function that handles 'call' events to determine which functions to trace into."""
-        if event == "call":
-            if self._origin_file is None:
-                return None
-            # Only trace functions in the same module as the calling function.
-            called_file = os.path.normcase(os.path.abspath(frame.f_code.co_filename))
-            if called_file == self._origin_file and frame.f_code.co_name not in (
-                "_trace_func",
-                "_global_trace_func",
-            ):
-                self._start_lineno = min(self._start_lineno, frame.f_code.co_firstlineno)
-                self._end_lineno = max(
-                    self._end_lineno,
-                    frame.f_code.co_firstlineno + len(inspect.getsourcelines(frame)[0]) - 1,
-                )
-                # Return self._trace_func to trace into the called function, otherwise return None to skip tracing.
-                return self._trace_func
+        if event != "call" or self._origin_file is None:
             return None
+        # Only trace functions in the same module as the calling function.
+        called_file = os.path.normcase(os.path.abspath(frame.f_code.co_filename))
+        if called_file == self._origin_file and frame.f_code.co_name not in (
+            self._trace_func.__name__,
+            self._global_trace_func.__name__,
+        ):
+            self._start_lineno = min(self._start_lineno, frame.f_code.co_firstlineno)
+            self._end_lineno = max(
+                self._end_lineno,
+                frame.f_code.co_firstlineno + len(inspect.getsourcelines(frame)[0]) - 1,
+            )
+            # Return self._trace_func to trace into the called function, otherwise return None to skip tracing.
+            return self._trace_func
+        return None
 
-    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
+    def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> None:
         """Local trace function set on each frame to take a snapshot of the variables in the functions specified in `self.include`."""
         if event == "line":
             self._start_lineno = min(self._start_lineno, frame.f_lineno)

--- a/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot_tracer.py
@@ -31,6 +31,7 @@ class SnapshotTracer:
         _snapshot_args: A dictionary of keyword arguments to pass to the `snapshot` function.
         _first_line: Line number of the first line in the `with` block.
         _origin_file: The absolute path of the module where SnapshotTracer is used.
+        _traced_frames: A list of dictionaries that store the first line number and source lines of same-module functions traced during execution.
     """
 
     webstepper: bool
@@ -38,6 +39,7 @@ class SnapshotTracer:
     _snapshot_args: dict[str, Any]
     _first_line: int
     _origin_file: str | None
+    _traced_frames: list[dict[str, Any]]
 
     def __init__(
         self,
@@ -66,6 +68,7 @@ class SnapshotTracer:
         self.webstepper = webstepper
         self._first_line = float("inf")
         self._origin_file = None
+        self._traced_frames = []
 
     def _trace_func(self, frame: types.FrameType, event: str, _arg: Any) -> Any:
         """Take a snapshot of the variables in the functions specified in `self.include`, tracing into same-module function calls."""
@@ -73,6 +76,12 @@ class SnapshotTracer:
             # Only trace functions in the same module as the calling function.
             called_file = os.path.normcase(os.path.abspath(frame.f_globals.get("__file__", "")))
             if called_file == self._origin_file and frame.f_code.co_name != "_trace_func":
+                self._traced_frames.append(
+                    {
+                        "co_firstlineno": frame.f_code.co_firstlineno,
+                        "source_lines": inspect.getsource(frame.f_code).splitlines(),
+                    }
+                )
                 return self._trace_func
             return None
 
@@ -134,8 +143,11 @@ class SnapshotTracer:
         template_env = Environment(loader=template_loader)
         template = template_env.get_template("webstepper_template.html.jinja")
 
+        code_text, start_line_number = self._get_code(func_frame)
+
         rendered_html = template.render(
-            code_text=self._get_code(func_frame),
+            code_text=code_text,
+            start_line_number=start_line_number,
             memory_viz_data=self._snapshots,
             bundle_content=bundle_content,
         )
@@ -150,7 +162,7 @@ class SnapshotTracer:
 
         open_html_in_browser(html_content, port)
 
-    def _get_code(self, func_frame: types.FrameType) -> str:
+    def _get_code(self, func_frame: types.FrameType) -> tuple[str, int]:
         """Retrieve and save the code string to be displayed in Webstepper."""
         code_lines = inspect.cleandoc(inspect.getsource(func_frame))
         i = self._first_line - func_frame.f_code.co_firstlineno
@@ -174,7 +186,23 @@ class SnapshotTracer:
             endpoint = i
             i += 1
 
-        return "\n".join(lst_str_lines[startpoint : endpoint + 1])
+        # If any same-module functions were traced, extend the displayed code to include
+        # the entire range of those functions.
+        if self._traced_frames:
+            for traced in self._traced_frames:
+                func_start_line = traced["co_firstlineno"]
+                func_end_line = func_start_line + len(traced["source_lines"]) - 1
+                func_first_index = func_start_line - func_frame.f_code.co_firstlineno
+                func_last_index = func_end_line - func_frame.f_code.co_firstlineno
+
+                if func_first_index < startpoint and func_first_index >= 0:
+                    startpoint = func_first_index
+                if func_last_index > endpoint and func_last_index < len(lst_str_lines):
+                    endpoint = func_last_index
+
+        start_line_number = func_frame.f_code.co_firstlineno + startpoint
+
+        return "\n".join(lst_str_lines[startpoint : endpoint + 1]), start_line_number
 
     @property
     def snapshots(self) -> list[dict[str, Any]]:

--- a/packages/python-ta/src/python_ta/debug/webstepper/webstepper_template.html.jinja
+++ b/packages/python-ta/src/python_ta/debug/webstepper/webstepper_template.html.jinja
@@ -10,6 +10,7 @@
     <script>
       window.codeText = `{{ code_text }}`;
       window.memoryVizData = {{ memory_viz_data | tojson }};
+      window.startLineNumber = {{ start_line_number }};
     </script>
     <script>
       // Two hacks here:

--- a/packages/python-ta/src/python_ta/debug/webstepper/webstepper_template.html.jinja
+++ b/packages/python-ta/src/python_ta/debug/webstepper/webstepper_template.html.jinja
@@ -10,7 +10,6 @@
     <script>
       window.codeText = `{{ code_text }}`;
       window.memoryVizData = {{ memory_viz_data | tojson }};
-      window.startLineNumber = {{ start_line_number }};
     </script>
     <script>
       // Two hacks here:

--- a/packages/python-ta/tests/test_debug/test_snapshot_tracer.py
+++ b/packages/python-ta/tests/test_debug/test_snapshot_tracer.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import importlib.util
 import inspect
 import os.path
 import sys
-from typing import Iterator
+from typing import Any, Iterator
 from unittest.mock import patch
 
 import pytest
@@ -151,6 +152,51 @@ def func_open_webstepper() -> None:
     return tracer
 
 
+def func_same_module_call() -> SnapshotTracer:
+    """
+    Function for testing SnapshotTracer traces into same-module function calls
+    """
+    with SnapshotTracer(
+        include_frames=(r"^func_same_module_call$", r"^helper_same_module$"),
+        exclude_vars=("tracer",),
+        memory_viz_args=MEMORY_VIZ_ARGS,
+        memory_viz_version=MEMORY_VIZ_VERSION,
+    ) as tracer:
+        helper_same_module(5)
+        num = 42
+
+    return tracer
+
+
+def func_builtin_call() -> SnapshotTracer:
+    """
+    Function for testing SnapshotTracer does not trace into built-in function calls
+    """
+    with SnapshotTracer(
+        include_frames=(r"^func_builtin_call$",),
+        exclude_vars=("tracer",),
+        memory_viz_args=MEMORY_VIZ_ARGS,
+        memory_viz_version=MEMORY_VIZ_VERSION,
+    ) as tracer:
+        nums = [1, 2, 3]
+        total = sum(nums)
+
+    return tracer
+
+
+def func_calls_external_helper(external_helper: Any) -> SnapshotTracer:
+    """Function for testing SnapshotTracer does not trace into imported modules."""
+    with SnapshotTracer(
+        include_frames=(r"^func_calls_external_helper$", r"^external_helper_call$"),
+        exclude_vars=("tracer",),
+        memory_viz_args=MEMORY_VIZ_ARGS,
+        memory_viz_version=MEMORY_VIZ_VERSION,
+    ) as tracer:
+        external_helper.external_helper_call()
+
+    return tracer
+
+
 # Helpers
 
 
@@ -168,6 +214,14 @@ def assert_snapshot_data(
         assert "memoryVizInput" in snapshot_entry
 
         assert isinstance(snapshot_entry["memoryVizInput"], list)
+
+
+def helper_same_module(x: int) -> int:
+    """
+    Helper used to verify SnapshotTracer traces into same-module calls.
+    """
+    result = x
+    return result
 
 
 # Tests
@@ -260,3 +314,65 @@ class TestSnapshotTracer:
         tracer = func_multi_line()
         with pytest.raises(AttributeError):
             tracer.snapshots = []
+
+    def test_traces_same_module_function_calls(self):
+        """
+        Test SnapshotTracer traces into helper functions defined in the same module.
+        """
+        tracer = func_same_module_call()
+        traced_frame_names = {
+            entry["name"]
+            for snapshot_entry in tracer.snapshots
+            for entry in snapshot_entry["memoryVizInput"]
+            if entry["type"] == ".frame"
+        }
+        assert "helper_same_module" in traced_frame_names
+
+    def test_does_not_trace_builtin_calls(self):
+        """
+        Test SnapshotTracer does not trace into built-in function calls
+        """
+        tracer = func_builtin_call()
+        traced_frame_names = {
+            entry["name"]
+            for snapshot_entry in tracer.snapshots
+            for entry in snapshot_entry["memoryVizInput"]
+            if entry["type"] == ".frame"
+        }
+        assert "sum" not in traced_frame_names
+
+    def test_does_not_trace_external_module_calls(self, tmp_path):
+        """
+        Test SnapshotTracer does not trace into functions defined in external modules.
+        """
+        module_path = tmp_path / "external_helper.py"
+        module_path.write_text(
+            """
+            def external_helper_call():
+                value = 1
+                value += 1
+                return value
+            """.lstrip(),
+            encoding="utf-8",
+        )
+
+        spec = importlib.util.spec_from_file_location("external_helper", module_path)
+        assert spec is not None and spec.loader is not None
+        external_helper = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(external_helper)
+
+        tracer = func_calls_external_helper(external_helper)
+        traced_frame_names = {
+            entry["name"]
+            for snapshot_entry in tracer.snapshots
+            for entry in snapshot_entry["memoryVizInput"]
+            if entry["type"] == ".frame"
+        }
+        assert "external_helper_call" not in traced_frame_names
+
+    def test_settrace_restored_after_exit(self):
+        """
+        Test that sys.settrace is restored after exiting the SnapshotTracer context.
+        """
+        func_one_line()
+        assert sys.gettrace() is None


### PR DESCRIPTION
## Proposed Changes

Modified `SnapshotTracer` to trace into calls of functions defined in the same module that `SnapshotTracer` is called, as `SnapshotTracer` previously only traced lines of code within the context block and did not trace into any function calls within the block. Note that built-in functions and functions from external libraries/modules are not traced into. 

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change

| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |     X  |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |          |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

- I modified the webstepper documentation `packages/python-ta/docs/debug/index.md` with the new feature. Before it was listed under "Current Limitations" which I just edited to reflect the change, but if it's no longer considered a 'limitation' since this fixes that limitation, I can move the description elsewhere.
- The same change to the MemoryViz Webstepper code (handled by the MemoryViz team) is required for this PR as well as for #1360, specifically implementing a `startLineNumber` which will ensure the correct line numbers and highlighting are shown in the code section of the Webstepper