### PR TITLE
Modify snapshot_to_json to handle functions and methods

### DIFF
--- a/packages/python-ta/CHANGELOG.md
+++ b/packages/python-ta/CHANGELOG.md
@@ -47,6 +47,7 @@ and adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Fixed bug in `invalid_name_checker.py` that allowed three leading underscores in `_check_method_and_attr_name`
 - Fixed PyTA CLI behaviour to prioritze the output format specified by the `--output-format` flag over the `config` file's `output-format` setting
 - Fix the `static_type_checker.py` so that it calls `mypy` with the Python interpreter
+- Fixed `snapshot_to_json()` to properly handle, process, and display variables assigned to functions and methods
 
 ### 🔧 Internal changes
 

--- a/packages/python-ta/src/python_ta/debug/snapshot.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot.py
@@ -35,9 +35,19 @@ def get_filtered_global_variables(frame: FrameType) -> dict:
         for var in global_vars
         if not var.startswith("__")
         and not inspect.ismodule(global_vars[var])
-        and not inspect.isfunction(global_vars[var])
         and not inspect.isclass(global_vars[var])
-        and getattr(inspect.getmodule(global_vars[var]), "__name__", "__main__") == "__main__"
+        and (
+            # Include routines assigned to variables
+            (
+                inspect.isroutine(global_vars[var])
+                and getattr(global_vars[var], "__name__", var) != var
+            )
+            or (
+                not inspect.isroutine(global_vars[var])
+                and getattr(inspect.getmodule(global_vars[var]), "__name__", "__main__")
+                == "__main__"
+            )
+        )
     }
     return {"__main__": true_global_vars}
 
@@ -219,6 +229,13 @@ def snapshot_to_json(
                     "name": "class",
                     "id": value_id_diagram,
                     "value": repr(val),
+                }
+            elif inspect.isroutine(val):
+                value_entry = {
+                    "type": ".class",
+                    "name": "function",
+                    "id": value_id_diagram,
+                    "value": getattr(val, "__qualname__", getattr(val, "__name__", repr(val))),
                 }
             # Handle user-defined classes
             elif hasattr(val, "__dict__"):  # Check if val is a user-defined class instance

--- a/packages/python-ta/src/python_ta/debug/snapshot.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot.py
@@ -233,15 +233,15 @@ def snapshot_to_json(
             # Handle functions and methods
             elif inspect.isroutine(val):
                 self_ = getattr(val, "__self__", None)
-                is_bound = (
+                is_bound_method = (
                     self_ is not None
                     and not inspect.ismodule(self_)
                     and not isinstance(self_, type)
                 )
-                if is_bound or inspect.ismethod(val):
-                    display_name = f"<bound method {val.__qualname__}>"
-                elif inspect.isbuiltin(val) or inspect.ismethoddescriptor(val):
+                if inspect.isbuiltin(val) and not is_bound_method:
                     display_name = f"<built-in function {val.__qualname__}>"
+                elif is_bound_method or inspect.ismethod(val):
+                    display_name = f"<bound method {val.__qualname__}>"
                 else:
                     display_name = f"<function {val.__qualname__}>"
                 value_entry = {

--- a/packages/python-ta/src/python_ta/debug/snapshot.py
+++ b/packages/python-ta/src/python_ta/debug/snapshot.py
@@ -230,12 +230,25 @@ def snapshot_to_json(
                     "id": value_id_diagram,
                     "value": repr(val),
                 }
+            # Handle functions and methods
             elif inspect.isroutine(val):
+                self_ = getattr(val, "__self__", None)
+                is_bound = (
+                    self_ is not None
+                    and not inspect.ismodule(self_)
+                    and not isinstance(self_, type)
+                )
+                if is_bound or inspect.ismethod(val):
+                    display_name = f"<bound method {val.__qualname__}>"
+                elif inspect.isbuiltin(val) or inspect.ismethoddescriptor(val):
+                    display_name = f"<built-in function {val.__qualname__}>"
+                else:
+                    display_name = f"<function {val.__qualname__}>"
                 value_entry = {
                     "type": ".class",
                     "name": "function",
                     "id": value_id_diagram,
-                    "value": getattr(val, "__qualname__", getattr(val, "__name__", repr(val))),
+                    "value": display_name,
                 }
             # Handle user-defined classes
             elif hasattr(val, "__dict__"):  # Check if val is a user-defined class instance

--- a/packages/python-ta/tests/test_debug/test_snapshot.py
+++ b/packages/python-ta/tests/test_debug/test_snapshot.py
@@ -778,7 +778,7 @@ def test_snapshot_to_json_unbound_method():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "<built-in function list.append>",
+        "value": "<function list.append>",
     }
 
 

--- a/packages/python-ta/tests/test_debug/test_snapshot.py
+++ b/packages/python-ta/tests/test_debug/test_snapshot.py
@@ -17,7 +17,6 @@ SNAPSHOT_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "snapshot_testing_snapshots"
 )
 
-
 # Globals used for global-keyword snapshot tests
 SNAPSHOT_GLOBAL_X = 10
 
@@ -714,7 +713,7 @@ def test_snapshot_to_json_builtin_function():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "sum",
+        "value": "<built-in function sum>",
     }
 
 
@@ -738,7 +737,7 @@ def test_snapshot_to_json_user_defined_function():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "test_snapshot_to_json_user_defined_function.<locals>.my_helper",
+        "value": "<function test_snapshot_to_json_user_defined_function.<locals>.my_helper>",
     }
 
 
@@ -759,7 +758,7 @@ def test_snapshot_to_json_bound_method():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "list.append",
+        "value": "<bound method list.append>",
     }
 
 
@@ -779,7 +778,7 @@ def test_snapshot_to_json_unbound_method():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "list.append",
+        "value": "<built-in function list.append>",
     }
 
 
@@ -799,7 +798,7 @@ def test_snapshot_to_json_lambda():
         "type": ".class",
         "name": "function",
         "id": 1,
-        "value": "test_snapshot_to_json_lambda.<locals>.<lambda>",
+        "value": "<function test_snapshot_to_json_lambda.<locals>.<lambda>>",
     }
 
 

--- a/packages/python-ta/tests/test_debug/test_snapshot.py
+++ b/packages/python-ta/tests/test_debug/test_snapshot.py
@@ -17,6 +17,7 @@ SNAPSHOT_DIR = os.path.join(
     os.path.dirname(os.path.realpath(__file__)), "snapshot_testing_snapshots"
 )
 
+
 # Globals used for global-keyword snapshot tests
 SNAPSHOT_GLOBAL_X = 10
 
@@ -695,6 +696,111 @@ def test_snapshot_to_json_dicts_of_dicts():
         {"id": 22, "type": "str", "value": "settingD"},
         {"id": 23, "type": "str", "value": "valueD"},
     ]
+
+
+def test_snapshot_to_json_builtin_function():
+    """
+    Test snapshot_to_json correctly handles built-in functions assigned to variables.
+    """
+    snapshot_data = [{"func1": {"my_func": sum}}]
+    json_data = snapshot_to_json(snapshot_data)
+
+    assert json_data[0] == {
+        "type": ".frame",
+        "name": "func1",
+        "value": {"my_func": 1},
+    }
+    assert json_data[1] == {
+        "type": ".class",
+        "name": "function",
+        "id": 1,
+        "value": "sum",
+    }
+
+
+def test_snapshot_to_json_user_defined_function():
+    """
+    Test snapshot_to_json correctly handles user-defined functions assigned to variables.
+    """
+
+    def my_helper():
+        pass
+
+    snapshot_data = [{"func1": {"my_func": my_helper}}]
+    json_data = snapshot_to_json(snapshot_data)
+
+    assert json_data[0] == {
+        "type": ".frame",
+        "name": "func1",
+        "value": {"my_func": 1},
+    }
+    assert json_data[1] == {
+        "type": ".class",
+        "name": "function",
+        "id": 1,
+        "value": "test_snapshot_to_json_user_defined_function.<locals>.my_helper",
+    }
+
+
+def test_snapshot_to_json_bound_method():
+    """
+    Test snapshot_to_json correctly handles bound methods assigned to variables.
+    """
+    my_list = [1, 2, 3]
+    snapshot_data = [{"func1": {"my_method": my_list.append}}]
+    json_data = snapshot_to_json(snapshot_data)
+
+    assert json_data[0] == {
+        "type": ".frame",
+        "name": "func1",
+        "value": {"my_method": 1},
+    }
+    assert json_data[1] == {
+        "type": ".class",
+        "name": "function",
+        "id": 1,
+        "value": "list.append",
+    }
+
+
+def test_snapshot_to_json_unbound_method():
+    """
+    Test snapshot_to_json correctly handles unbound methods assigned to variables.
+    """
+    snapshot_data = [{"func1": {"my_method": list.append}}]
+    json_data = snapshot_to_json(snapshot_data)
+
+    assert json_data[0] == {
+        "type": ".frame",
+        "name": "func1",
+        "value": {"my_method": 1},
+    }
+    assert json_data[1] == {
+        "type": ".class",
+        "name": "function",
+        "id": 1,
+        "value": "list.append",
+    }
+
+
+def test_snapshot_to_json_lambda():
+    """
+    Test snapshot_to_json correctly handles lambda functions assigned to variables.
+    """
+    snapshot_data = [{"func1": {"my_lambda": lambda x: x * 2}}]
+    json_data = snapshot_to_json(snapshot_data)
+
+    assert json_data[0] == {
+        "type": ".frame",
+        "name": "func1",
+        "value": {"my_lambda": 1},
+    }
+    assert json_data[1] == {
+        "type": ".class",
+        "name": "function",
+        "id": 1,
+        "value": "test_snapshot_to_json_lambda.<locals>.<lambda>",
+    }
 
 
 class OneClass:


### PR DESCRIPTION
## Proposed Changes

Modified `snapshot_to_json()` to handle, process, and display variables assigned to functions and methods. 
Previously, variables assigned to functions (built-in, user-defined, and methods) were not displayed in the MemoryViz Webstepper. This PR fixes this issue. 

...

<details>
<summary>Screenshots of your changes (if applicable)</summary>

</details>

## Type of Change


| Type                                                                                    | Applies? |
| --------------------------------------------------------------------------------------- | -------- |
| 🚨 _Breaking change_ (fix or feature that would cause existing functionality to change) |          |
| ✨ _New feature_ (non-breaking change that adds functionality)                          |          |
| 🐛 _Bug fix_ (non-breaking change that fixes an issue)                                  |     X    |
| ♻️ _Refactoring_ (internal change to codebase, without changing functionality)          |          |
| 🚦 _Test update_ (change that _only_ adds or modifies tests)                            |          |
| 📚 _Documentation update_ (change that _only_ updates documentation)                    |          |
| 📦 _Dependency update_ (change that updates a dependency)                               |          |
| 🔧 _Internal_ (change that _only_ affects developers or continuous integration)         |          |

## Checklist

Before opening your pull request:

- [x] I have performed a self-review of my changes.
  - Check that all changed files included in this pull request are intentional changes.
  - Check that all changes are relevant to the purpose of this pull request, as described above.
- [x] I have added tests for my changes, if applicable.
  - This is **required** for all bug fixes and new features.
- [x] I have updated the project documentation, if applicable.
  - This is **required** for new features.
- [x] I have updated the project Changelog (this is required for all changes).
- [x] If this is my first contribution, I have added myself to the [list of contributors](https://github.com/pyta-uoft/pyta/blob/master/README.md#contributors).

After opening your pull request:

- [x] I have verified that the CI tests have passed.
- [x] I have reviewed the test coverage changes reported by Coveralls.
- [x] I have [requested a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from a project maintainer.

## Questions and Comments

