### PR TITLE
Fix PyTA CLI output format behaviour

### DIFF
--- a/packages/python-ta/CHANGELOG.md
+++ b/packages/python-ta/CHANGELOG.md
@@ -40,6 +40,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Existing opt-in users will receive a new anonymous client ID after upgrading.
 - Fixed webstepper build to include only a single file.
 - Fixed bug in `invalid_name_checker.py` that allowed three leading underscores in `_check_method_and_attr_name`
+- Fixed PyTA CLI behaviour to prioritze the output format specified by the `--output-format` flag over the `config` file's `output-format` setting
 
 ### 🔧 Internal changes
 

--- a/packages/python-ta/src/python_ta/__init__.py
+++ b/packages/python-ta/src/python_ta/__init__.py
@@ -57,6 +57,7 @@ def check_errors(
     load_default_config: bool = True,
     autoformat: Optional[bool] = False,
     on_verify_fail: Literal["log", "raise"] = "log",
+    pylint_args: Optional[list[str]] = None,
 ) -> PythonTaReporter:
     """Check a module for errors, printing a report."""
     return _check(
@@ -67,6 +68,7 @@ def check_errors(
         load_default_config=load_default_config,
         autoformat=autoformat,
         on_verify_fail=on_verify_fail,
+        pylint_args=pylint_args,
     )
 
 
@@ -77,6 +79,7 @@ def check_all(
     load_default_config: bool = True,
     autoformat: Optional[bool] = False,
     on_verify_fail: Literal["log", "raise"] = "log",
+    pylint_args: Optional[list[str]] = None,
 ) -> PythonTaReporter:
     """Analyse one or more Python modules for code issues and display the results.
 
@@ -106,6 +109,8 @@ def check_all(
             Determines how to handle files that cannot be checked. If set to "log" (default), an error
             message is logged and execution continues. If set to "raise", an error is raised immediately to stop
             execution.
+        pylint_args:
+            A list of command-line arguments to pass to pylint.
 
     Returns:
         The ``PythonTaReporter`` object that generated the report.
@@ -118,6 +123,7 @@ def check_all(
         load_default_config=load_default_config,
         autoformat=autoformat,
         on_verify_fail=on_verify_fail,
+        pylint_args=pylint_args,
     )
 
 
@@ -129,6 +135,7 @@ def _check(
     load_default_config: bool = True,
     autoformat: Optional[bool] = False,
     on_verify_fail: Literal["log", "raise"] = "log",
+    pylint_args: Optional[list[str]] = None,
 ) -> PythonTaReporter:
     """Check a module for problems, printing a report.
 
@@ -145,10 +152,16 @@ def _check(
     `autoformat` is used to specify whether the black formatting tool is run. It is not run by default.
     `on_verify_fail` determines how to handle files that cannot be checked. If set to "log" (default), an error
      message is logged and execution continues. If set to "raise", an error is raised immediately to stop execution.
+    `pylint_args` is a list of command-line arguments to pass to pylint.
     """
     # Configuring logger
     logging.basicConfig(format="[%(levelname)s] %(message)s", level=logging.INFO)
-    linter, current_reporter = setup_linter(local_config, load_default_config, output)
+    linter, current_reporter = setup_linter(
+        local_config,
+        load_default_config,
+        output,
+        pylint_args=pylint_args,
+    )
     try:
         # Flag indicating whether at least one file has been checked
         is_any_file_checked = False
@@ -173,6 +186,7 @@ def _check(
                     is_any_file_checked=is_any_file_checked,
                     current_reporter=current_reporter,
                     f_paths=f_paths,
+                    pylint_args=pylint_args,
                 )
                 current_reporter = linter.reporter
                 current_reporter.print_messages(level)

--- a/packages/python-ta/src/python_ta/__main__.py
+++ b/packages/python-ta/src/python_ta/__main__.py
@@ -1,31 +1,15 @@
 from __future__ import annotations
 
-import configparser
 import sys
 from os import path
 from typing import Optional
 
 import click
-import toml
 
 from python_ta import __version__, check_all, check_errors
-from python_ta.config import DEFAULT_CONFIG_LOCATION, flatten
+from python_ta.config import DEFAULT_CONFIG_LOCATION
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
-
-
-def _load_config_as_dict(config_path: str) -> dict[str, str]:
-    """Load a config file and return it as a dictionary of option: value pairs."""
-    if config_path.endswith(".toml"):
-        return flatten(toml.load(config_path).get("tool", {}).get("python-ta", {}))
-    else:
-        parser = configparser.ConfigParser()
-        parser.read(config_path)
-        return {
-            option: value
-            for section in parser.sections()
-            for option, value in parser.items(section)
-        }
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -85,9 +69,11 @@ def main(
 
     if output_format and config:
         # If both specified, use the config file and override the output format
-        config_data = _load_config_as_dict(config)
-        config_data["output-format"] = output_format
-        reporter = checker(module_name=paths, config=config_data)
+        reporter = checker(
+            module_name=paths,
+            config=config,
+            pylint_args=["--output-format", output_format],
+        )
     elif output_format:
         reporter = checker(module_name=paths, config={"output-format": output_format})
     elif config:

--- a/packages/python-ta/src/python_ta/__main__.py
+++ b/packages/python-ta/src/python_ta/__main__.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
+import configparser
 import sys
 from os import path
 from typing import Optional
 
 import click
+import toml
 
 from python_ta import __version__, check_all, check_errors
-from python_ta.config import DEFAULT_CONFIG_LOCATION
+from python_ta.config import DEFAULT_CONFIG_LOCATION, flatten
 
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
+
+
+def _load_config_as_dict(config_path: str) -> dict[str, str]:
+    """Load a config file and return it as a dictionary of option: value pairs."""
+    if config_path.endswith(".toml"):
+        return flatten(toml.load(config_path).get("tool", {}).get("python-ta", {}))
+    else:
+        parser = configparser.ConfigParser()
+        parser.read(config_path)
+        return {
+            option: value
+            for section in parser.sections()
+            for option, value in parser.items(section)
+        }
 
 
 @click.command(context_settings=CONTEXT_SETTINGS)
@@ -36,8 +52,8 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 )
 @click.option(
     "--output-format",
-    help="Specify the format of output report. This option is ignored if a --config argument is specified.",
-    default="pyta-html",
+    help="Specify the format of output report. This option overrides the output format specified in the config file.",
+    default=None,
 )
 def main(
     version: bool,
@@ -46,7 +62,7 @@ def main(
     filenames: list[str],
     exit_zero: bool,
     generate_config: bool,
-    output_format: str,
+    output_format: Optional[str],
 ) -> None:
     """A code checking tool for teaching Python.
     FILENAMES can be a string of a directory, or file to check (`.py` extension optional) or
@@ -67,10 +83,17 @@ def main(
     checker = check_errors if errors_only else check_all
     paths = [click.format_filename(fn) for fn in filenames]
 
-    if config is None:
+    if output_format and config:
+        # If both specified, use the config file and override the output format
+        config_data = _load_config_as_dict(config)
+        config_data["output-format"] = output_format
+        reporter = checker(module_name=paths, config=config_data)
+    elif output_format:
         reporter = checker(module_name=paths, config={"output-format": output_format})
-    else:
+    elif config:
         reporter = checker(module_name=paths, config=config)
+    else:
+        reporter = checker(module_name=paths)
 
     if not exit_zero and reporter.has_messages():
         sys.exit(1)

--- a/packages/python-ta/src/python_ta/check/helpers.py
+++ b/packages/python-ta/src/python_ta/check/helpers.py
@@ -48,9 +48,14 @@ def setup_linter(
     local_config: Union[dict[str, Any], str],
     load_default_config: bool,
     output: Optional[Union[str, IO]],
+    pylint_args: Optional[list[str]] = None,
 ) -> tuple[PyLinter, Union[BaseReporter, MultiReporter]]:
     """Set up the linter and reporter for the check."""
-    linter = reset_linter(config=local_config, load_default_config=load_default_config)
+    linter = reset_linter(
+        config=local_config,
+        load_default_config=load_default_config,
+        pylint_args=pylint_args,
+    )
     current_reporter = linter.reporter
     current_reporter.set_output(output)
     messages_config_path = linter.config.messages_config_path
@@ -70,6 +75,7 @@ def check_file(
     is_any_file_checked: bool,
     current_reporter: Union[BaseReporter, MultiReporter],
     f_paths: list,
+    pylint_args: Optional[list[str]] = None,
 ) -> tuple[bool, PyLinter]:
     """Perform linting on a single Python file using the provided linter and configuration"""
     # Load config file in user location. Construct new linter each
@@ -79,6 +85,7 @@ def check_file(
         config=local_config,
         file_linted=file_py,
         load_default_config=load_default_config,
+        pylint_args=pylint_args,
     )
 
     if autoformat:
@@ -146,6 +153,7 @@ def reset_linter(
     config: Optional[Union[dict, str]] = None,
     file_linted: Optional[AnyStr] = None,
     load_default_config: bool = True,
+    pylint_args: Optional[list[str]] = None,
 ) -> PyLinter:
     """Construct a new linter. Register config and checker plugins.
 
@@ -281,7 +289,7 @@ def reset_linter(
     default_config_path = find_local_config(os.path.dirname(os.path.dirname(__file__)))
     set_config = load_config
 
-    output_format_override = _get_output_format_override(config)
+    output_format_override = _get_output_format_override(config, pylint_args)
 
     reporter_class_path = _get_reporter_class_path(output_format_override)
     reporter_class = _load_reporter_by_class(reporter_class_path)
@@ -293,7 +301,7 @@ def reset_linter(
         set_config = override_config
 
     if isinstance(config, str) and config != "":
-        set_config(linter, config)
+        set_config(linter, config, pylint_args=pylint_args)
     else:
         # If available, use config file at directory of the file being linted.
         config_location = None
@@ -302,7 +310,7 @@ def reset_linter(
 
         # Load or override the options if there is a config file in the current directory.
         if config_location:
-            set_config(linter, config_location)
+            set_config(linter, config_location, pylint_args=pylint_args)
 
         # Override part of the default config, with a dict of config options.
         # Note: these configs are overridden by config file in user's codebase
@@ -455,8 +463,15 @@ def verify_pre_check(
     return True
 
 
-def _get_output_format_override(config: Optional[Union[str, dict]]) -> Optional[str]:
+def _get_output_format_override(
+    config: Optional[Union[str, dict]], pylint_args: Optional[list[str]] = None
+) -> Optional[str]:
     """Retrieve the output format override from the parsed configuration prematurely"""
+    if pylint_args and "--output-format" in pylint_args:
+        output_format_index = pylint_args.index("--output-format")
+        if output_format_index + 1 < len(pylint_args):
+            return pylint_args[output_format_index + 1]
+
     output_format_override = None
     if isinstance(config, str) and config != "":
         config_path = os.path.abspath(config)

--- a/packages/python-ta/src/python_ta/config/__init__.py
+++ b/packages/python-ta/src/python_ta/config/__init__.py
@@ -35,14 +35,24 @@ def find_local_config(curr_dir: AnyStr) -> Optional[AnyStr]:
         return os.path.join(curr_dir, "config", "pyproject.toml")
 
 
-def load_config(linter: PyLinter, config_location: AnyStr) -> None:
+def load_config(
+    linter: PyLinter,
+    config_location: AnyStr,
+    pylint_args: Optional[list[str]] = None,
+) -> None:
     """Load configuration into the linter."""
     args_list = _get_pyta_toml_args(config_location, linter)
+    if pylint_args:
+        args_list.extend(pylint_args)
     _config_initialization(linter, args_list=args_list, config_file=config_location)
     linter.config_file = config_location
 
 
-def override_config(linter: PyLinter, config_location: AnyStr) -> None:
+def override_config(
+    linter: PyLinter,
+    config_location: AnyStr,
+    pylint_args: Optional[list[str]] = None,
+) -> None:
     """Override the default linter configuration options (if possible).
 
     Snippets taken from pylint.config.config_initialization.
@@ -58,6 +68,8 @@ def override_config(linter: PyLinter, config_location: AnyStr) -> None:
         sys.exit(32)
 
     config_args.extend(_get_pyta_toml_args(config_location, linter))
+    if pylint_args:
+        config_args.extend(pylint_args)
 
     # Override the config options by parsing the provided file.
     try:

--- a/packages/python-ta/tests/test_main.py
+++ b/packages/python-ta/tests/test_main.py
@@ -7,12 +7,18 @@ from os import path
 from click.testing import CliRunner
 
 import python_ta
+import python_ta.__main__ as pyta_main
 from python_ta.__main__ import main
 from python_ta.config import DEFAULT_CONFIG_LOCATION
 
 SOURCE_ROOT = path.normpath(path.join(path.dirname(__file__), "../../.."))
 TEST_ROOT = path.join(SOURCE_ROOT, "packages", "python-ta", "tests")
 TEST_CONFIG = path.join(TEST_ROOT, "test.pylintrc")
+
+
+class _DummyReporter:
+    def has_messages(self) -> bool:
+        return False
 
 
 def test_check_no_errors_zero() -> None:
@@ -121,3 +127,113 @@ def test_no_config() -> None:
     )
 
     assert output.exit_code == 0
+
+
+def test_output_format_overrides_config_value(monkeypatch, tmp_path) -> None:
+    """Test that CLI output-format takes precedence if both --config and --output-format are passed."""
+    config_file = tmp_path / "pyproject.toml"
+    config_file.write_text(
+        """
+        [tool.python-ta]
+        output-format = "pyta-html"
+        max-line-length = 90
+        """.strip(),
+        encoding="utf-8",
+    )
+
+    calls = []
+
+    def fake_checker(*, module_name, config=None):
+        calls.append({"module_name": module_name, "config": config})
+        return _DummyReporter()
+
+    monkeypatch.setattr(pyta_main, "check_all", fake_checker)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyta_main.main,
+        [
+            "--config",
+            str(config_file),
+            "--output-format",
+            "pyta-plain",
+            path.join(TEST_ROOT, "fixtures", "no_errors.py"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert isinstance(calls[0]["config"], dict)
+    assert calls[0]["config"]["output-format"] == "pyta-plain"
+    assert calls[0]["config"]["max-line-length"] == 90
+
+
+def test_output_format_only_passes_output_format_dict(monkeypatch) -> None:
+    """Test that checker receives only the override dict if only --output-format is passed."""
+    calls = []
+
+    def fake_checker(*, module_name, config=None):
+        calls.append({"module_name": module_name, "config": config})
+        return _DummyReporter()
+
+    monkeypatch.setattr(pyta_main, "check_all", fake_checker)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyta_main.main,
+        [
+            "--output-format",
+            "pyta-plain",
+            path.join(TEST_ROOT, "fixtures", "no_errors.py"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["config"] == {"output-format": "pyta-plain"}
+
+
+def test_config_only_passes_config_path(monkeypatch) -> None:
+    """Test that checker receives the config path string if only --config is passed."""
+    calls = []
+
+    def fake_checker(*, module_name, config=None):
+        calls.append({"module_name": module_name, "config": config})
+        return _DummyReporter()
+
+    monkeypatch.setattr(pyta_main, "check_all", fake_checker)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyta_main.main,
+        [
+            "--config",
+            TEST_CONFIG,
+            path.join(TEST_ROOT, "fixtures", "no_errors.py"),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["config"] == path.abspath(TEST_CONFIG)
+
+
+def test_no_output_format_or_config_uses_defaults(monkeypatch) -> None:
+    """Test that checker is called without config if neither --config nor --output-format is passed."""
+    calls = []
+
+    def fake_checker(*, module_name, **kwargs):
+        calls.append({"module_name": module_name, "kwargs": kwargs})
+        return _DummyReporter()
+
+    monkeypatch.setattr(pyta_main, "check_all", fake_checker)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        pyta_main.main,
+        [path.join(TEST_ROOT, "fixtures", "no_errors.py")],
+    )
+
+    assert result.exit_code == 0
+    assert len(calls) == 1
+    assert calls[0]["kwargs"] == {}

--- a/packages/python-ta/tests/test_main.py
+++ b/packages/python-ta/tests/test_main.py
@@ -143,8 +143,8 @@ def test_output_format_overrides_config_value(monkeypatch, tmp_path) -> None:
 
     calls = []
 
-    def fake_checker(*, module_name, config=None):
-        calls.append({"module_name": module_name, "config": config})
+    def fake_checker(*, module_name, config=None, pylint_args=None):
+        calls.append({"module_name": module_name, "config": config, "pylint_args": pylint_args})
         return _DummyReporter()
 
     monkeypatch.setattr(pyta_main, "check_all", fake_checker)
@@ -163,17 +163,16 @@ def test_output_format_overrides_config_value(monkeypatch, tmp_path) -> None:
 
     assert result.exit_code == 0
     assert len(calls) == 1
-    assert isinstance(calls[0]["config"], dict)
-    assert calls[0]["config"]["output-format"] == "pyta-plain"
-    assert calls[0]["config"]["max-line-length"] == 90
+    assert calls[0]["config"] == str(config_file)
+    assert calls[0]["pylint_args"] == ["--output-format", "pyta-plain"]
 
 
 def test_output_format_only_passes_output_format_dict(monkeypatch) -> None:
     """Test that checker receives only the override dict if only --output-format is passed."""
     calls = []
 
-    def fake_checker(*, module_name, config=None):
-        calls.append({"module_name": module_name, "config": config})
+    def fake_checker(*, module_name, config=None, pylint_args=None):
+        calls.append({"module_name": module_name, "config": config, "pylint_args": pylint_args})
         return _DummyReporter()
 
     monkeypatch.setattr(pyta_main, "check_all", fake_checker)
@@ -191,14 +190,15 @@ def test_output_format_only_passes_output_format_dict(monkeypatch) -> None:
     assert result.exit_code == 0
     assert len(calls) == 1
     assert calls[0]["config"] == {"output-format": "pyta-plain"}
+    assert calls[0]["pylint_args"] is None
 
 
 def test_config_only_passes_config_path(monkeypatch) -> None:
     """Test that checker receives the config path string if only --config is passed."""
     calls = []
 
-    def fake_checker(*, module_name, config=None):
-        calls.append({"module_name": module_name, "config": config})
+    def fake_checker(*, module_name, config=None, pylint_args=None):
+        calls.append({"module_name": module_name, "config": config, "pylint_args": pylint_args})
         return _DummyReporter()
 
     monkeypatch.setattr(pyta_main, "check_all", fake_checker)
@@ -216,6 +216,7 @@ def test_config_only_passes_config_path(monkeypatch) -> None:
     assert result.exit_code == 0
     assert len(calls) == 1
     assert calls[0]["config"] == path.abspath(TEST_CONFIG)
+    assert calls[0]["pylint_args"] is None
 
 
 def test_no_output_format_or_config_uses_defaults(monkeypatch) -> None:


### PR DESCRIPTION
## Proposed Changes

Fixed the PythonTA CLI behaviour to prioritze the output format specified by the `--output-format` flag over the `config` file's `output-format` setting. 
Previously, any output format specified in the `--config file` would override the output format specified in the `--output-format` option. This PR reverses that behaviour.

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change


| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |     X    |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist


Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments
